### PR TITLE
Integrate Spring Modulith in `application-server`

### DIFF
--- a/server/application-server/pom.xml
+++ b/server/application-server/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.3.2</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<relativePath />
+		<!-- lookup parent from repository -->
 	</parent>
 	<groupId>de.tum.in.www1</groupId>
 	<artifactId>hephaestus</artifactId>
@@ -111,7 +111,28 @@
 			<artifactId>therapi-runtime-javadoc</artifactId>
 			<version>0.15.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.modulith</groupId>
+			<artifactId>spring-modulith-starter-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.modulith</groupId>
+			<artifactId>spring-modulith-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.modulith</groupId>
+				<artifactId>spring-modulith-bom</artifactId>
+				<version>1.2.2</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/Application.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/Application.java
@@ -2,8 +2,10 @@ package de.tum.in.www1.hephaestus;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.modulith.Modulithic;
 
 @SpringBootApplication
+@Modulithic(systemName = "Hephaestus")
 public class Application {
 
 	public static void main(String[] args) {

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusApplicationTests.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusApplicationTests.java
@@ -10,6 +10,8 @@ class HephaestusApplicationTests {
 
 	@Test
 	void contextLoads() {
+		// ContextLoads
+		assert (true);
 	}
 
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusModulithTests.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusModulithTests.java
@@ -18,10 +18,11 @@ public class HephaestusModulithTests {
 
     @Test
     void writeDocumentationSnippets() {
+        DiagramOptions options = DiagramOptions.defaults().withStyle(DiagramStyle.UML);
         new Documenter(modules)
                 .writeModuleCanvases()
-                .writeModulesAsPlantUml()
-                .writeIndividualModulesAsPlantUml(DiagramOptions.defaults().withStyle(DiagramStyle.UML));
+                .writeModulesAsPlantUml(options)
+                .writeIndividualModulesAsPlantUml(options);
     }
 
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusModulithTests.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusModulithTests.java
@@ -3,6 +3,8 @@ package de.tum.in.www1.hephaestus;
 import org.junit.jupiter.api.Test;
 import org.springframework.modulith.core.ApplicationModules;
 import org.springframework.modulith.docs.Documenter;
+import org.springframework.modulith.docs.Documenter.DiagramOptions;
+import org.springframework.modulith.docs.Documenter.DiagramOptions.DiagramStyle;
 
 public class HephaestusModulithTests {
 
@@ -19,7 +21,7 @@ public class HephaestusModulithTests {
         new Documenter(modules)
                 .writeModuleCanvases()
                 .writeModulesAsPlantUml()
-                .writeIndividualModulesAsPlantUml();
+                .writeIndividualModulesAsPlantUml(DiagramOptions.defaults().withStyle(DiagramStyle.UML));
     }
 
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusModulithTests.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/HephaestusModulithTests.java
@@ -1,0 +1,25 @@
+package de.tum.in.www1.hephaestus;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.core.ApplicationModules;
+import org.springframework.modulith.docs.Documenter;
+
+public class HephaestusModulithTests {
+
+    ApplicationModules modules = ApplicationModules.of(Application.class);
+
+    @Test
+    void shouldBeCompliant() {
+        modules.forEach(System.out::println);
+        modules.verify();
+    }
+
+    @Test
+    void writeDocumentationSnippets() {
+        new Documenter(modules)
+                .writeModuleCanvases()
+                .writeModulesAsPlantUml()
+                .writeIndividualModulesAsPlantUml();
+    }
+
+}


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Spring Modulith allows for module-driven development in a Spring project including internal and API-exposed parts within a module. It provides event management for cross-module communication and integration testing functionality.

### Description
<!-- Provide a brief summary of the changes. -->
Adds the core packages of Spring Modulith to the Application Server.
Added tests include a module integrity verification (according to https://docs.spring.io/spring-modulith/reference/verification.html) as well as UML diagram generation.

### Resources for used modules/JARs
- https://docs.spring.io/spring-modulith/reference/appendix.html#artifacts

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [ ] Proper error handling has been implemented
- [x] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)