### PR TITLE
Autowire Converters in WebMVC

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/WebConfig.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/WebConfig.java
@@ -1,0 +1,27 @@
+package de.tum.in.www1.hephaestus;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import de.tum.in.www1.hephaestus.codereview.comment.IssueCommentConverter;
+import de.tum.in.www1.hephaestus.codereview.comment.review.PullRequestReviewCommentConverter;
+import de.tum.in.www1.hephaestus.codereview.pullrequest.PullRequestConverter;
+import de.tum.in.www1.hephaestus.codereview.pullrequest.review.PullRequestReviewConverter;
+import de.tum.in.www1.hephaestus.codereview.repository.RepositoryConverter;
+import de.tum.in.www1.hephaestus.codereview.user.UserConverter;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(@NonNull FormatterRegistry registry) {
+        registry.addConverter(new UserConverter());
+        registry.addConverter(new RepositoryConverter());
+        registry.addConverter(new PullRequestConverter());
+        registry.addConverter(new PullRequestReviewConverter());
+        registry.addConverter(new IssueCommentConverter());
+        registry.addConverter(new PullRequestReviewCommentConverter());
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncService.java
@@ -23,6 +23,7 @@ import org.kohsuke.github.PagedIterator;
 import org.kohsuke.github.GHPullRequestQueryBuilder.Sort;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -68,12 +69,18 @@ public class GitHubDataSyncService {
     private final PullRequestReviewCommentRepository reviewCommentRepository;
     private final UserRepository userRepository;
 
-    private final RepositoryConverter repositoryConverter;
-    private final PullRequestConverter pullRequestConverter;
-    private final PullRequestReviewConverter reviewConverter;
-    private final IssueCommentConverter commentConverter;
-    private final PullRequestReviewCommentConverter reviewCommentConverter;
-    private final UserConverter userConverter;
+    @Autowired
+    private RepositoryConverter repositoryConverter;
+    @Autowired
+    private PullRequestConverter pullRequestConverter;
+    @Autowired
+    private PullRequestReviewConverter reviewConverter;
+    @Autowired
+    private IssueCommentConverter commentConverter;
+    @Autowired
+    private PullRequestReviewCommentConverter reviewCommentConverter;
+    @Autowired
+    private UserConverter userConverter;
 
     private Set<User> users = new HashSet<>();
     private Set<PullRequestReview> reviews = new HashSet<>();
@@ -81,10 +88,7 @@ public class GitHubDataSyncService {
     public GitHubDataSyncService(RepositoryRepository repositoryRepository, PullRequestRepository pullRequestRepository,
             PullRequestReviewRepository prReviewRepository,
             IssueCommentRepository commentRepository, PullRequestReviewCommentRepository reviewCommentRepository,
-            UserRepository userRepository,
-            RepositoryConverter repositoryConverter, PullRequestConverter pullRequestConverter,
-            PullRequestReviewConverter reviewConverter, IssueCommentConverter commentConverter,
-            PullRequestReviewCommentConverter reviewCommentConverter, UserConverter userConverter) {
+            UserRepository userRepository) {
         logger.info("Hello from GitHubDataSyncService!");
 
         this.repositoryRepository = repositoryRepository;
@@ -93,13 +97,6 @@ public class GitHubDataSyncService {
         this.commentRepository = commentRepository;
         this.reviewCommentRepository = reviewCommentRepository;
         this.userRepository = userRepository;
-
-        this.repositoryConverter = repositoryConverter;
-        this.pullRequestConverter = pullRequestConverter;
-        this.reviewConverter = reviewConverter;
-        this.commentConverter = commentConverter;
-        this.reviewCommentConverter = reviewCommentConverter;
-        this.userConverter = userConverter;
     }
 
     public void syncData() {


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Seperating the server logic across dedicated files often helps keep files clean and understandable. Our type converters can easily be handled by Spring itself, making manual handling obsolete.

### Description
<!-- Provide a brief summary of the changes. -->
This PR adds all our type converters to a dedicated `WebMvcConfigurer` making it possible to be autowired whenever necessary. This cleans up a lot of boilerplate code of our `GitHubDataSyncService`-constructor, letting Spring handle the injection.
Source: https://www.baeldung.com/spring-type-conversions#creating-a-custom-converter

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [ ] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)
