### PR TITLE
Fix: Improve filter layout for mobile

### DIFF
--- a/webapp/src/app/home/home.component.html
+++ b/webapp/src/app/home/home.component.html
@@ -1,6 +1,6 @@
 <div class="flex flex-col items-center">
   <div class="">
-    <div class="grid grid-cols-1 xl:grid-cols-4 gap-4 xl:gap-8">
+    <div class="grid grid-cols-1 xl:grid-cols-4 gap-y-4 xl:gap-8">
       <div class="space-y-2 col-span-1">
         <div class="flex flex-col gap-2 mb-4">
           <h1 class="text-3xl font-bold">Artemis Leaderboard</h1>

--- a/webapp/src/app/home/leaderboard/filter/filter.component.html
+++ b/webapp/src/app/home/leaderboard/filter/filter.component.html
@@ -1,9 +1,9 @@
-<div class="inline-flex flex-col gap-2 border rounded-md border-input bg-background p-4">
+<div class="w-full xl:w-fit inline-flex flex-col gap-2 border rounded-md border-input bg-background p-4">
   <span class="flex items-center pb-2 gap-2 text-muted-foreground">
     <lucide-angular [img]="ListFilter" class="size-4" />
     <h3 class="text-base font-semibold tracking-wide">Filter</h3>
   </span>
-  <form ngForm class="flex xl:flex-col gap-4">
+  <form ngForm class="flex flex-wrap gap-4">
     <app-leaderboard-filter-timeframe />
     @if (repositories() && repositories()!.length > 1) {
       <app-leaderboard-filter-repository [repositories]="repositories()!" />

--- a/webapp/src/app/home/leaderboard/filter/repository/repository.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/repository/repository.component.ts
@@ -26,15 +26,13 @@ export class LeaderboardFilterRepositoryComponent {
   });
 
   options = computed(() => {
-    const options: SelectOption[] = !this.repositories()
-      ? []
-      : this.repositories()!.map((name, index) => {
-          return {
-            id: index + 1,
-            value: name,
-            label: name
-          };
-        });
+    const options: SelectOption[] = this.repositories().map((name, index) => {
+      return {
+        id: index + 1,
+        value: name,
+        label: name
+      };
+    });
     options.unshift({
       id: 0,
       value: 'all',


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
On smaller screens (e.g. mobile) the leaderboard filters are sometimes outside of the viewing area.

### Description
<!-- Provide a brief summary of the changes. -->
This PR gives the filter component more responsiveness for smaller screens.

### Screenshots (if applicable)
<!-- Attach screenshots here. -->
Width <580px:
![image](https://github.com/user-attachments/assets/1caec1d6-efe7-47a9-95d7-209f25bb5e54)
Width 580-1280px:
![image](https://github.com/user-attachments/assets/f1534a8d-7c06-4aad-92da-ed6bd0ec44c1)


### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [x] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
