### PR TITLE
Fix: Timeframe Same Day Detection

### DIFF
--- a/webapp/src/app/home/home.component.ts
+++ b/webapp/src/app/home/home.component.ts
@@ -48,7 +48,7 @@ export class HomeComponent {
     if (afterParam) return afterParam;
 
     let defaultDate = dayjs().isoWeekday(this.leaderboardSchedule().day).startOf('hour').hour(this.leaderboardSchedule().hour).minute(this.leaderboardSchedule().minute);
-    if (defaultDate.isAfter(dayjs())) {
+    if (defaultDate.isAfter(dayjs()) || defaultDate.isSame(dayjs(), 'day')) {
       defaultDate = defaultDate.subtract(1, 'week');
     }
     return defaultDate.format();

--- a/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
@@ -68,7 +68,7 @@ export class LeaderboardFilterTimeframeComponent {
     const currentOption = this.value() !== '.' ? this.options().find(option => option.value === this.value()) : this.options()[0];
     const [startDate, endDate] = currentOption!.value.split('.').map(date => dayjs(date));
     const sameMonth = startDate.month() === endDate.month();
-    const endDateFormatted = endDate.isSame(dayjs(), 'minutes') ? 'Now' : (sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A'));
+    const endDateFormatted = endDate.isSame(dayjs(), 'hour') ? 'Now' : (sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A'));
     if (sameMonth) {
       return `${startDate.format('MMM D, h:mm A')} - ${endDateFormatted}`;
     } else {

--- a/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
@@ -66,13 +66,17 @@ export class LeaderboardFilterTimeframeComponent {
 
   formattedDates = computed(() => {
     const dates = this.value().split('.');
-    const startDate = dayjs(dates[0].length > 0 ? dates[0] : this.after());
+    let startDate = dayjs(dates[0].length > 0 ? dates[0] : this.after());
+    if (startDate.isAfter(dayjs()) || startDate.isSame(dayjs(), 'day')) {
+      startDate = startDate.subtract(1, 'week');
+    }
     const endDate = dayjs(dates[1].length > 0 ? dates[1] : this.before());
     const sameMonth = startDate.month() === endDate.month();
+    const endDateFormatted = endDate.isSame(dayjs(), 'day') ? 'Now' : (sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A'));
     if (sameMonth) {
-      return `${startDate.format('MMM D')} - ${endDate.format('D')}`;
+      return `${startDate.format('MMM D, h:mm A')} - ${endDateFormatted}`;
     } else {
-      return `${startDate.format('MMM D')} - ${endDate.format('MMM D')}`;
+      return `${startDate.format('MMM D, h:mm A')} - ${endDateFormatted}`;
     }
   });
 

--- a/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
@@ -65,10 +65,10 @@ export class LeaderboardFilterTimeframeComponent {
   });
 
   formattedDates = computed(() => {
-    const currentOption = this.value() !== '.' ? this.options().find(option => option.value === this.value()) : this.options()[0];
-    const [startDate, endDate] = currentOption!.value.split('.').map(date => dayjs(date));
+    const currentOption = this.value() !== '.' ? this.options().find((option) => option.value === this.value()) : this.options()[0];
+    const [startDate, endDate] = currentOption!.value.split('.').map((date) => dayjs(date));
     const sameMonth = startDate.month() === endDate.month();
-    const endDateFormatted = endDate.isSame(dayjs(), 'hour') ? 'Now' : (sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A'));
+    const endDateFormatted = endDate.isSame(dayjs(), 'hour') ? 'Now' : sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A');
     if (sameMonth) {
       return `${startDate.format('MMM D, h:mm A')} - ${endDateFormatted}`;
     } else {

--- a/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
@@ -65,14 +65,10 @@ export class LeaderboardFilterTimeframeComponent {
   });
 
   formattedDates = computed(() => {
-    const dates = this.value().split('.');
-    let startDate = dayjs(dates[0].length > 0 ? dates[0] : this.after());
-    if (startDate.isAfter(dayjs()) || startDate.isSame(dayjs(), 'day')) {
-      startDate = startDate.subtract(1, 'week');
-    }
-    const endDate = dayjs(dates[1].length > 0 ? dates[1] : this.before());
+    const currentOption = this.value() !== '.' ? this.options().find(option => option.value === this.value()) : this.options()[0];
+    const [startDate, endDate] = currentOption!.value.split('.').map(date => dayjs(date));
     const sameMonth = startDate.month() === endDate.month();
-    const endDateFormatted = endDate.isSame(dayjs(), 'day') ? 'Now' : (sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A'));
+    const endDateFormatted = endDate.isSame(dayjs(), 'minutes') ? 'Now' : (sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A'));
     if (sameMonth) {
       return `${startDate.format('MMM D, h:mm A')} - ${endDateFormatted}`;
     } else {


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes a bug where the leaderboard timeframe is incorrect on the starting day of a new leaderboard cycle.

### Description
<!-- Provide a brief summary of the changes. -->
Currently, there is a bug which causes the week to be displayed incorrectly on the same day of the new leaderboard cycle:
![image](https://github.com/user-attachments/assets/4e3cc4a8-bc1f-4001-aa47-f114865954b9)
This PR additionally also changes:
- Time of the day is now displayed
- The "before" of the active leaderboard week is now displayed as "Now". "Now" is only shown for a "before" within the same hour

**Interesting behavior:**
Currently the leaderboard data is not refreshed ("up-to-date") when switching select-options due to our initial determination of dates. For example if we switch back to the "current week" after leaving the page open for a few minutes, our data will still be the same as it was when accessing the "current week" for the first time. Only a page-refresh updates the data. 

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Run the `application-server` and `webapp`
- Go to http://localhost:4200/ and check if the placerholder in the "Select week"-select is correct
- Cycle through other weeks and check if the description text below stays correct

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
