### PR TITLE
Add Github colors to Tailwind

### DIFF
--- a/webapp/.storybook/preview.ts
+++ b/webapp/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import { applicationConfig, Preview } from '@storybook/angular';
-import { withThemeByClassName } from '@storybook/addon-themes';
+import { withThemeByClassName, withThemeByDataAttribute } from '@storybook/addon-themes';
 import { DocsContainer } from '@storybook/blocks';
 import { createElement } from 'react';
 import { themes } from '@storybook/core/theming';
@@ -45,6 +45,9 @@ const preview: Preview = {
           ...theme,
           appContentBg: `hsl(${backgroundHSL})`,
         };
+        el?.setAttribute('data-color-mode', currentTheme);
+        el?.setAttribute('data-light-theme', 'light');
+        el?.setAttribute('data-dark-theme', 'dark');
         return createElement(DocsContainer, props);
       },
     },
@@ -54,6 +57,14 @@ const preview: Preview = {
       themes: {
         light: '',
         dark: 'dark bg-background',
+      },
+      defaultTheme: 'light',
+    }),
+    withThemeByDataAttribute({
+      attributeName: 'data-color-mode',
+      themes: {
+        light: 'light',
+        dark: 'dark',
       },
       defaultTheme: 'light',
     }),

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "18.2.1",
         "@angular/platform-browser-dynamic": "18.2.1",
         "@angular/router": "18.2.1",
+        "@primer/primitives": "^9.1.1",
         "@tanstack/angular-query-devtools-experimental": "5.52.0",
         "@tanstack/angular-query-experimental": "5.52.0",
         "autoprefixer": "10.4.20",
@@ -4408,6 +4409,29 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@prettier/sync": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.5.2.tgz",
+      "integrity": "sha512-Yb569su456XNx5BsH/Vyem7xD6g/y9iLmLUzRKM1a/dhU/D7HqqvkAG72znulXlMXztbV0iiu9O5AL8K98TzZQ==",
+      "dependencies": {
+        "make-synchronized": "^0.2.8"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier-synchronized?sponsor=1"
+      },
+      "peerDependencies": {
+        "prettier": "*"
+      }
+    },
+    "node_modules/@primer/primitives": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-9.1.1.tgz",
+      "integrity": "sha512-c8PjLIG+houvCRg9bKza3gj/VoM2QZcN7TqYRa4dl5ZYd1A+BOSvAenjGhVVK23ws8uZSVPYDuvdQk1PO1jm1A==",
+      "dependencies": {
+        "@prettier/sync": "^0.5.2",
+        "prettier": "3.3"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -13428,6 +13452,14 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/make-synchronized": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.2.9.tgz",
+      "integrity": "sha512-4wczOs8SLuEdpEvp3vGo83wh8rjJ78UsIk7DIX5fxdfmfMJGog4bQzxfvOwq7Q3yCHLC4jp1urPHIxRS/A93gA==",
+      "funding": {
+        "url": "https://github.com/fisker/make-synchronized?sponsor=1"
+      }
+    },
     "node_modules/map-or-similar": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -15687,7 +15719,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,6 +28,7 @@
     "@angular/platform-browser": "18.2.1",
     "@angular/platform-browser-dynamic": "18.2.1",
     "@angular/router": "18.2.1",
+    "@primer/primitives": "^9.1.1",
     "@tanstack/angular-query-devtools-experimental": "5.52.0",
     "@tanstack/angular-query-experimental": "5.52.0",
     "autoprefixer": "10.4.20",

