### PR TITLE
Remove App prefix for components

### DIFF
--- a/webapp/src/app/example/counter/counter.component.ts
+++ b/webapp/src/app/example/counter/counter.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, input, signal } from '@angular/core';
 import { counter } from './counter';
-import { AppButtonComponent } from 'app/ui/button/button.component';
+import { ButtonComponent } from 'app/ui/button/button.component';
 
 interface CounterHistoryEntry {
   dec: number;
@@ -10,7 +10,7 @@ interface CounterHistoryEntry {
 @Component({
   selector: 'app-counter',
   standalone: true,
-  imports: [AppButtonComponent],
+  imports: [ButtonComponent],
   templateUrl: './counter.component.html'
 })
 export class CounterComponent {

--- a/webapp/src/app/example/hello/hello.component.ts
+++ b/webapp/src/app/example/hello/hello.component.ts
@@ -3,12 +3,12 @@ import { injectMutation, injectQuery, injectQueryClient } from '@tanstack/angula
 import { AngularQueryDevtools } from '@tanstack/angular-query-devtools-experimental';
 import { lastValueFrom } from 'rxjs';
 import { HelloService } from 'app/core/modules/openapi';
-import { AppButtonComponent } from 'app/ui/button/button.component';
+import { ButtonComponent } from 'app/ui/button/button.component';
 
 @Component({
   selector: 'app-hello',
   standalone: true,
-  imports: [AppButtonComponent, AngularQueryDevtools],
+  imports: [ButtonComponent, AngularQueryDevtools],
   templateUrl: './hello.component.html'
 })
 export class HelloComponent {

--- a/webapp/src/app/ui/button/button.component.ts
+++ b/webapp/src/app/ui/button/button.component.ts
@@ -39,7 +39,7 @@ interface ButtonVariants extends VariantProps<typeof buttonVariants> {}
   standalone: true,
   templateUrl: './button.component.html'
 })
-export class AppButtonComponent {
+export class ButtonComponent {
   class = input<ClassValue>('');
   variant = input<ButtonVariants['variant']>('default');
   size = input<ButtonVariants['size']>('default');

--- a/webapp/src/app/ui/button/button.stories.ts
+++ b/webapp/src/app/ui/button/button.stories.ts
@@ -1,12 +1,12 @@
 import { argsToTemplate, moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
-import { AppButtonComponent, args, argTypes } from './button.component';
+import { ButtonComponent, args, argTypes } from './button.component';
 import { LucideAngularModule, ChevronRight, Mail, Loader2 } from 'lucide-angular';
 import { within, userEvent, expect, fn } from '@storybook/test';
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
-const meta: Meta<AppButtonComponent> = {
+const meta: Meta<ButtonComponent> = {
   title: 'UI/Button',
-  component: AppButtonComponent,
+  component: ButtonComponent,
   tags: ['autodocs'],
   args: {
     ...args,
@@ -25,7 +25,7 @@ const meta: Meta<AppButtonComponent> = {
 };
 
 export default meta;
-type Story = StoryObj<AppButtonComponent>;
+type Story = StoryObj<ButtonComponent>;
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Primary: Story = {

--- a/webapp/src/app/ui/input/input.component.ts
+++ b/webapp/src/app/ui/input/input.component.ts
@@ -29,7 +29,7 @@ interface InputVariants extends VariantProps<typeof inputVariants> {}
   standalone: true,
   templateUrl: './input.component.html'
 })
-export class AppInputComponent {
+export class InputComponent {
   class = input<ClassValue>('');
   type = input<string>('text');
   placeholder = input<string>('');

--- a/webapp/src/app/ui/input/input.stories.ts
+++ b/webapp/src/app/ui/input/input.stories.ts
@@ -1,12 +1,12 @@
 import { argsToTemplate, moduleMetadata, type Meta, type StoryObj } from '@storybook/angular';
-import { AppInputComponent, args, argTypes } from './input.component';
 import { action } from '@storybook/addon-actions';
-import { AppButtonComponent } from '@app/ui/button/button.component';
-import { AppLabelComponent } from '@app/ui/label/label.component';
+import { ButtonComponent } from '@app/ui/button/button.component';
+import { LabelComponent } from '@app/ui/label/label.component';
+import { InputComponent, args, argTypes } from './input.component';
 
-const meta: Meta<AppInputComponent> = {
+const meta: Meta<InputComponent> = {
   title: 'UI/Input',
-  component: AppInputComponent,
+  component: InputComponent,
   tags: ['autodocs'],
   args: {
     ...args,
@@ -25,13 +25,13 @@ const meta: Meta<AppInputComponent> = {
   },
   decorators: [
     moduleMetadata({
-      imports: [AppButtonComponent, AppLabelComponent]
+      imports: [ButtonComponent, LabelComponent]
     })
   ]
 };
 
 export default meta;
-type Story = StoryObj<AppInputComponent>;
+type Story = StoryObj<InputComponent>;
 
 export const Default: Story = {
   render: (args) => ({

--- a/webapp/src/app/ui/label/label.component.ts
+++ b/webapp/src/app/ui/label/label.component.ts
@@ -12,7 +12,7 @@ export { args, argTypes };
   standalone: true,
   templateUrl: './label.component.html'
 })
-export class AppLabelComponent {
+export class LabelComponent {
   class = input<ClassValue>('');
   for = input<string>('');
 

--- a/webapp/src/app/ui/label/label.stories.ts
+++ b/webapp/src/app/ui/label/label.stories.ts
@@ -1,9 +1,9 @@
 import { argsToTemplate, type Meta, type StoryObj } from '@storybook/angular';
-import { AppLabelComponent, args, argTypes } from './label.component';
+import { LabelComponent, args, argTypes } from './label.component';
 
-const meta: Meta<AppLabelComponent> = {
+const meta: Meta<LabelComponent> = {
   title: 'UI/Label',
-  component: AppLabelComponent,
+  component: LabelComponent,
   tags: ['autodocs'],
   args: {
     ...args,
@@ -15,7 +15,7 @@ const meta: Meta<AppLabelComponent> = {
 };
 
 export default meta;
-type Story = StoryObj<AppLabelComponent>;
+type Story = StoryObj<LabelComponent>;
 
 export const Default: Story = {
   render: (args) => ({


### PR DESCRIPTION
### Description

Remove unnecessary `App` prefix for components for consistency, we only need it in the template to avoid colliding with html tags.