### PR TITLE
GUI for Custom Time Sliding Window in Leaderboard

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -24,6 +24,7 @@
         "autoprefixer": "10.4.20",
         "class-variance-authority": "0.7.0",
         "clsx": "2.1.1",
+        "dayjs": "^1.11.13",
         "lucide-angular": "0.429.0",
         "postcss": "8.4.41",
         "rxjs": "7.8.1",
@@ -9135,6 +9136,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.6",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -36,6 +36,7 @@
     "autoprefixer": "10.4.20",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.1",
+    "dayjs": "^1.11.13",
     "lucide-angular": "0.429.0",
     "postcss": "8.4.41",
     "rxjs": "7.8.1",

--- a/webapp/src/app/home/home.component.html
+++ b/webapp/src/app/home/home.component.html
@@ -1,11 +1,18 @@
 <div class="flex gap-2 flex-col items-center justify-center">
   <h1 class="text-3xl font-bold mb-4">Artemis Leaderboard</h1>
-  @if (query.isPending()) {
-    <span class="text-muted-foreground">Data is loading...</span>
-  } @else if (query.error()) {
-    <span class="text-destructive">An error has occurred</span>
-  }
-  @if (query.data()) {
-    <app-leaderboard [leaderboard]="query.data()" />
-  }
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 place-content-center">
+    <app-leaderboard-filter [after]="after()" [before]="before()" />
+    <div class="md:col-span-2 flex flex-col items-center gap-4">
+      @if (query.isPending()) {
+        <app-skeleton class="w-full h-96"></app-skeleton>
+      } @else if (query.error()) {
+        <span class="text-xl text-destructive mt-2">An error has occurred</span>
+      } @else if (query.data()) {
+        <div class="border rounded-md border-input">
+          <app-leaderboard [leaderboard]="query.data()" />
+        </div>
+      }
+    </div>
+  </div>
 </div>

--- a/webapp/src/app/home/home.component.ts
+++ b/webapp/src/app/home/home.component.ts
@@ -3,13 +3,15 @@ import { ActivatedRoute } from '@angular/router';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { LeaderboardService } from 'app/core/modules/openapi/api/leaderboard.service';
 import { LeaderboardComponent } from 'app/home/leaderboard/leaderboard.component';