--- a/webapp/src/app/components/theme-switcher/theme-switcher.service.ts
+++ b/webapp/src/app/components/theme-switcher/theme-switcher.service.ts
@@ -24,12 +24,14 @@ export class ThemeSwitcherService {
     this.currentTheme.set(AppTheme.LIGHT);
     this.setToLocalStorage(AppTheme.LIGHT);
     this.removeClassFromHtml('dark');
+    document.documentElement.setAttribute('data-color-mode', 'light');
   }
 
   setDarkTheme() {
     this.currentTheme.set(AppTheme.DARK);
     this.setToLocalStorage(AppTheme.DARK);
     this.addClassToHtml('dark');
+    document.documentElement.setAttribute('data-color-mode', 'dark');
   }
 
   setSystemTheme() {
@@ -42,6 +44,8 @@ export class ThemeSwitcherService {
     } else {
       this.removeClassFromHtml('dark');
     }
+
+    document.documentElement.setAttribute('data-color-mode', 'auto');
   }
 
   private addClassToHtml(className: string) {

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
   <head>
     <meta charset="utf-8" />
     <title>Hephaestus</title>
@@ -22,10 +22,12 @@
       if (theme === 'dark') {
         document.documentElement.classList.add('dark');
       }
+      document.documentElement.setAttribute('data-color-mode', theme);
     } else {
       if (browserDark) {
         document.documentElement.classList.add('dark');
       }
+      document.documentElement.setAttribute('data-color-mode', browserDark ? 'dark' : 'light');
       localStorage.setItem('theme', browserDark ? 'dark' : 'light');
     }
   </script>

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -1,3 +1,7 @@
+/* GitHub Primer CSS */
+@import '@primer/primitives/dist/css/functional/themes/light.css';
+@import '@primer/primitives/dist/css/functional/themes/dark.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/webapp/tailwind.config.ts
+++ b/webapp/tailwind.config.ts
@@ -50,6 +50,82 @@ const config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        github: {
+          foreground: "var(--fgColor-default)",
+          background: "var(--bgColor-default)",
+          muted: {
+            DEFAULT: "var(--bgColor-muted)",
+            foreground: "var(--fgColor-muted)",
+          },
+          onEmphasis: {
+            DEFAULT: "var(--bgColor-emphasis)",
+            foreground: "var(--fgColor-onEmphasis)",
+          },
+          onInverse: {
+            DEFAULT: "var(--bgColor-inverse)",
+            foreground: "var(--fgColor-onInverse)",
+          },
+          white: {
+            DEFAULT: "var(--bgColor-white)",
+            foreground: "var(--fgColor-white)",
+          },
+          black: {
+            DEFAULT: "var(--bgColor-black)",
+            foreground: "var(--fgColor-black)",
+          },
+          disabled: {
+            DEFAULT: "var(--bgColor-disabled)",
+            foreground: "var(--fgColor-disabled)",
+          },
+          link: {
+            DEFAULT: "var(--bgColor-link)",
+            foreground: "var(--fgColor-link)",
+          },
+          neutral: {
+            DEFAULT: "var(--bgColor-neutral)",
+            foreground: "var(--fgColor-neutral)",
+          },
+          accent: {
+            DEFAULT: "var(--bgColor-accent)",
+            foreground: "var(--fgColor-accent)",
+          },
+          success: {
+            DEFAULT: "var(--bgColor-success)",
+            foreground: "var(--fgColor-success)",
+          },
+          open: {
+            DEFAULT: "var(--bgColor-open)",
+            foreground: "var(--fgColor-open)",
+          },
+          attention: {
+            DEFAULT: "var(--bgColor-attention)",
+            foreground: "var(--fgColor-attention)",
+          },
+          severe: {
+            DEFAULT: "var(--bgColor-severe)",
+            foreground: "var(--fgColor-severe)",
+          },
+          danger: {
+            DEFAULT: "var(--bgColor-danger)",
+            foreground: "var(--fgColor-danger)",
+          },
+          closed: {
+            DEFAULT: "var(--bgColor-closed)",
+            foreground: "var(--fgColor-closed)",
+          },
+          done: {
+            DEFAULT: "var(--bgColor-done)",
+            foreground: "var(--fgColor-done)",
+          },
+          upsell: {
+            DEFAULT: "var(--bgColor-upsell)",
+            foreground: "var(--fgColor-upsell)",
+          },
+          sponsors: {
+            DEFAULT: "var(--bgColor-sponsors)",
+            foreground: "var(--fgColor-sponsors)",
+          },
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->

Github's design system's colors are openly available and we can make use of them.

### Description
<!-- Provide a brief summary of the changes. -->

Integrated GitHub's design system colors and created tailwind colors for it. 