### PR TITLE
Fix build env for webapp preview deployments

### DIFF
--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY ./ /app/
 
 RUN ls -la
+RUN cat .env*
 # Ensure .env file exists
 RUN touch .env
 RUN env

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -6,6 +6,7 @@ COPY ./ /app/
 
 # Ensure .env file exists
 RUN touch .env
+RUN echo "Contents of .env file:" && cat .env
 
 # Fix buggy replacement of COOLIFY_URL in .env
 RUN COOLIFY_URL_VALUE=$(grep '^COOLIFY_URL=' .env | cut -d '=' -f2) && \

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -7,8 +7,8 @@ COPY ./ /app/
 RUN ls -la
 RUN cat .env*
 # Ensure .env file exists
+RUN mv .env* .env || true
 RUN touch .env
-RUN env
 RUN echo "Contents of .env file:" && cat .env
 
 # Fix buggy replacement of COOLIFY_URL in .env

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY ./ /app/
 
+RUN ls -la
 # Ensure .env file exists
 RUN touch .env
 RUN env

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -4,12 +4,10 @@ WORKDIR /app
 
 COPY ./ /app/
 
-RUN ls -la
-RUN cat .env*
 # Ensure .env file exists
 RUN mv .env* .env || true
 RUN touch .env
-RUN echo "Contents of .env file:" && cat .env
+RUN cat .env
 
 # Fix buggy replacement of COOLIFY_URL in .env
 RUN COOLIFY_URL_VALUE=$(grep '^COOLIFY_URL=' .env | cut -d '=' -f2) && \

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -6,6 +6,7 @@ COPY ./ /app/
 
 # Ensure .env file exists
 RUN touch .env
+RUN env
 RUN echo "Contents of .env file:" && cat .env
 
 # Fix buggy replacement of COOLIFY_URL in .env


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->

`.env` is `.env-pr-63` for example during preview deployments with Coolify

### Description
<!-- Provide a brief summary of the changes. -->

Move `.env*` to `.env` during build
