### PR TITLE
Fix: Changing Server Timezone

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/Application.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/Application.java
@@ -8,9 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Application {
 
 	public static void main(String[] args) {
-        System.out.println("Old TimeZone: " + TimeZone.getDefault().toString());
 		TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
-		System.out.println("New TimeZone: " + TimeZone.getDefault().toString());
 		SpringApplication.run(Application.class, args);
 	}
 }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/Application.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/Application.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.hephaestus;
 
+import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Application {
 
 	public static void main(String[] args) {
+        System.out.println("Old TimeZone: " + TimeZone.getDefault().toString());
+		TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"));
+		System.out.println("New TimeZone: " + TimeZone.getDefault().toString());
 		SpringApplication.run(Application.class, args);
 	}
 }


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
We want to change the timezone of the server to correctly schedule CRON-jobs, such as the scheduled Slack message.

### Description
<!-- Provide a brief summary of the changes. -->
This PR sets the timezone to `Europe/Berlin`, which resolves to UTC+1/+2 handling daylight saving time automatically.
Has been tested as preview deployment on the server:
![Screenshot 2024-11-12 145458](https://github.com/user-attachments/assets/7e9a096c-6229-40f6-bbd4-e927e0d8772e)

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
Nothing to test really

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [ ] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [x] Changes have been tested in different environments (if applicable)
