### PR TITLE
Add workflow to generate API specs and clients with a manual trigger

### DIFF
--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -62,7 +62,7 @@ jobs:
   commit-changes:
     name: Commit and Push API Client Changes
     runs-on: ubuntu-latest
-    needs: generate-api-client
+    # The job should only run when triggered manually
     if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -64,7 +65,6 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "chore: update API specs and client"
-          echo "$GH_PAT_USER"
           git push https://$GH_PAT_USER:$GH_PAT@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
         env:
           GH_PAT_USER: ${{ secrets.GH_PAT_USER }}

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -2,6 +2,7 @@ name: OpenAPI
 
 on:
   pull_request:
+    types: [opened, synchronize, labeled, reopened]
     paths:
       - 'server/application-server/**'
       - '.github/workflows/generate-api-client.yml'
@@ -55,21 +56,11 @@ jobs:
             exit 1
           fi
 
-  log-github-event-name:
-    name: Log GitHub Event Name
-    runs-on: ubuntu-latest
-    needs: generate-api-client
-    if: ${{ always() }}
-    steps:
-      - name: Log the github.event_name
-        run: |
-          echo "The GitHub event name is: ${{ github.event_name }}"
-
   commit-changes:
     name: Commit and Push API Client Changes
     runs-on: ubuntu-latest
     needs: generate-api-client
