### PR TITLE
Workflow: Exclude OpenAPI folder from Webapp QA workflow

### DIFF
--- a/.github/workflows/webapp-qa.yml
+++ b/.github/workflows/webapp-qa.yml
@@ -4,9 +4,11 @@ on:
     pull_request:
         paths:
             - "webapp/**"
+            - "!webapp/src/app/core/modules/openapi/**"
     push:
         paths:
             - "webapp/**"
+            - "!webapp/src/app/core/modules/openapi/**"
         branches: [develop]
 
 jobs:


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
We want to avoid unnecessary workflow executions by limiting its trigger conditions.

### Description
<!-- Provide a brief summary of the changes. -->
This PR excludes the OpenAPI auto-generated folder from the trigger conditions for the workflow. 
In cases where changes in the application server require a OpenAPI Spec re-generation, this workflow should not be needed. 

Both ESLint and Prettier are configured to ignore the openapi folder, so a workflow execution is redundant and should be guaranteed to not provide any new results.

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [ ] Changes have been tested locally
