### PR TITLE
Fix: `LazyInitializationException` in CRON-job execution

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncService.java
@@ -49,6 +49,7 @@ import de.tum.in.www1.hephaestus.codereview.repository.RepositoryRepository;
 import de.tum.in.www1.hephaestus.codereview.user.User;
 import de.tum.in.www1.hephaestus.codereview.user.UserConverter;
 import de.tum.in.www1.hephaestus.codereview.user.UserRepository;
+import jakarta.transaction.Transactional;
 
 @Service
 public class GitHubDataSyncService {
@@ -143,6 +144,7 @@ public class GitHubDataSyncService {
      * 
      * @throws IOException
      */
+    @Transactional
     public void fetchRepository(String nameWithOwner) throws IOException {
         GHRepository ghRepo = github.getRepository(nameWithOwner);
         // Avoid double fetching of already stored repositories

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/scheduler/GitHubDataSyncService.java
@@ -51,6 +51,7 @@ import de.tum.in.www1.hephaestus.codereview.user.UserConverter;
 import de.tum.in.www1.hephaestus.codereview.user.UserRepository;
 import jakarta.transaction.Transactional;
 
+@Transactional
 @Service
 public class GitHubDataSyncService {
     private static final Logger logger = LoggerFactory.getLogger(GitHubDataSyncService.class);
@@ -144,7 +145,6 @@ public class GitHubDataSyncService {
      * 
      * @throws IOException
      */
-    @Transactional
     public void fetchRepository(String nameWithOwner) throws IOException {
         GHRepository ghRepo = github.getRepository(nameWithOwner);
         // Avoid double fetching of already stored repositories


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
The CRON-job execution currently fails with a `LazyInitializationException` leading to incorrect data updates and subsequent lack to data in the database.

### Description
<!-- Provide a brief summary of the changes. -->
Makes the scheduling `transactional` again to allow for arbitarity database access. This is required as some relations are only fetched lazily, requiring on-demand fetching during the scheduled task. 
Has been tested as Preview Deployment in Coolify, but not with the production DB.

For future reference: transactions can be customized via [Sessions](https://docs.jboss.org/hibernate/orm/3.5/javadocs/org/hibernate/Session.html).

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Server (if applicable)

- [ ] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [x] Changes have been tested in different environments (local + preview deployment)
