### PR TITLE
Fix: Wait for Leaderboard params init

### DIFF
--- a/webapp/src/app/home/leaderboard/filter/filter.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/filter.component.ts
@@ -38,10 +38,10 @@ function formatLabel(startDate: dayjs.Dayjs, endDate: dayjs.Dayjs | undefined) {
 })
 export class LeaderboardFilterComponent {
   protected ListFilter = ListFilter;
-  after = input<string>();
-  before = input<string>();
+  after = input<string>('');
+  before = input<string>('');
 
-  value = signal<string>(`${this.after() ?? dayjs().day(1).format('YYYY-MM-DD')}.${this.before() ?? dayjs().format('YYYY-MM-DD')}`);
+  value = signal<string>(`${this.after()}.${this.before()}`);
 
   placeholder = computed(() => {
     return formatLabel(dayjs(this.after()) ?? dayjs().day(1), this.before() === undefined ? undefined : dayjs(this.before()));
@@ -74,6 +74,7 @@ export class LeaderboardFilterComponent {
 
   constructor(private router: Router) {
     effect(() => {
+      if (this.value().length === 1) return;
       const dates = this.value().split('.');
       // change query params
       this.router.navigate([], {


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes #107 but for the new Spartan select component.

### Description
<!-- Provide a brief summary of the changes. -->
With the new implementation of the select component, the scoreboard always skips to the newest timeframe options after a page refresh instead of keeping the state from the URL.
This PR fixes this issue by avoiding a navigation before the old query params are retrieved.

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [ ] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