-import { lastValueFrom } from 'rxjs';
+import { delay, lastValueFrom } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { LeaderboardFilterComponent } from './leaderboard/filter/filter.component';
+import { SkeletonComponent } from 'app/ui/skeleton/skeleton.component';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [LeaderboardComponent],
+  imports: [LeaderboardComponent, LeaderboardFilterComponent, SkeletonComponent],
   templateUrl: './home.component.html'
 })
 export class HomeComponent {
@@ -24,6 +26,6 @@ export class HomeComponent {
 
   query = injectQuery(() => ({
     queryKey: ['leaderboard', { after: this.after(), before: this.before() }],
-    queryFn: async () => lastValueFrom(this.leaderboardService.getLeaderboard(this.after(), this.before()))
+    queryFn: async () => lastValueFrom(this.leaderboardService.getLeaderboard(this.after(), this.before()).pipe(delay(1000)))
   }));
 }

--- a/webapp/src/app/home/leaderboard/filter/filter.component.html
+++ b/webapp/src/app/home/leaderboard/filter/filter.component.html
@@ -1,0 +1,7 @@
+<div class="flex flex-col gap-2 border rounded-md border-input bg-background px-3 py-4">
+  <h3 class="text-base font-bold leading-none uppercase text-muted-foreground text-center pb-4 tracking-wider">Filter</h3>
+  <div class="flex flex-col px-2 gap-1">
+    <app-label for="timeframe" class="text-sm font-semibold text-muted-foreground leading-relaxed">Timeframe</app-label>
+    <app-select name="timeframe" [options]="options()" (selectChange)="selectFn($event)" [defaultOption]="after() + '.' + before()"></app-select>
+  </div>
+</div>

--- a/webapp/src/app/home/leaderboard/filter/filter.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/filter.component.ts
@@ -1,0 +1,45 @@
+import { Component, input, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { SelectComponent, SelectOption } from 'app/ui/select/select.component';
+import dayjs from 'dayjs';
+import { LabelComponent } from '../../../ui/label/label.component';
+
+@Component({
+  selector: 'app-leaderboard-filter',
+  standalone: true,
+  imports: [SelectComponent, RouterLink, LabelComponent],
+  templateUrl: './filter.component.html'
+})
+export class LeaderboardFilterComponent {
+  after = input<string>();
+  before = input<string>();
+
+  options = signal<SelectOption[]>([]);
+
+  constructor(private router: Router) {
+    // get monday - sunday of last 4 weeks
+    const options = new Array<SelectOption>();
+    let currentDate = dayjs().day(1);
+    for (let i = 0; i < 4; i++) {
+      const newDate = currentDate.subtract(7, 'day');
+      options.push({
+        id: newDate.unix(),
+        value: `${newDate.format('YYYY-MM-DD')}.${currentDate.subtract(1, 'day').format('YYYY-MM-DD')}`,
+        label: `${newDate.format('MMM D')} - ${currentDate.subtract(1, 'day').format('MMM D')}`
+      });
+      currentDate = newDate;
+    }
+    this.options.set(options);
+  }
+
+  selectFn(value: string) {
+    const dates = value.split('.');
+    // change query params
+    this.router.navigate([], {
+      queryParams: {
+        after: dates[0],
+        before: dates[1]
+      }
+    });
+  }
+}

--- a/webapp/src/app/home/leaderboard/filter/filter.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/filter.component.ts
@@ -19,7 +19,13 @@ export class LeaderboardFilterComponent {
   constructor(private router: Router) {
     // get monday - sunday of last 4 weeks
     const options = new Array<SelectOption>();
+    const now = dayjs();
     let currentDate = dayjs().day(1);
+    options.push({
+      id: now.unix(),
+      value: `${currentDate.format('YYYY-MM-DD')}.${now.format('YYYY-MM-DD')}`,
+      label: `${currentDate.format('MMM D')} - ${now.format('MMM D')}`
+    });
     for (let i = 0; i < 4; i++) {
       const newDate = currentDate.subtract(7, 'day');
       options.push({

--- a/webapp/src/app/home/leaderboard/filter/filter.stories.ts
+++ b/webapp/src/app/home/leaderboard/filter/filter.stories.ts
@@ -1,0 +1,36 @@
+import { argsToTemplate, type Meta, type StoryObj } from '@storybook/angular';
+import { LeaderboardFilterComponent } from './filter.component';
+
+const meta: Meta<LeaderboardFilterComponent> = {
+  title: 'Components/Home/LeaderboardFilter',
+  component: LeaderboardFilterComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    after: {
+      control: {
+        type: 'text'
+      },
+      description: 'Left limit of the timeframe'
+    },
+    before: {
+      control: {
+        type: 'text'
+      },
+      description: 'Right limit of the timeframe'
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<LeaderboardFilterComponent>;
+
+export const Default: Story = {
+  args: {
+    after: '2024-09-09',
+    before: '2024-09-15'
+  },
+  render: (args) => ({
+    props: args,
+    template: `<app-leaderboard-filter ${argsToTemplate(args)} />`
+  })
+};

--- a/webapp/src/app/ui/select/select.component.html
+++ b/webapp/src/app/ui/select/select.component.html
@@ -1,0 +1,9 @@
+<select
+  class="h-10 w-full bg-background cursor-pointer select-none border-r-8 border-transparent px-4 text-base outline outline-1 outline-input rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+  (change)="onSelectChange($event)"
+  [name]="name()"
+>
+  @for (option of options(); track option.id) {
+    <option value="{{ option.value }}" [selected]="option.value === defaultOption()">{{ option.label }}</option>
+  }
+</select>

--- a/webapp/src/app/ui/select/select.component.ts
+++ b/webapp/src/app/ui/select/select.component.ts
@@ -1,0 +1,24 @@
+import { Component, input, output } from '@angular/core';
+
+export type SelectOption = {
+  id: number;
+  value: string;
+  label: string;
+};
+
+@Component({
+  selector: 'app-select',
+  standalone: true,
+  templateUrl: './select.component.html'
+})
+export class SelectComponent {
+  options = input.required<SelectOption[]>();
+  defaultOption = input<string>();
+  selectChange = output<string>();
+  name = input<string>();
+
+  onSelectChange(event: Event) {
+    const value = (event.target as HTMLSelectElement).value;
+    this.selectChange.emit(value);
+  }
+}

--- a/webapp/src/app/ui/select/select.stories.ts
+++ b/webapp/src/app/ui/select/select.stories.ts
@@ -1,0 +1,37 @@
+import { argsToTemplate, type Meta, type StoryObj } from '@storybook/angular';
+import { SelectComponent } from './select.component';
+
+const meta: Meta<SelectComponent> = {
+  title: 'UI/Select',
+  component: SelectComponent,
+  tags: ['autodocs'],
+  args: {
+    options: [
+      {
+        id: 1,
+        value: 'option-1',
+        label: 'Option 1'
+      },
+      {
+        id: 2,
+        value: 'option-2',
+        label: 'Option 2'
+      },
+      {
+        id: 3,
+        value: 'option-3',
+        label: 'Option 3'
+      }
+    ]
+  }
+};
+
+export default meta;
+type Story = StoryObj<SelectComponent>;
+
+export const Default: Story = {
+  render: (args) => ({
+    props: args,
+    template: `<app-select ${argsToTemplate(args)} />`
+  })
+};

--- a/webapp/src/app/ui/skeleton/skeleton.component.ts
+++ b/webapp/src/app/ui/skeleton/skeleton.component.ts
@@ -1,0 +1,23 @@
+import { Component, computed, input } from '@angular/core';
+import { cn } from 'app/utils';
+import { ClassValue } from 'clsx';
+
+export type SelectOption = {
+  id: string;
+  value: string;
+  label: string;
+};
+
+@Component({
+  selector: 'app-skeleton',
+  standalone: true,
+  template: '',
+  host: {
+    '[class]': 'computedClass()'
+  }
+})
+export class SkeletonComponent {
+  class = input<ClassValue>('');
+
+  computedClass = computed(() => cn('block animate-pulse rounded-md bg-muted', this.class()));
+}

--- a/webapp/src/app/ui/skeleton/skeleton.stories.ts
+++ b/webapp/src/app/ui/skeleton/skeleton.stories.ts
@@ -1,0 +1,18 @@
+import { type Meta, type StoryObj } from '@storybook/angular';
+import { SkeletonComponent } from './skeleton.component';
+
+const meta: Meta<SkeletonComponent> = {
+  title: 'UI/Skeleton',
+  component: SkeletonComponent,
+  tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<SkeletonComponent>;
+
+export const Default: Story = {
+  render: (args) => ({
+    props: args,
+    template: `<app-skeleton class="size-12" />`
+  })
+};


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
After the introduction of sliding time windows on the server in #100, we now aim to provide an intuitive GUI on the client to navigate through the past weekly leaderboards.

### Description
<!-- Provide a brief summary of the changes. -->
This PR introduces a FILTER-card for the leaderboard among smaller QoL improvements:
- When the data is still available yet, we feature a new `Skeleton`-component with an artificial delay (1s) added on top to improve UX and display smooth transitions
- A filter-card features a new `Select`-component for choosing the timeframe to be displayed in the leaderboard. A timeframe is defined as a calendar week (monday-sunday). The options consist of the current as well as the last 4 weeks.
- The filter card is displayed to the left of the leaderboard or above it on small devices.

### Screenshots (if applicable)
<!-- Attach screenshots here. -->
![Screenshot 2024-09-27 173746](https://github.com/user-attachments/assets/486c77cc-ea86-461e-804e-a1a5edb19f40)
![Screenshot 2024-09-27 175816](https://github.com/user-attachments/assets/81e6009e-ef0b-4e2c-af71-aac495571f6e)

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [x] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [x] Added Storybook stories for new components
- [x] Components follow design system guidelines (if applicable)
