### PR TITLE
Fix: Initial Leaderboard filter params

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -24,7 +24,7 @@
         "autoprefixer": "10.4.20",
         "class-variance-authority": "0.7.0",
         "clsx": "2.1.1",
-        "dayjs": "^1.11.13",
+        "dayjs": "1.11.13",
         "lucide-angular": "0.429.0",
         "postcss": "8.4.41",
         "rxjs": "7.8.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -36,7 +36,7 @@
     "autoprefixer": "10.4.20",
     "class-variance-authority": "0.7.0",
     "clsx": "2.1.1",
-    "dayjs": "^1.11.13",
+    "dayjs": "1.11.13",
     "lucide-angular": "0.429.0",
     "postcss": "8.4.41",
     "rxjs": "7.8.1",

--- a/webapp/src/app/home/home.component.ts
+++ b/webapp/src/app/home/home.component.ts
@@ -7,6 +7,7 @@ import { combineLatest, timer, lastValueFrom, map } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { LeaderboardFilterComponent } from './leaderboard/filter/filter.component';
 import { SkeletonComponent } from 'app/ui/skeleton/skeleton.component';
+import dayjs from 'dayjs';
 
 @Component({
   selector: 'app-home',
@@ -21,8 +22,8 @@ export class HomeComponent {
   // example: 2024-09-19
   private readonly route = inject(ActivatedRoute);
   private queryParams = toSignal(this.route.queryParamMap, { requireSync: true });
-  protected after = computed(() => this.queryParams().get('after') ?? undefined);
-  protected before = computed(() => this.queryParams().get('before') ?? undefined);
+  protected after = computed(() => this.queryParams().get('after') ?? dayjs().day(1).format('YYYY-MM-DD'));
+  protected before = computed(() => this.queryParams().get('before') ?? dayjs().format('YYYY-MM-DD'));
 
   query = injectQuery(() => ({
     queryKey: ['leaderboard', { after: this.after(), before: this.before() }],


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Closes #107.

### Description
<!-- Provide a brief summary of the changes. -->
We now use the current week as default whenever there are no query params. This should have been part of the original PR #105, but I must have missed it.
It also fixes the Dayjs package version, which got merged with a `^` in #92.

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Changes have been tested locally
- [x] Self-review of the code has been done
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [ ] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [ ] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)