### PR TITLE
Fix: Score calculation and avoid counting 'dismissed'-reviews as comments

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
@@ -108,8 +108,8 @@ public class LeaderboardService {
      * @return score
      */
     private int calculateScore(PullRequest pullRequest) {
-        Double complexityScore = (pullRequest.getChangedFiles() * 3) + (pullRequest.getCommits() * 0.5)
-                + pullRequest.getAdditions() + pullRequest.getDeletions();
+        Double complexityScore = ((pullRequest.getChangedFiles() * 3) + (pullRequest.getCommits() * 0.5)
+                + pullRequest.getAdditions() + pullRequest.getDeletions()) / 10;
         if (complexityScore < 10) {
             return 1; // Simple
         } else if (complexityScore < 50) {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
@@ -40,7 +40,7 @@ public class LeaderboardService {
         logger.info("Creating leaderboard dataset");
 
         List<User> users = userService.getAllUsers();
-        logger.info("Found " + users.size() + " users");
+        logger.info("Leaderboard has " + users.size() + " users");
 
         OffsetDateTime cutOffTime = new Date(System.currentTimeMillis() - 1000 * 60 * 60 * 24 * timeframe)
                 .toInstant().atOffset(ZoneOffset.UTC);
@@ -49,7 +49,6 @@ public class LeaderboardService {
             if (user.getType() != UserType.USER) {
                 return null;
             }
-            logger.info("User: " + user.getLogin());
             AtomicInteger score = new AtomicInteger(0);
             Set<PullRequestReviewDTO> changesRequestedSet = new HashSet<>();
             Set<PullRequestReviewDTO> approvedSet = new HashSet<>();
@@ -64,6 +63,7 @@ public class LeaderboardService {
                         }
                         PullRequestReviewDTO reviewDTO = new PullRequestReviewDTO(review.getId(), review.getCreatedAt(),
                                 review.getUpdatedAt(), review.getSubmittedAt(), review.getState());
+
                         switch (review.getState()) {
                             case CHANGES_REQUESTED:
                                 changesRequestedSet.add(reviewDTO);
@@ -71,9 +71,12 @@ public class LeaderboardService {
                             case APPROVED:
                                 approvedSet.add(reviewDTO);
                                 break;
-                            default:
+                            case COMMENTED:
                                 commentSet.add(reviewDTO);
                                 break;
+                            default:
+                                // ignore other states and don't add to score
+                                return;
                         }
                         score.addAndGet(calculateScore(review.getPullRequest()));
                     });


### PR DESCRIPTION
### Description
<!-- Provide a brief summary of the changes. -->
This PR fixes stats for the leaderboard.
- the score calculation formula was missing a divison by 10
- `dismissed`-reviews are no longer counted as comment (`commented`-state)

The original Python script goes a step further and backtraces `dismissed`-reviews to their original state. For now I was unable to figure out how to translate this behavior to our API-Wrapper, we might be able to do this in a follow-up.

### Screenshots (if applicable)
<!-- Attach screenshots here. -->

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [ ] Added tests for new functionality
