### PR TITLE
Fix: Avatar alt string template

### DIFF
--- a/webapp/src/app/home/leaderboard/leaderboard.component.html
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.html
@@ -14,7 +14,7 @@
         <td appTableCell>
           <a href="https://github.com/{{ entry.githubName }}" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 font-medium">
             <app-avatar class="-my-2">
-              <app-avatar-image [src]="entry.avatarUrl ?? ''" [alt]="'${entry.name}\'s avatar'" />
+              <app-avatar-image [src]="entry.avatarUrl ?? ''" [alt]="entry.name + '\'s avatar'" />
               <app-avatar-fallback>
                 {{ entry.name?.slice(0, 1)?.toUpperCase() }}
               </app-avatar-fallback>


### PR DESCRIPTION
### Description
<!-- Provide a brief summary of the changes. -->
Fixes a bug with the `alt`-attribute of the avatar component usage for the leaderboard.

### Screenshots (if applicable)
<!-- Attach screenshots here. -->
Before:
![image](https://github.com/user-attachments/assets/a815b49e-b89b-4481-9c6f-c130ad9a6aa3)
After:
![image](https://github.com/user-attachments/assets/c4a0bcd0-59be-42f5-8ee2-1f3152e825e5)

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [x] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)