### PR TITLE
Improve naming of OpenAPI client services

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   ],
   "scripts": {
     "generate:api:clean": "rimraf webapp/src/app/core/modules/openapi",
+    "generate:api:application-server-specs": "cd server/application-server && mvn verify -DskipTests=true && node ../../scripts/clean-openapi-specs.js",
     "generate:api:application-server-client": "npx openapi-generator-cli generate -i server/application-server/openapi.yaml -g typescript-angular -o webapp/src/app/core/modules/openapi --additional-properties fileNaming=kebab-case,withInterfaces=true --generate-alias-as-model",
-    "generate:api:application-server-specs": "cd server/application-server && mvn verify -DskipTests=true",
     "generate:api": "npm run generate:api:clean && npm run generate:api:application-server-client && npm run generate:api:application-server-specs"
   },
   "devDependencies": {

--- a/scripts/clean-openapi-specs.js
+++ b/scripts/clean-openapi-specs.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+
+const filePath = path.join(__dirname, "../server/application-server/openapi.yaml");
+
+fs.readFile(filePath, "utf8", (err, data) => {
+  if (err) {
+    console.error("Error reading the file:", err);
+    return;
+  }
+
+  const pattern = /tags:\n\s*-\s*.*?-controller\b/g;
+
+  // Function to remove '-controller' from the tag
+  const updatedContent = data.replace(pattern, (match) => {
+    return match.replace("-controller", "");
+  });
+
+  fs.writeFile(filePath, updatedContent, "utf8", (err) => {
+    if (err) {
+      console.error("Error writing the file:", err);
+      return;
+    }
+  });
+});

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -16,7 +16,7 @@ paths:
   /hello:
     get:
       tags:
-      - hello-controller
+      - hello
       operationId: getAllHellos
       responses:
         "200":
@@ -29,7 +29,7 @@ paths:
                   $ref: "#/components/schemas/Hello"
     post:
       tags:
-      - hello-controller
+      - hello
       operationId: addHello
       responses:
         "200":
@@ -41,7 +41,7 @@ paths:
   /admin:
     get:
       tags:
-      - admin-controller
+      - admin
       operationId: admin
       responses:
         "200":

--- a/webapp/src/app/core/modules/openapi/.openapi-generator/FILES
+++ b/webapp/src/app/core/modules/openapi/.openapi-generator/FILES
@@ -2,11 +2,11 @@
 .openapi-generator-ignore
 README.md
 api.module.ts
-api/admin-controller.service.ts
-api/admin-controller.serviceInterface.ts
+api/admin.service.ts
+api/admin.serviceInterface.ts
 api/api.ts
-api/hello-controller.service.ts
-api/hello-controller.serviceInterface.ts
+api/hello.service.ts
+api/hello.serviceInterface.ts
 configuration.ts
 encoder.ts
 git_push.sh

--- a/webapp/src/app/core/modules/openapi/api/admin.service.ts
+++ b/webapp/src/app/core/modules/openapi/api/admin.service.ts
@@ -18,22 +18,20 @@ import { HttpClient, HttpHeaders, HttpParams,
 import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
-// @ts-ignore
-import { Hello } from '../model/hello';
 
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
 import {
-    HelloControllerServiceInterface
-} from './hello-controller.serviceInterface';
+    AdminServiceInterface
+} from './admin.serviceInterface';
 
 
 
 @Injectable({
   providedIn: 'root'
 })
-export class HelloControllerService implements HelloControllerServiceInterface {
+export class AdminService implements AdminServiceInterface {
 
     protected basePath = 'http://localhost';
     public defaultHeaders = new HttpHeaders();
@@ -99,10 +97,10 @@ export class HelloControllerService implements HelloControllerServiceInterface {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public addHello(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Hello>;
-    public addHello(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Hello>>;
-    public addHello(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Hello>>;
-    public addHello(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+    public admin(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<string>;
+    public admin(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<string>>;
+    public admin(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<string>>;
+    public admin(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
 
         let localVarHeaders = this.defaultHeaders;
 
@@ -140,67 +138,8 @@ export class HelloControllerService implements HelloControllerServiceInterface {
             }
         }
 
-        let localVarPath = `/hello`;
-        return this.httpClient.request<Hello>('post', `${this.configuration.basePath}${localVarPath}`,
-            {
-                context: localVarHttpContext,
-                responseType: <any>responseType_,
-                withCredentials: this.configuration.withCredentials,
-                headers: localVarHeaders,
-                observe: observe,
-                transferCache: localVarTransferCache,
-                reportProgress: reportProgress
-            }
-        );
-    }
-
-    /**
-     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
-     * @param reportProgress flag to report request and response progress.
-     */
-    public getAllHellos(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Array<Hello>>;
-    public getAllHellos(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Array<Hello>>>;
-    public getAllHellos(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Array<Hello>>>;
-    public getAllHellos(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
-
-        let localVarHeaders = this.defaultHeaders;
-
-        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
-        if (localVarHttpHeaderAcceptSelected === undefined) {
-            // to determine the Accept header
-            const httpHeaderAccepts: string[] = [
-                'application/json'
-            ];
-            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
-        }
-        if (localVarHttpHeaderAcceptSelected !== undefined) {
-            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
-        }
-
-        let localVarHttpContext: HttpContext | undefined = options && options.context;
-        if (localVarHttpContext === undefined) {
-            localVarHttpContext = new HttpContext();
-        }
-
-        let localVarTransferCache: boolean | undefined = options && options.transferCache;
-        if (localVarTransferCache === undefined) {
-            localVarTransferCache = true;
-        }
-
-
-        let responseType_: 'text' | 'json' | 'blob' = 'json';
-        if (localVarHttpHeaderAcceptSelected) {
-            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
-                responseType_ = 'text';
-            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
-                responseType_ = 'json';
-            } else {
-                responseType_ = 'blob';
-            }
-        }
-
-        let localVarPath = `/hello`;
-        return this.httpClient.request<Array<Hello>>('get', `${this.configuration.basePath}${localVarPath}`,
+        let localVarPath = `/admin`;
+        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,

--- a/webapp/src/app/core/modules/openapi/api/admin.serviceInterface.ts
+++ b/webapp/src/app/core/modules/openapi/api/admin.serviceInterface.ts
@@ -19,7 +19,7 @@ import { Configuration }                                     from '../configurat
 
 
 
-export interface AdminControllerServiceInterface {
+export interface AdminServiceInterface {
     defaultHeaders: HttpHeaders;
     configuration: Configuration;
 

--- a/webapp/src/app/core/modules/openapi/api/api.ts
+++ b/webapp/src/app/core/modules/openapi/api/api.ts
@@ -1,7 +1,7 @@
-export * from './admin-controller.service';
-import { AdminControllerService } from './admin-controller.service';
-export * from './admin-controller.serviceInterface';
-export * from './hello-controller.service';
-import { HelloControllerService } from './hello-controller.service';
-export * from './hello-controller.serviceInterface';
-export const APIS = [AdminControllerService, HelloControllerService];
+export * from './admin.service';
+import { AdminService } from './admin.service';
+export * from './admin.serviceInterface';
+export * from './hello.service';
+import { HelloService } from './hello.service';
+export * from './hello.serviceInterface';
+export const APIS = [AdminService, HelloService];

--- a/webapp/src/app/core/modules/openapi/api/hello.service.ts
+++ b/webapp/src/app/core/modules/openapi/api/hello.service.ts
@@ -18,20 +18,22 @@ import { HttpClient, HttpHeaders, HttpParams,
 import { CustomHttpParameterCodec }                          from '../encoder';
 import { Observable }                                        from 'rxjs';
 
+// @ts-ignore
+import { Hello } from '../model/hello';
 
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS }                     from '../variables';
 import { Configuration }                                     from '../configuration';
 import {
-    AdminControllerServiceInterface
-} from './admin-controller.serviceInterface';
+    HelloServiceInterface
+} from './hello.serviceInterface';
 
 
 
 @Injectable({
   providedIn: 'root'
 })
-export class AdminControllerService implements AdminControllerServiceInterface {
+export class HelloService implements HelloServiceInterface {
 
     protected basePath = 'http://localhost';
     public defaultHeaders = new HttpHeaders();
@@ -97,10 +99,10 @@ export class AdminControllerService implements AdminControllerServiceInterface {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public admin(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<string>;
-    public admin(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<string>>;
-    public admin(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<string>>;
-    public admin(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+    public addHello(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Hello>;
+    public addHello(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Hello>>;
+    public addHello(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Hello>>;
+    public addHello(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
 
         let localVarHeaders = this.defaultHeaders;
 
@@ -138,8 +140,67 @@ export class AdminControllerService implements AdminControllerServiceInterface {
             }
         }
 
-        let localVarPath = `/admin`;
-        return this.httpClient.request<string>('get', `${this.configuration.basePath}${localVarPath}`,
+        let localVarPath = `/hello`;
+        return this.httpClient.request<Hello>('post', `${this.configuration.basePath}${localVarPath}`,
+            {
+                context: localVarHttpContext,
+                responseType: <any>responseType_,
+                withCredentials: this.configuration.withCredentials,
+                headers: localVarHeaders,
+                observe: observe,
+                transferCache: localVarTransferCache,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public getAllHellos(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Array<Hello>>;
+    public getAllHellos(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Array<Hello>>>;
+    public getAllHellos(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Array<Hello>>>;
+    public getAllHellos(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
+
+        let localVarHeaders = this.defaultHeaders;
+
+        let localVarHttpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (localVarHttpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/json'
+            ];
+            localVarHttpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (localVarHttpHeaderAcceptSelected !== undefined) {
+            localVarHeaders = localVarHeaders.set('Accept', localVarHttpHeaderAcceptSelected);
+        }
+
+        let localVarHttpContext: HttpContext | undefined = options && options.context;
+        if (localVarHttpContext === undefined) {
+            localVarHttpContext = new HttpContext();
+        }
+
+        let localVarTransferCache: boolean | undefined = options && options.transferCache;
+        if (localVarTransferCache === undefined) {
+            localVarTransferCache = true;
+        }
+
+
+        let responseType_: 'text' | 'json' | 'blob' = 'json';
+        if (localVarHttpHeaderAcceptSelected) {
+            if (localVarHttpHeaderAcceptSelected.startsWith('text')) {
+                responseType_ = 'text';
+            } else if (this.configuration.isJsonMime(localVarHttpHeaderAcceptSelected)) {
+                responseType_ = 'json';
+            } else {
+                responseType_ = 'blob';
+            }
+        }
+
+        let localVarPath = `/hello`;
+        return this.httpClient.request<Array<Hello>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,

--- a/webapp/src/app/core/modules/openapi/api/hello.serviceInterface.ts
+++ b/webapp/src/app/core/modules/openapi/api/hello.serviceInterface.ts
@@ -20,7 +20,7 @@ import { Configuration }                                     from '../configurat
 
 
 
-export interface HelloControllerServiceInterface {
+export interface HelloServiceInterface {
     defaultHeaders: HttpHeaders;
     configuration: Configuration;
 

--- a/webapp/src/app/example/hello/hello.component.ts
+++ b/webapp/src/app/example/hello/hello.component.ts
@@ -2,7 +2,7 @@ import { Component, inject } from '@angular/core';
 import { injectMutation, injectQuery, injectQueryClient } from '@tanstack/angular-query-experimental';
 import { AngularQueryDevtools } from '@tanstack/angular-query-devtools-experimental'
 import { lastValueFrom } from 'rxjs';
-import { HelloControllerService } from 'app/core/modules/openapi';
+import { HelloService } from 'app/core/modules/openapi';
 import { AppButtonComponent } from 'app/ui/button/button/button.component';
 
 @Component({
@@ -12,17 +12,17 @@ import { AppButtonComponent } from 'app/ui/button/button/button.component';
   templateUrl: './hello.component.html'
 })
 export class PokemonComponent {
-  helloControllerService = inject(HelloControllerService)
+  helloService = inject(HelloService)
   queryClient = injectQueryClient()
 
   query = injectQuery(() => ({
     queryKey: ['hellos'],
-    queryFn: async () => lastValueFrom(this.helloControllerService.getAllHellos()),
+    queryFn: async () => lastValueFrom(this.helloService.getAllHellos()),
     })
   );
 
   mutation = injectMutation(() => ({
-    mutationFn: () => lastValueFrom(this.helloControllerService.addHello()),
+    mutationFn: () => lastValueFrom(this.helloService.addHello()),
     onSuccess: () => 
       this.queryClient.invalidateQueries({
         queryKey: ['hellos'],


### PR DESCRIPTION
## Description

Remove controller from API client it is now `HelloService` instead of `HelloControllerService`