### PR TITLE
Replace `ApplicationRunner` with `EventListener` to fix startup time

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/codereview/base/Comment.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/codereview/base/Comment.java
@@ -1,11 +1,9 @@
 package de.tum.in.www1.hephaestus.codereview.base;
 
 import de.tum.in.www1.hephaestus.codereview.user.User;
-import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncScheduler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncScheduler.java
@@ -3,13 +3,13 @@ package de.tum.in.www1.hephaestus.scheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-public class GitHubDataSyncScheduler implements ApplicationRunner {
+public class GitHubDataSyncScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(GitHubDataSyncScheduler.class);
     private final GitHubDataSyncService dataSyncService;
@@ -21,8 +21,8 @@ public class GitHubDataSyncScheduler implements ApplicationRunner {
         this.dataSyncService = dataSyncService;
     }
 
-    @Override
-    public void run(ApplicationArguments args) throws Exception {
+    @EventListener(ApplicationReadyEvent.class)
+    public void run() {
         if (runOnStartup) {
             logger.info("Starting initial GitHub data sync...");
             dataSyncService.syncData();


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Guarantee the Github sync only runs after the server has started and is available.

### Description
<!-- Provide a brief summary of the changes. -->
Replaces the `ApplicationRunner` with an `EventLister` for the `ApplicationReadyEvent` event.

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [x] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)