-    if: ${{ failure() && github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.label.name == 'autocommit-api' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -104,3 +95,9 @@ jobs:
           git push origin HEAD:${{ github.event.pull_request.head.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove the label
+        run: |
+          echo "Removing the autocommit-api label..."
+          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-api        

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -63,8 +63,8 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "chore: update API client"
-          git push https://x-access-token:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
+          git commit -m "chore: update API specs and client"
+          git push https://${{ secrets.GH_PAT_USER }}:${{ secrets.GH_PAT }}@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
 
       - name: Remove autocommit-openapi label
         if: ${{ contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'server/application-server/openapi.yaml'
       - 'webapp/src/app/core/modules/openapi/**'
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:
@@ -57,3 +58,43 @@ jobs:
             echo "NO_CHANGES_DETECTED=false" >> $GITHUB_ENV
             exit 1
           fi
+
+  commit-changes:
+    name: Commit and Push API Client Changes
+    runs-on: ubuntu-latest
+    needs: generate-api-client
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate API client
+        run: npm run generate:api
+
+      - name: Commit and push changes
+        run: |
+          echo "Committing and pushing changes..."
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: update API client"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -67,7 +67,7 @@ jobs:
           git push https://x-access-token:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
 
       - name: Remove autocommit-openapi label
-        if: ${{ success() }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
         run: |
           echo "Removing the autocommit-openapi label..."
           curl --silent --fail-with-body -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -62,8 +62,8 @@ jobs:
   commit-changes:
     name: Commit and Push API Client Changes
     runs-on: ubuntu-latest
-    # The job should only run when triggered manually
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: generate-api-client
+    if: ${{ failure() && github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -64,7 +64,11 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "chore: update API specs and client"
-          git push https://${{ secrets.GH_PAT_USER }}:${{ secrets.GH_PAT }}@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
+          echo "$GH_PAT_USER"
+          git push https://$GH_PAT_USER:$GH_PAT@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
+        env:
+          GH_PAT_USER: ${{ secrets.GH_PAT_USER }}
+          GH_PAT: ${{ secrets.GH_PAT }}
 
       - name: Remove autocommit-openapi label
         if: ${{ contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -57,22 +57,18 @@ jobs:
           fi
 
       - name: Commit and push changes
-        if: ${{ failure() && github.event.label.name == 'autocommit-openapi' }}
+        if: ${{ failure() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
         run: |
           echo "Committing and pushing changes..."
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "chore: update API client"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
-        env:
-          # Use a personal access token (PAT) or GitHub App token instead of GITHUB_TOKEN
-          # This PAT must have repo scope permissions
-          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          git push https://x-access-token:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
 
       - name: Remove autocommit-openapi label
-        if: ${{ github.event.label.name == 'autocommit-openapi' }}
+        if: ${{ success() }}
         run: |
           echo "Removing the autocommit-openapi label..."
-          curl -s -X DELETE -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
+          curl --silent --fail-with-body -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -57,21 +57,23 @@ jobs:
             exit 1
           fi
 
-      - name: Commit and push changes
-        if: ${{ failure() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
+      - name: Commit files
+        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
         run: |
           echo "Committing and pushing changes..."
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "chore: update API specs and client"
-          git push https://$GH_PAT_USER:$GH_PAT@github.com/${{ github.repository }} HEAD:${{ github.event.pull_request.head.ref }}
-        env:
-          GH_PAT_USER: ${{ secrets.GH_PAT_USER }}
-          GH_PAT: ${{ secrets.GH_PAT }}
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -a -m "chore: update API specs and client"
+
+      - name: Push changes
+        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GH_PAT }}
+          branch: ${{ github.ref }}
 
       - name: Remove autocommit-openapi label
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
+        if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}
         run: |
           echo "Removing the autocommit-openapi label..."
           curl --silent --fail-with-body -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -70,7 +70,7 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GH_PAT }}
-          branch: ${{ github.ref }}
+          branch: ${{ github.event.pull_request.head.ref  }}
 
       - name: Remove autocommit-openapi label
         if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'autocommit-openapi') }}

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -68,11 +68,11 @@ jobs:
         env:
           # Use a personal access token (PAT) or GitHub App token instead of GITHUB_TOKEN
           # This PAT must have repo scope permissions
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
       - name: Remove autocommit-openapi label
         if: ${{ github.event.label.name == 'autocommit-openapi' }}
         run: |
           echo "Removing the autocommit-openapi label..."
-          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}" \
+          curl -s -X DELETE -H "Authorization: token ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -66,10 +66,13 @@ jobs:
           git commit -m "chore: update API client"
           git push origin HEAD:${{ github.event.pull_request.head.ref }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a personal access token (PAT) or GitHub App token instead of GITHUB_TOKEN
+          # This PAT must have repo scope permissions
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
 
       - name: Remove autocommit-openapi label
+        if: ${{ github.event.label.name == 'autocommit-openapi' }}
         run: |
           echo "Removing the autocommit-openapi label..."
-          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   generate-api-client:
-    name: Verify API Specs and Client
+    name: Verify API Specs and Client (add autocommit-openapi label to PR to auto-commit changes)
     runs-on: ubuntu-latest
 
     steps:
@@ -56,44 +56,8 @@ jobs:
             exit 1
           fi
 
-      - name: Remove autocommit-openapi label if job succeeds
-        if: ${{ success() && github.event.label.name == 'autocommit-openapi' }}
-        run: |
-          echo "Removing the autocommit-openapi label..."
-          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi
-
-
-  commit-changes:
-    name: Commit and Push API Client Changes
-    runs-on: ubuntu-latest
-    needs: generate-api-client
-    if: ${{ failure() && github.event.label.name == 'autocommit-openapi' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Generate API client
-        run: npm run generate:api
-
       - name: Commit and push changes
+        if: ${{ failure() && github.event.label.name == 'autocommit-openapi' }}
         run: |
           echo "Committing and pushing changes..."
           git config --global user.name "github-actions[bot]"
@@ -104,8 +68,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Remove the label
+      - name: Remove autocommit-openapi label
         run: |
-          echo "Removing the autocommit-api label..."
+          echo "Removing the autocommit-openapi label..."
           curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi        
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -56,11 +56,19 @@ jobs:
             exit 1
           fi
 
+      - name: Remove autocommit-openapi label if job succeeds
+        if: ${{ success() && github.event.label.name == 'autocommit-openapi' }}
+        run: |
+          echo "Removing the autocommit-openapi label..."
+          curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi
+
+
   commit-changes:
     name: Commit and Push API Client Changes
     runs-on: ubuntu-latest
     needs: generate-api-client
-    if: ${{ github.event.label.name == 'autocommit-openapi' }}
+    if: ${{ failure() && github.event.label.name == 'autocommit-openapi' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -60,7 +60,7 @@ jobs:
     name: Commit and Push API Client Changes
     runs-on: ubuntu-latest
     needs: generate-api-client
-    if: ${{ github.event.label.name == 'autocommit-api' }}
+    if: ${{ github.event.label.name == 'autocommit-openapi' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -100,4 +100,4 @@ jobs:
         run: |
           echo "Removing the autocommit-api label..."
           curl -s -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-api        
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/autocommit-openapi        

--- a/.github/workflows/generate-api-client.yml
+++ b/.github/workflows/generate-api-client.yml
@@ -12,10 +12,6 @@ on:
     branches: [develop]
   workflow_dispatch:
 
-concurrency:
-  group: generate-api-client
-  cancel-in-progress: true
-
 jobs:
   generate-api-client:
     name: Verify API Specs and Client
@@ -58,6 +54,16 @@ jobs:
             echo "NO_CHANGES_DETECTED=false" >> $GITHUB_ENV
             exit 1
           fi
+
+  log-github-event-name:
+    name: Log GitHub Event Name
+    runs-on: ubuntu-latest
+    needs: generate-api-client
+    if: ${{ always() }}
+    steps:
+      - name: Log the github.event_name
+        run: |
+          echo "The GitHub event name is: ${{ github.event_name }}"
 
   commit-changes:
     name: Commit and Push API Client Changes

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "generate:api:clean": "rimraf webapp/src/app/core/modules/openapi",
     "generate:api:application-server-specs": "cd server/application-server && mvn verify -DskipTests=true && node ../../scripts/clean-openapi-specs.js",
     "generate:api:application-server-client": "npx openapi-generator-cli generate -i server/application-server/openapi.yaml -g typescript-angular -o webapp/src/app/core/modules/openapi --additional-properties fileNaming=kebab-case,withInterfaces=true --generate-alias-as-model",
-    "generate:api": "npm run generate:api:clean && npm run generate:api:application-server-client && npm run generate:api:application-server-specs"
+    "generate:api": "npm run generate:api:application-server-specs && npm run generate:api:clean && npm run generate:api:application-server-client"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "2.13.5",

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -22,10 +22,11 @@ paths:
       operationId: getAllHellos
       responses:
         "200":
-          description: A list of all Hello entities
+          description: A set of all Hello entities
           content:
             application/json:
               schema:
+                uniqueItems: true
                 type: array
                 items:
                   $ref: "#/components/schemas/Hello"

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -22,7 +22,7 @@ paths:
       operationId: getAllHellos
       responses:
         "200":
-          description: A set of all Hello entities
+          description: Set of all Hello entities
           content:
             application/json:
               schema:

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -22,7 +22,7 @@ paths:
       operationId: getAllHellos
       responses:
         "200":
-          description: Set of all Hello entities
+          description: A set of all Hello entities
           content:
             application/json:
               schema:

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloController.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloController.java
@@ -21,7 +21,7 @@ public class HelloController {
   /**
    * Retrieves all {@link Hello} entities.
    * 
-   * @return A set of all Hello entities
+   * @return Set of all Hello entities
    */
   @GetMapping
   public Set<Hello> getAllHellos() {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloController.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloController.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.hephaestus.hello;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,10 +21,10 @@ public class HelloController {
   /**
    * Retrieves all {@link Hello} entities.
    * 
-   * @return A list of all Hello entities
+   * @return A set of all Hello entities
    */
   @GetMapping
-  public List<Hello> getAllHellos() {
+  public Set<Hello> getAllHellos() {
     return helloService.getAllHellos();
   }
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloController.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloController.java
@@ -21,7 +21,7 @@ public class HelloController {
   /**
    * Retrieves all {@link Hello} entities.
    * 
-   * @return Set of all Hello entities
+   * @return A set of all Hello entities
    */
   @GetMapping
   public Set<Hello> getAllHellos() {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/hello/HelloService.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.hephaestus.hello;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,12 +23,12 @@ public class HelloService {
   /**
    * Retrieves all {@link Hello} entities from the repository.
    * 
-   * @return A list of all Hello entities
+   * @return A set of all Hello entities
    */
-  public List<Hello> getAllHellos() {
+  public Set<Hello> getAllHellos() {
     var hellos = helloRepository.findAll();
     logger.info("Getting Hellos: {}", hellos);
-    return helloRepository.findAll();
+    return helloRepository.findAll().stream().collect(Collectors.toSet());
   }
 
   /**

--- a/webapp/src/app/core/modules/openapi/api/hello.service.ts
+++ b/webapp/src/app/core/modules/openapi/api/hello.service.ts
@@ -162,9 +162,9 @@ export class HelloService implements HelloServiceInterface {
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
-    public getAllHellos(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Array<Hello>>;
-    public getAllHellos(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Array<Hello>>>;
-    public getAllHellos(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Array<Hello>>>;
+    public getAllHellos(observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<Set<Hello>>;
+    public getAllHellos(observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpResponse<Set<Hello>>>;
+    public getAllHellos(observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<HttpEvent<Set<Hello>>>;
     public getAllHellos(observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json', context?: HttpContext, transferCache?: boolean}): Observable<any> {
 
         let localVarHeaders = this.defaultHeaders;
@@ -204,7 +204,7 @@ export class HelloService implements HelloServiceInterface {
         }
 
         let localVarPath = `/hello`;
-        return this.httpClient.request<Array<Hello>>('get', `${this.configuration.basePath}${localVarPath}`,
+        return this.httpClient.request<Set<Hello>>('get', `${this.configuration.basePath}${localVarPath}`,
             {
                 context: localVarHttpContext,
                 responseType: <any>responseType_,

--- a/webapp/src/app/core/modules/openapi/api/hello.serviceInterface.ts
+++ b/webapp/src/app/core/modules/openapi/api/hello.serviceInterface.ts
@@ -34,6 +34,6 @@ export interface HelloServiceInterface {
      * Retrieves all {@link Hello Hello} entities.
      * Retrieves all {@link Hello Hello} entities.
      */
-    getAllHellos(extraHttpRequestParams?: any): Observable<Array<Hello>>;
+    getAllHellos(extraHttpRequestParams?: any): Observable<Set<Hello>>;
 
 }


### PR DESCRIPTION
### Motivation 

Closes #72 

### Description

You can add label `autocommit-openapi` to automatically let a GitHub workflow commit the updated specs and api clients