### PR TITLE
Popover for reviewed PRs & Copy-Button

### DIFF
--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -344,6 +344,7 @@ components:
       - numberOfReviewedPRs
       - numberOfUnknowns
       - rank
+      - reviewedPullRequests
       - score
       - user
       type: object
@@ -356,6 +357,10 @@ components:
           format: int32
         user:
           $ref: "#/components/schemas/UserInfo"
+        reviewedPullRequests:
+          type: array
+          items:
+            $ref: "#/components/schemas/PullRequestInfo"
         numberOfReviewedPRs:
           type: integer
           format: int32

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardEntryDTO.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardEntryDTO.java
@@ -1,12 +1,15 @@
 package de.tum.in.www1.hephaestus.leaderboard;
 
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestInfoDTO;
 import de.tum.in.www1.hephaestus.gitprovider.user.UserInfoDTO;
 import io.micrometer.common.lang.NonNull;
+import java.util.List;
 
 public record LeaderboardEntryDTO(
         @NonNull Integer rank,
         @NonNull Integer score,
         @NonNull UserInfoDTO user,
+        @NonNull List<PullRequestInfoDTO> reviewedPullRequests,
         @NonNull Integer numberOfReviewedPRs,
         @NonNull Integer numberOfApprovals,
         @NonNull Integer numberOfChangeRequests,

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
@@ -1,29 +1,29 @@
 package de.tum.in.www1.hephaestus.leaderboard;
 
-import java.util.stream.IntStream;
-import java.util.Map;
-import java.time.OffsetDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.IssueComment;
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.IssueCommentRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequest;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestInfoDTO;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreview.PullRequestReview;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreview.PullRequestReviewRepository;
 import de.tum.in.www1.hephaestus.gitprovider.user.User;
 import de.tum.in.www1.hephaestus.gitprovider.user.UserInfoDTO;
 import jakarta.transaction.Transactional;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Service
 public class LeaderboardService {
+
     private static final Logger logger = LoggerFactory.getLogger(LeaderboardService.class);
 
     private final PullRequestReviewRepository pullRequestReviewRepository;
@@ -33,116 +33,178 @@ public class LeaderboardService {
     private int timeframe;
 
     public LeaderboardService(
-            PullRequestReviewRepository pullRequestReviewRepository,
-            IssueCommentRepository issueCommentRepository) {
+        PullRequestReviewRepository pullRequestReviewRepository,
+        IssueCommentRepository issueCommentRepository
+    ) {
         this.pullRequestReviewRepository = pullRequestReviewRepository;
         this.issueCommentRepository = issueCommentRepository;
     }
 
     @Transactional
-    public List<LeaderboardEntryDTO> createLeaderboard(OffsetDateTime after, OffsetDateTime before,
-            Optional<String> repository) {
+    public List<LeaderboardEntryDTO> createLeaderboard(
+        OffsetDateTime after,
+        OffsetDateTime before,
+        Optional<String> repository
+    ) {
         logger.info("Creating leaderboard dataset");
         logger.info("Timeframe: {} - {}", after, before);
-        List<PullRequestReview> reviews = pullRequestReviewRepository.findAllInTimeframe(after, before,
-                repository);
-        List<IssueComment> issueComments = issueCommentRepository.findAllInTimeframe(after, before,
-                repository, true);
+        List<PullRequestReview> reviews = pullRequestReviewRepository.findAllInTimeframe(after, before, repository);
+        List<IssueComment> issueComments = issueCommentRepository.findAllInTimeframe(after, before, repository, true);
 
-        Map<Long, User> usersById = reviews.stream().map(PullRequestReview::getAuthor)
-                .collect(Collectors.toMap(User::getId, user -> user, (u1, u2) -> u1));
-        
+        Map<Long, User> usersById = reviews
+            .stream()
+            .map(PullRequestReview::getAuthor)
+            .collect(Collectors.toMap(User::getId, user -> user, (u1, u2) -> u1));
+
         // Review activity
-        Map<Long, List<PullRequestReview>> reviewsByUserId = reviews.stream()
-                .collect(Collectors.groupingBy(review -> review.getAuthor().getId()));
-        Map<Long, List<IssueComment>> issueCommentsByUserId = issueComments.stream()
-                .collect(Collectors.groupingBy(comment -> comment.getAuthor().getId()));
-        
-        Map<Long, Integer> scoresByUserId = reviewsByUserId.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> calculateTotalScore(entry.getValue(), 
-                        issueCommentsByUserId.getOrDefault(entry.getKey(), List.of()).size())));
+        Map<Long, List<PullRequestReview>> reviewsByUserId = reviews
+            .stream()
+            .collect(Collectors.groupingBy(review -> review.getAuthor().getId()));
+        Map<Long, List<IssueComment>> issueCommentsByUserId = issueComments
+            .stream()
+            .collect(Collectors.groupingBy(comment -> comment.getAuthor().getId()));
+
+        Map<Long, Integer> scoresByUserId = reviewsByUserId
+            .entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(Map.Entry::getKey, entry ->
+                    calculateTotalScore(
+                        entry.getValue(),
+                        issueCommentsByUserId.getOrDefault(entry.getKey(), List.of()).size()
+                    )
+                )
+            );
 
         // Ranking (sorted by score descending)
-        List<Long> rankingByUserId = scoresByUserId.entrySet().stream()
-                .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+        List<Long> rankingByUserId = scoresByUserId
+            .entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
 
         List<LeaderboardEntryDTO> leaderboard = IntStream.range(0, rankingByUserId.size())
-                .mapToObj(index -> {
-                    int rank = index + 1;
-                    Long userId = rankingByUserId.get(index);
-                    int score = scoresByUserId.get(userId);
-                    UserInfoDTO user = UserInfoDTO.fromUser(usersById.get(userId));
-                    List<PullRequestReview> userReviews = reviewsByUserId.getOrDefault(userId, List.of());
-                    List<IssueComment> userIssueComments = issueCommentsByUserId.getOrDefault(userId, List.of());
+            .mapToObj(index -> {
+                int rank = index + 1;
+                Long userId = rankingByUserId.get(index);
+                int score = scoresByUserId.get(userId);
+                UserInfoDTO user = UserInfoDTO.fromUser(usersById.get(userId));
+                List<PullRequestReview> userReviews = reviewsByUserId.getOrDefault(userId, List.of());
+                List<IssueComment> userIssueComments = issueCommentsByUserId.getOrDefault(userId, List.of());
+                List<PullRequestInfoDTO> reviewedPullRequests = userReviews
+                    .stream()
+                    .map(review -> review.getPullRequest())
+                    // First collect to a map keyed by PR ID to ensure uniqueness
+                    .collect(
+                        Collectors.groupingBy(
+                            PullRequest::getId, // Key by ID
+                            Collectors.collectingAndThen(
+                                Collectors.toList(),
+                                list -> PullRequestInfoDTO.fromPullRequest(list.get(0)) // Convert first instance to DTO
+                            )
+                        )
+                    )
+                    .values()
+                    .stream()
+                    .collect(Collectors.toList());
 
-                    int numberOfReviewedPRs = userReviews.stream().map(review -> review.getPullRequest().getId())
-                            .collect(Collectors.toSet()).size();
-                    int numberOfApprovals = (int) userReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.APPROVED).count();
-                    int numberOfChangeRequests = (int) userReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.CHANGES_REQUESTED).count();
-                    int numberOfComments = (int) userReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.COMMENTED)
-                            .filter(review -> review.getBody() != null).count();
-                    numberOfComments += userIssueComments.size();
-                    
-                    int numberOfUnknowns = (int) userReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.UNKNOWN)
-                            .filter(review -> review.getBody() != null).count();
-                    int numberOfCodeComments = userReviews.stream().map(review -> review.getComments().size()).reduce(0,
-                            Integer::sum);
+                int numberOfReviewedPRs = userReviews
+                    .stream()
+                    .map(review -> review.getPullRequest().getId())
+                    .collect(Collectors.toSet())
+                    .size();
+                int numberOfApprovals = (int) userReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.APPROVED)
+                    .count();
+                int numberOfChangeRequests = (int) userReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.CHANGES_REQUESTED)
+                    .count();
+                int numberOfComments = (int) userReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.COMMENTED)
+                    .filter(review -> review.getBody() != null)
+                    .count();
+                numberOfComments += userIssueComments.size();
 
-                    return new LeaderboardEntryDTO(rank, score, user, numberOfReviewedPRs, numberOfApprovals,
-                            numberOfChangeRequests, numberOfComments, numberOfUnknowns, numberOfCodeComments);
-                })
-                .toList();
+                int numberOfUnknowns = (int) userReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.UNKNOWN)
+                    .filter(review -> review.getBody() != null)
+                    .count();
+                int numberOfCodeComments = userReviews
+                    .stream()
+                    .map(review -> review.getComments().size())
+                    .reduce(0, Integer::sum);
+
+                return new LeaderboardEntryDTO(
+                    rank,
+                    score,
+                    user,
+                    reviewedPullRequests,
+                    numberOfReviewedPRs,
+                    numberOfApprovals,
+                    numberOfChangeRequests,
+                    numberOfComments,
+                    numberOfUnknowns,
+                    numberOfCodeComments
+                );
+            })
+            .toList();
 
         return leaderboard;
     }
 
     private int calculateTotalScore(List<PullRequestReview> reviews, int numberOfIssueComments) {
         // Could contain multiple reviews for the same pull request
-        Map<Long, List<PullRequestReview>> reviewsByPullRequestId = reviews.stream()
-                .collect(Collectors.groupingBy(review -> review.getPullRequest().getId()));
+        Map<Long, List<PullRequestReview>> reviewsByPullRequestId = reviews
+            .stream()
+            .collect(Collectors.groupingBy(review -> review.getPullRequest().getId()));
 
         double totalScore = reviewsByPullRequestId
-                .values()
-                .stream()
-                .map(pullRequestReviews -> {
-                    // All reviews are for the same pull request
-                    int complexityScore = calculateComplexityScore(pullRequestReviews.get(0).getPullRequest());
+            .values()
+            .stream()
+            .map(pullRequestReviews -> {
+                // All reviews are for the same pull request
+                int complexityScore = calculateComplexityScore(pullRequestReviews.get(0).getPullRequest());
 
-                    int approvalReviews = (int) pullRequestReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.APPROVED)
-                            .count();
-                    int changesRequestedReviews = (int) pullRequestReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.CHANGES_REQUESTED)
-                            .count();
-                    int commentReviews = (int) pullRequestReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.COMMENTED)
-                            .filter(review -> review.getBody() != null) // Only count if there is a comment
-                            .count();
-                    int unknownReviews = (int) pullRequestReviews.stream()
-                            .filter(review -> review.getState() == PullRequestReview.State.UNKNOWN)
-                            .filter(review -> review.getBody() != null) // Only count if there is a comment
-                            .count();
+                int approvalReviews = (int) pullRequestReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.APPROVED)
+                    .count();
+                int changesRequestedReviews = (int) pullRequestReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.CHANGES_REQUESTED)
+                    .count();
+                int commentReviews = (int) pullRequestReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.COMMENTED)
+                    .filter(review -> review.getBody() != null) // Only count if there is a comment
+                    .count();
+                int unknownReviews = (int) pullRequestReviews
+                    .stream()
+                    .filter(review -> review.getState() == PullRequestReview.State.UNKNOWN)
+                    .filter(review -> review.getBody() != null) // Only count if there is a comment
+                    .count();
 
-                    int codeComments = pullRequestReviews.stream()
-                            .map(review -> review.getComments().size())
-                            .reduce(0, Integer::sum);
+                int codeComments = pullRequestReviews
+                    .stream()
+                    .map(review -> review.getComments().size())
+                    .reduce(0, Integer::sum);
 
-                    double interactionScore = (approvalReviews * 1.5 +
-                            changesRequestedReviews * 2.0 +
-                            (commentReviews + unknownReviews + numberOfIssueComments) +
-                            codeComments * 0.5);
+                double interactionScore =
+                    (approvalReviews * 1.5 +
+                        changesRequestedReviews * 2.0 +
+                        (commentReviews + unknownReviews + numberOfIssueComments) +
+                        codeComments * 0.5);
 
-                    double complexityBonus = 1 + (complexityScore - 1) / 32.0;
+                double complexityBonus = 1 + (complexityScore - 1) / 32.0;
 
-                    return 5 * interactionScore * complexityBonus;
-                })
-                .reduce(0.0, Double::sum);
+                return 5 * interactionScore * complexityBonus;
+            })
+            .reduce(0.0, Double::sum);
         return (int) Math.ceil(totalScore);
     }
 
@@ -150,13 +212,17 @@ public class LeaderboardService {
      * Calculates the complexity score for a given pull request.
      * Possible values: 1, 3, 7, 17, 33.
      * Taken from the original leaderboard implementation script.
-     * 
+     *
      * @param pullRequest
      * @return score
      */
     private int calculateComplexityScore(PullRequest pullRequest) {
-        Double complexityScore = ((pullRequest.getChangedFiles() * 3) + (pullRequest.getCommits() * 0.5)
-                + pullRequest.getAdditions() + pullRequest.getDeletions()) / 10;
+        Double complexityScore =
+            ((pullRequest.getChangedFiles() * 3) +
+                (pullRequest.getCommits() * 0.5) +
+                pullRequest.getAdditions() +
+                pullRequest.getDeletions()) /
+            10;
         if (complexityScore < 10) {
             return 1; // Simple
         } else if (complexityScore < 50) {

--- a/webapp/src/app/core/modules/openapi/model/leaderboard-entry.ts
+++ b/webapp/src/app/core/modules/openapi/model/leaderboard-entry.ts
@@ -13,7 +13,7 @@ import { PullRequestInfo } from './pull-request-info';
 import { UserInfo } from './user-info';
 
 
-export interface LeaderboardEntry {
+export interface LeaderboardEntry { 
     rank: number;
     score: number;
     user: UserInfo;

--- a/webapp/src/app/core/modules/openapi/model/leaderboard-entry.ts
+++ b/webapp/src/app/core/modules/openapi/model/leaderboard-entry.ts
@@ -13,7 +13,7 @@ import { PullRequestInfo } from './pull-request-info';
 import { UserInfo } from './user-info';
 
 
-export interface LeaderboardEntry { 
+export interface LeaderboardEntry {
     rank: number;
     score: number;
     user: UserInfo;

--- a/webapp/src/app/core/modules/openapi/model/leaderboard-entry.ts
+++ b/webapp/src/app/core/modules/openapi/model/leaderboard-entry.ts
@@ -9,6 +9,7 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
+import { PullRequestInfo } from './pull-request-info';
 import { UserInfo } from './user-info';
 
 
@@ -16,6 +17,7 @@ export interface LeaderboardEntry {
     rank: number;
     score: number;
     user: UserInfo;
+    reviewedPullRequests: Array<PullRequestInfo>;
     numberOfReviewedPRs: number;
     numberOfApprovals: number;
     numberOfChangeRequests: number;

--- a/webapp/src/app/home/leaderboard/leaderboard.component.html
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.html
@@ -56,41 +56,7 @@
           <td appTableCell class="py-2">
             <div class="flex items-center gap-2">
               @if (entry.numberOfReviewedPRs) {
-                <brn-popover sideOffset="5" closeDelay="100">
-                  <button variant="outline" size="sm" class="flex items-center gap-1 text-github-muted-foreground" brnPopoverTrigger hlmBtn (click)="$event.stopPropagation()">
-                    <ng-icon [svg]="octGitPullRequest" size="16" />
-                    {{ entry.numberOfReviewedPRs }}
-                  </button>
-                  <div hlmPopoverContent class="w-80 space-y-4" *brnPopoverContent="let ctx">
-                    <div class="flex flex-wrap justify-between items-center gap-4">
-                      <div class="flex items-center gap-2">
-                        <ng-icon [svg]="octGitPullRequest" size="20" />
-                        <h4 class="font-medium leading-none">Reviewed PRs</h4>
-                      </div>
-                      <button variant="outline" size="icon" (click)="copyPullRequests(entry)" hlmBtn>
-                        @if (showCopySuccess()) {
-                          <hlm-icon name="lucideCheck" class="text-green-600 h-5 w-5" />
-                        } @else {
-                          <hlm-icon name="lucideClipboardCopy" class="h-5 w-5" />
-                        }
-                      </button>
-                    </div>
-                    <hlm-scroll-area class="rounded-md" [autoHeightDisabled]="false" [style]="'height: ' + calcScrollHeight(entry.reviewedPullRequests)">
-                      @for (pr of entry.reviewedPullRequests; track pr.id) {
-                        <a
-                          [href]="pr.htmlUrl"
-                          target="_blank"
-                          class="flex items-center gap-2 p-2 text-sm text-muted-foreground containerSize my-1 mr-2"
-                          variant="outline"
-                          hlmBtn
-                          [title]="pr.title"
-                        >
-                          <span [innerHTML]="displayPullRequestTitle(pr.title)" class="truncate w-[95%]"></span>
-                        </a>
-                      }
-                    </hlm-scroll-area>
-                  </div>
-                </brn-popover>
+                <app-reviews-popover [reviewedPRs]="entry.reviewedPullRequests" />
                 <div class="flex items-center text-github-muted-foreground">
                   <ng-icon [svg]="octChevronLeft" size="16" />
                 </div>

--- a/webapp/src/app/home/leaderboard/leaderboard.component.html
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.html
@@ -56,10 +56,34 @@
           <td appTableCell class="py-2">
             <div class="flex items-center gap-2">
               @if (entry.numberOfReviewedPRs) {
-                <div class="flex items-center gap-1 text-github-muted-foreground" title="Total reviewed PRs">
-                  <ng-icon [svg]="octGitPullRequest" size="16" />
-                  {{ entry.numberOfReviewedPRs }}
-                </div>
+                <brn-popover sideOffset="5" closeDelay="100">
+                  <button variant="outline" size="sm" class="flex items-center gap-1 text-github-muted-foreground" brnPopoverTrigger hlmBtn (click)="$event.stopPropagation()">
+                    <ng-icon [svg]="octGitPullRequest" size="16" />
+                    {{ entry.numberOfReviewedPRs }}
+                  </button>
+                  <div hlmPopoverContent class="w-80 space-y-4" *brnPopoverContent="let ctx">
+                    <div class="flex flex-wrap justify-between items-center gap-4">
+                      <div class="flex items-center gap-2">
+                        <ng-icon [svg]="octGitPullRequest" size="20" />
+                        <h4 class="font-medium leading-none">Reviewed PRs</h4>
+                      </div>
+                      <button variant="outline" size="icon" (click)="copyPullRequests(entry)" hlmBtn>
+                        @if (showCopySuccess()) {
+                          <hlm-icon name="lucideCheck" class="text-green-600 h-5 w-5" />
+                        } @else {
+                          <hlm-icon name="lucideClipboardCopy" class="h-5 w-5"  />
+                        }
+                      </button>
+                    </div>
+                    <hlm-scroll-area class="rounded-md" [autoHeightDisabled]="false" [style]="'height: ' + calcScrollHeight(entry.reviewedPullRequests)">
+                      @for (pr of entry.reviewedPullRequests; track pr.id) {
+                        <a [href]="pr.htmlUrl" target="_blank" class="flex items-center gap-2 p-2 text-sm text-muted-foreground containerSize my-1 mr-2" variant="outline" hlmBtn [title]="pr.title">
+                          <span [innerHTML]="displayPullRequestTitle(pr.title)" class="truncate w-[95%]"></span>
+                        </a>
+                      }
+                    </hlm-scroll-area>
+                  </div>
+                </brn-popover>
                 <div class="flex items-center text-github-muted-foreground">
                   <ng-icon [svg]="octChevronLeft" size="16" />
                 </div>

--- a/webapp/src/app/home/leaderboard/leaderboard.component.html
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.html
@@ -71,13 +71,20 @@
                         @if (showCopySuccess()) {
                           <hlm-icon name="lucideCheck" class="text-green-600 h-5 w-5" />
                         } @else {
-                          <hlm-icon name="lucideClipboardCopy" class="h-5 w-5"  />
+                          <hlm-icon name="lucideClipboardCopy" class="h-5 w-5" />
                         }
                       </button>
                     </div>
                     <hlm-scroll-area class="rounded-md" [autoHeightDisabled]="false" [style]="'height: ' + calcScrollHeight(entry.reviewedPullRequests)">
                       @for (pr of entry.reviewedPullRequests; track pr.id) {
-                        <a [href]="pr.htmlUrl" target="_blank" class="flex items-center gap-2 p-2 text-sm text-muted-foreground containerSize my-1 mr-2" variant="outline" hlmBtn [title]="pr.title">
+                        <a
+                          [href]="pr.htmlUrl"
+                          target="_blank"
+                          class="flex items-center gap-2 p-2 text-sm text-muted-foreground containerSize my-1 mr-2"
+                          variant="outline"
+                          hlmBtn
+                          [title]="pr.title"
+                        >
                           <span [innerHTML]="displayPullRequestTitle(pr.title)" class="truncate w-[95%]"></span>
                         </a>
                       }

--- a/webapp/src/app/home/leaderboard/leaderboard.component.ts
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.ts
@@ -16,7 +16,6 @@ import { BrnPopoverComponent, BrnPopoverContentDirective, BrnPopoverTriggerDirec
 import { HlmScrollAreaComponent } from '@spartan-ng/ui-scrollarea-helm';
 import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
 
-
 import { RouterLink } from '@angular/router';
 import { SecurityStore } from '@app/core/security/security-store.service';
 import { cn } from '@app/utils';
@@ -71,7 +70,7 @@ export class LeaderboardComponent {
   calcScrollHeight = (arr: PullRequestInfo[]) => {
     return `min(200px, calc(${15 + 42 * arr.length}px))`;
   };
-  displayPullRequestTitle = (title: string) => (title).replace(/`([^`]+)`/g, '<code class="textCode">$1</code>');
+  displayPullRequestTitle = (title: string) => title.replace(/`([^`]+)`/g, '<code class="textCode">$1</code>');
 
   copyPullRequests = (entry: LeaderboardEntry) => {
     const htmlList = `<ul>

--- a/webapp/src/app/home/leaderboard/leaderboard.component.ts
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.ts
@@ -1,25 +1,19 @@
-import { Component, inject, input, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Component, inject, input } from '@angular/core';
 import { NgIconComponent } from '@ng-icons/core';
 import { octFileDiff, octCheck, octComment, octCommentDiscussion, octGitPullRequest, octChevronLeft, octNoEntry } from '@ng-icons/octicons';
-import { LeaderboardEntry, type PullRequestInfo } from 'app/core/modules/openapi';
+import { cn } from '@app/utils';
+import { HlmAvatarModule } from '@spartan-ng/ui-avatar-helm';
+import { HlmSkeletonModule } from '@spartan-ng/ui-skeleton-helm';
+import { SecurityStore } from '@app/core/security/security-store.service';
+import { LeaderboardEntry } from 'app/core/modules/openapi';
 import { TableBodyDirective } from 'app/ui/table/table-body.directive';
 import { TableCellDirective } from 'app/ui/table/table-cell.directive';
 import { TableHeadDirective } from 'app/ui/table/table-head.directive';
 import { TableHeaderDirective } from 'app/ui/table/table-header.directive';
 import { TableRowDirective } from 'app/ui/table/table-row.directive';
 import { TableComponent } from 'app/ui/table/table.component';
-import { HlmAvatarModule } from '@spartan-ng/ui-avatar-helm';
-import { HlmSkeletonModule } from '@spartan-ng/ui-skeleton-helm';
-import { HlmPopoverModule } from '@spartan-ng/ui-popover-helm';
-import { HlmButtonModule } from '@spartan-ng/ui-button-helm';
-import { BrnPopoverComponent, BrnPopoverContentDirective, BrnPopoverTriggerDirective } from '@spartan-ng/ui-popover-brain';
-import { HlmScrollAreaComponent } from '@spartan-ng/ui-scrollarea-helm';
-import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
-
-import { RouterLink } from '@angular/router';
-import { SecurityStore } from '@app/core/security/security-store.service';
-import { cn } from '@app/utils';
-import { lucideCheck, lucideClipboardCopy } from '@ng-icons/lucide';
+import { ReviewsPopoverComponent } from './reviews-popover/reviews-popover.component';
 
 @Component({
   selector: 'app-leaderboard',
@@ -33,17 +27,10 @@ import { lucideCheck, lucideClipboardCopy } from '@ng-icons/lucide';
     TableHeaderDirective,
     TableHeadDirective,
     TableRowDirective,
+    ReviewsPopoverComponent,
     NgIconComponent,
-    RouterLink,
-    HlmPopoverModule,
-    BrnPopoverComponent,
-    BrnPopoverContentDirective,
-    BrnPopoverTriggerDirective,
-    HlmScrollAreaComponent,
-    HlmButtonModule,
-    HlmIconComponent
+    RouterLink
   ],
-  providers: [provideIcons({ lucideClipboardCopy, lucideCheck })],
   templateUrl: './leaderboard.component.html'
 })
 export class LeaderboardComponent {
@@ -61,38 +48,8 @@ export class LeaderboardComponent {
 
   leaderboard = input<LeaderboardEntry[]>();
   isLoading = input<boolean>();
-  showCopySuccess = signal(false);
 
   trClass = (entry: LeaderboardEntry) => {
     return cn('cursor-pointer', this.signedIn() && this.user()?.username.toLowerCase() === entry.user.login.toLowerCase() ? 'bg-accent' : '');
-  };
-
-  calcScrollHeight = (arr: PullRequestInfo[]) => {
-    return `min(200px, calc(${15 + 42 * arr.length}px))`;
-  };
-  displayPullRequestTitle = (title: string) => title.replace(/`([^`]+)`/g, '<code class="textCode">$1</code>');
-
-  copyPullRequests = (entry: LeaderboardEntry) => {
-    const htmlList = `<ul>
-      ${entry.reviewedPullRequests.map((pr) => `<li><a href="${pr.htmlUrl}">#${pr.number}</a></li>`).join('\n')}
-    </ul>`;
-
-    const plainText = entry.reviewedPullRequests.map((pr) => `#${pr.number}`).join('\n');
-
-    const clipboardItem = new ClipboardItem({
-      'text/html': new Blob([htmlList], { type: 'text/html' }),
-      'text/plain': new Blob([plainText], { type: 'text/plain' })
-    });
-
-    navigator.clipboard.write([clipboardItem]).catch(() => {
-      // Fallback to plain text if html copying fails
-      navigator.clipboard.writeText(plainText);
-    });
-
-    this.showCopySuccess.set(true);
-
-    setTimeout(() => {
-      this.showCopySuccess.set(false);
-    }, 2000);
   };
 }

--- a/webapp/src/app/home/leaderboard/leaderboard.component.ts
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.ts
@@ -1,20 +1,26 @@
-import { Component, inject, input } from '@angular/core';
+import { Component, inject, input, signal } from '@angular/core';
 import { NgIconComponent } from '@ng-icons/core';
 import { octFileDiff, octCheck, octComment, octCommentDiscussion, octGitPullRequest, octChevronLeft, octNoEntry } from '@ng-icons/octicons';
-import { LeaderboardEntry } from 'app/core/modules/openapi';
+import { LeaderboardEntry, type PullRequestInfo } from 'app/core/modules/openapi';
 import { TableBodyDirective } from 'app/ui/table/table-body.directive';
-import { TableCaptionDirective } from 'app/ui/table/table-caption.directive';
 import { TableCellDirective } from 'app/ui/table/table-cell.directive';
-import { TableFooterDirective } from 'app/ui/table/table-footer.directive';
 import { TableHeadDirective } from 'app/ui/table/table-head.directive';
 import { TableHeaderDirective } from 'app/ui/table/table-header.directive';
 import { TableRowDirective } from 'app/ui/table/table-row.directive';
 import { TableComponent } from 'app/ui/table/table.component';
 import { HlmAvatarModule } from '@spartan-ng/ui-avatar-helm';
 import { HlmSkeletonModule } from '@spartan-ng/ui-skeleton-helm';
-import { RouterLink, RouterOutlet } from '@angular/router';
+import { HlmPopoverModule } from '@spartan-ng/ui-popover-helm';
+import { HlmButtonModule } from '@spartan-ng/ui-button-helm';
+import { BrnPopoverComponent, BrnPopoverContentDirective, BrnPopoverTriggerDirective } from '@spartan-ng/ui-popover-brain';
+import { HlmScrollAreaComponent } from '@spartan-ng/ui-scrollarea-helm';
+import { HlmIconComponent, provideIcons } from '@spartan-ng/ui-icon-helm';
+
+
+import { RouterLink } from '@angular/router';
 import { SecurityStore } from '@app/core/security/security-store.service';
 import { cn } from '@app/utils';
+import { lucideCheck, lucideClipboardCopy } from '@ng-icons/lucide';
 
 @Component({
   selector: 'app-leaderboard',
@@ -24,16 +30,21 @@ import { cn } from '@app/utils';
     HlmSkeletonModule,
     TableComponent,
     TableBodyDirective,
-    TableCaptionDirective,
     TableCellDirective,
-    TableFooterDirective,
     TableHeaderDirective,
     TableHeadDirective,
     TableRowDirective,
     NgIconComponent,
     RouterLink,
-    RouterOutlet
+    HlmPopoverModule,
+    BrnPopoverComponent,
+    BrnPopoverContentDirective,
+    BrnPopoverTriggerDirective,
+    HlmScrollAreaComponent,
+    HlmButtonModule,
+    HlmIconComponent
   ],
+  providers: [provideIcons({ lucideClipboardCopy, lucideCheck })],
   templateUrl: './leaderboard.component.html'
 })
 export class LeaderboardComponent {
@@ -49,10 +60,40 @@ export class LeaderboardComponent {
   signedIn = this.securityStore.signedIn;
   user = this.securityStore.loadedUser;
 
+  leaderboard = input<LeaderboardEntry[]>();
+  isLoading = input<boolean>();
+  showCopySuccess = signal(false);
+
   trClass = (entry: LeaderboardEntry) => {
     return cn('cursor-pointer', this.signedIn() && this.user()?.username.toLowerCase() === entry.user.login.toLowerCase() ? 'bg-accent' : '');
   };
 
-  leaderboard = input<LeaderboardEntry[]>();
-  isLoading = input<boolean>();
+  calcScrollHeight = (arr: PullRequestInfo[]) => {
+    return `min(200px, calc(${15 + 42 * arr.length}px))`;
+  };
+  displayPullRequestTitle = (title: string) => (title).replace(/`([^`]+)`/g, '<code class="textCode">$1</code>');
+
+  copyPullRequests = (entry: LeaderboardEntry) => {
+    const htmlList = `<ul>
+      ${entry.reviewedPullRequests.map((pr) => `<li><a href="${pr.htmlUrl}">#${pr.number}</a></li>`).join('\n')}
+    </ul>`;
+
+    const plainText = entry.reviewedPullRequests.map((pr) => `#${pr.number}`).join('\n');
+
+    const clipboardItem = new ClipboardItem({
+      'text/html': new Blob([htmlList], { type: 'text/html' }),
+      'text/plain': new Blob([plainText], { type: 'text/plain' })
+    });
+
+    navigator.clipboard.write([clipboardItem]).catch(() => {
+      // Fallback to plain text if html copying fails
+      navigator.clipboard.writeText(plainText);
+    });
+
+    this.showCopySuccess.set(true);
+
+    setTimeout(() => {
+      this.showCopySuccess.set(false);
+    }, 2000);
+  };
 }

--- a/webapp/src/app/home/leaderboard/leaderboard.stories.ts
+++ b/webapp/src/app/home/leaderboard/leaderboard.stories.ts
@@ -13,6 +13,7 @@ const leaderboardEntries: LeaderboardEntry[] = [
       name: 'Armin Stanitzok',
       htmlUrl: 'https://github.com/GODrums'
     },
+    reviewedPullRequests: [],
     numberOfReviewedPRs: 18,
     numberOfApprovals: 8,
     numberOfChangeRequests: 7,
@@ -30,6 +31,7 @@ const leaderboardEntries: LeaderboardEntry[] = [
       name: 'Felix T.J. Dietrich',
       htmlUrl: 'https://github.com/FelixTJDietrich'
     },
+    reviewedPullRequests: [],
     numberOfReviewedPRs: 8,
     numberOfApprovals: 1,
     numberOfChangeRequests: 5,
@@ -47,6 +49,7 @@ const leaderboardEntries: LeaderboardEntry[] = [
       name: 'Stephan Krusche',
       htmlUrl: 'https://github.com/krusche'
     },
+    reviewedPullRequests: [],
     numberOfReviewedPRs: 5,
     numberOfApprovals: 3,
     numberOfChangeRequests: 1,
@@ -64,6 +67,7 @@ const leaderboardEntries: LeaderboardEntry[] = [
       name: 'shadcn',
       htmlUrl: 'https://github.com/shadcn'
     },
+    reviewedPullRequests: [],
     numberOfReviewedPRs: 3,
     numberOfApprovals: 0,
     numberOfChangeRequests: 1,
@@ -81,6 +85,7 @@ const leaderboardEntries: LeaderboardEntry[] = [
       name: 'NoAvatarUser',
       htmlUrl: 'https://github.com/NoAvatarUser'
     },
+    reviewedPullRequests: [],
     numberOfReviewedPRs: 0,
     numberOfApprovals: 0,
     numberOfChangeRequests: 0,

--- a/webapp/src/app/home/leaderboard/reviews-popover/reviews-popover.component.html
+++ b/webapp/src/app/home/leaderboard/reviews-popover/reviews-popover.component.html
@@ -1,0 +1,38 @@
+<brn-popover sideOffset="5" closeDelay="100">
+  <button
+    variant="ghost"
+    size="sm"
+    class="flex items-center gap-1 text-github-muted-foreground"
+    brnPopoverTrigger
+    hlmBtn
+    (click)="$event.stopPropagation()"
+    [disabled]="!reviewedPRs().length"
+  >
+    <ng-icon [svg]="octGitPullRequest" size="16" />
+    {{ reviewedPRs().length }}
+  </button>
+  <div hlmPopoverContent class="space-y-2 w-60" *brnPopoverContent="let ctx">
+    <div class="flex flex-wrap justify-between items-center gap-4">
+      <div class="flex items-center gap-2">
+        <ng-icon [svg]="octGitPullRequest" size="20" />
+        <h4 class="font-medium leading-none">Reviewed PRs</h4>
+      </div>
+      <button hlmBtn variant="outline" size="icon" (click)="copyPullRequests()">
+        @if (showCopySuccess()) {
+          <lucide-angular [img]="Check" class="text-green-600 size-5" />
+        } @else {
+          <lucide-angular [img]="ClipboardCopy" class="size-5" />
+        }
+      </button>
+    </div>
+    <hlm-scroll-area [autoHeightDisabled]="false" class="-mr-2.5" [style]="'height: min(200px, calc(' + 42 * reviewedPRs().length + 'px'">
+      <div class="flex flex-col rounded-md text-muted-foreground text-sm pr-2.5">
+        @for (pullRequest of sortedReviewedPRs(); track pullRequest.id) {
+          <a hlmBtn [href]="pullRequest.htmlUrl" target="_blank" variant="ghost" class="justify-start" [title]="pullRequest.title">
+            {{ pullRequest.repository?.name ?? '' }}:{{ pullRequest.number }}
+          </a>
+        }
+      </div>
+    </hlm-scroll-area>
+  </div>
+</brn-popover>

--- a/webapp/src/app/home/leaderboard/reviews-popover/reviews-popover.component.ts
+++ b/webapp/src/app/home/leaderboard/reviews-popover/reviews-popover.component.ts
@@ -1,0 +1,84 @@
+import { Component, computed, input, signal } from '@angular/core';
+import { LucideAngularModule, ClipboardCopy, Check } from 'lucide-angular';
+import { octGitPullRequest } from '@ng-icons/octicons';
+import { HlmPopoverModule } from '@spartan-ng/ui-popover-helm';
+import { BrnPopoverComponent, BrnPopoverContentDirective, BrnPopoverTriggerDirective } from '@spartan-ng/ui-popover-brain';
+import { HlmScrollAreaComponent } from '@spartan-ng/ui-scrollarea-helm';
+import { HlmButtonModule } from '@spartan-ng/ui-button-helm';
+import { NgIconComponent } from '@ng-icons/core';
+
+interface PullRequestInfo {
+  id: number;
+  repository?: {
+    name: string;
+  };
+  number: number;
+  title: string;
+  htmlUrl: string;
+}
+
+@Component({
+  selector: 'app-reviews-popover',
+  standalone: true,
+  imports: [
+    HlmPopoverModule,
+    BrnPopoverComponent,
+    BrnPopoverContentDirective,
+    BrnPopoverTriggerDirective,
+    HlmScrollAreaComponent,
+    HlmButtonModule,
+    NgIconComponent,
+    LucideAngularModule
+  ],
+  templateUrl: './reviews-popover.component.html'
+})
+export class ReviewsPopoverComponent {
+  protected ClipboardCopy = ClipboardCopy;
+  protected Check = Check;
+  protected octGitPullRequest = octGitPullRequest;
+
+  reviewedPRs = input.required<PullRequestInfo[]>();
+  sortedReviewedPRs = computed(() =>
+    this.reviewedPRs().sort((a, b) => {
+      if (a.repository?.name === b.repository?.name) {
+        return a.number - b.number;
+      }
+      return (a.repository?.name ?? '').localeCompare(b.repository?.name ?? '');
+    })
+  );
+  showCopySuccess = signal(false);
+
+  private timeoutShowCopySuccess: ReturnType<typeof setTimeout> | undefined;
+
+  copyPullRequests() {
+    const htmlList = `<ul>
+      ${this.sortedReviewedPRs()
+        .map((pullRequest) => `<li><a href="${pullRequest.htmlUrl}">${pullRequest.repository?.name ?? ''}:${pullRequest.number}</a></li>`)
+        .join('\n')}
+    </ul>`;
+
+    // As markdown text
+    const plainText = this.sortedReviewedPRs()
+      .map((pullRequest) => `[${pullRequest.repository?.name ?? ''}:${pullRequest.number}](${pullRequest.htmlUrl})`)
+      .join('\n');
+
+    const clipboardItem = new ClipboardItem({
+      'text/html': new Blob([htmlList], { type: 'text/html' }),
+      'text/plain': new Blob([plainText], { type: 'text/plain' })
+    });
+
+    navigator.clipboard.write([clipboardItem]).catch(() => {
+      // Fallback to plain text if html copying fails
+      navigator.clipboard.writeText(plainText);
+    });
+
+    this.showCopySuccess.set(true);
+
+    if (this.timeoutShowCopySuccess) {
+      clearTimeout(this.timeoutShowCopySuccess);
+    }
+    this.timeoutShowCopySuccess = setTimeout(() => {
+      this.showCopySuccess.set(false);
+    }, 2000);
+  }
+}

--- a/webapp/src/app/home/leaderboard/reviews-popover/reviews-popover.stories.ts
+++ b/webapp/src/app/home/leaderboard/reviews-popover/reviews-popover.stories.ts
@@ -1,0 +1,149 @@
+import { type Meta, type StoryObj } from '@storybook/angular';
+import { ReviewsPopoverComponent } from './reviews-popover.component';
+
+const meta: Meta<ReviewsPopoverComponent> = {
+  component: ReviewsPopoverComponent,
+  tags: ['autodocs'],
+  args: {
+    reviewedPRs: [
+      {
+        id: 1,
+        repository: {
+          name: 'Artemis'
+        },
+        number: 9231,
+        title: 'Fix Artemis',
+        htmlUrl: 'https://www.github.com/ls1intum/Artemis/pull/9231'
+      },
+      {
+        id: 2,
+        repository: {
+          name: 'Hephaestus'
+        },
+        number: 132,
+        title: 'Fix Hephaestus',
+        htmlUrl: 'https://www.github.com/ls1intum/Hephaestus/pull/132'
+      },
+      {
+        id: 3,
+        repository: {
+          name: 'Artemis'
+        },
+        number: 9232,
+        title: 'Fix Artemis',
+        htmlUrl: 'https://www.github.com/ls1intum/Artemis/pull/9232'
+      }
+    ]
+  },
+  parameters: {
+    layout: 'centered'
+  }
+};
+
+export default meta;
+type Story = StoryObj<ReviewsPopoverComponent>;
+
+export const Default: Story = {};
+
+export const ManyPullRequests: Story = {
+  args: {
+    reviewedPRs: [
+      {
+        id: 1,
+        repository: {
+          name: 'Artemis'
+        },
+        number: 9231,
+        title: 'Fix Artemis authentication bug',
+        htmlUrl: 'https://www.github.com/ls1intum/Artemis/pull/9231'
+      },
+      {
+        id: 2,
+        repository: {
+          name: 'Hephaestus'
+        },
+        number: 132,
+        title: 'Improve Hephaestus logging',
+        htmlUrl: 'https://www.github.com/ls1intum/Hephaestus/pull/132'
+      },
+      {
+        id: 3,
+        repository: {
+          name: 'Artemis'
+        },
+        number: 9232,
+        title: 'Add Artemis new feature',
+        htmlUrl: 'https://www.github.com/ls1intum/Artemis/pull/9232'
+      },
+      {
+        id: 4,
+        repository: {
+          name: 'Zeus'
+        },
+        number: 45,
+        title: 'Refactor Zeus module',
+        htmlUrl: 'https://www.github.com/ls1intum/Zeus/pull/45'
+      },
+      {
+        id: 5,
+        repository: {
+          name: 'Athena'
+        },
+        number: 789,
+        title: 'Update Athena dependencies',
+        htmlUrl: 'https://www.github.com/ls1intum/Athena/pull/789'
+      },
+      {
+        id: 6,
+        repository: {
+          name: 'Apollo'
+        },
+        number: 256,
+        title: 'Optimize Apollo queries',
+        htmlUrl: 'https://www.github.com/ls1intum/Apollo/pull/256'
+      },
+      {
+        id: 7,
+        repository: {
+          name: 'Hermes'
+        },
+        number: 1024,
+        title: 'Fix Hermes deployment issue',
+        htmlUrl: 'https://www.github.com/ls1intum/Hermes/pull/1024'
+      },
+      {
+        id: 8,
+        repository: {
+          name: 'Poseidon'
+        },
+        number: 678,
+        title: 'Enhance Poseidon UI',
+        htmlUrl: 'https://www.github.com/ls1intum/Poseidon/pull/678'
+      },
+      {
+        id: 9,
+        repository: {
+          name: 'Hera'
+        },
+        number: 310,
+        title: 'Add Hera analytics feature',
+        htmlUrl: 'https://www.github.com/ls1intum/Hera/pull/310'
+      },
+      {
+        id: 10,
+        repository: {
+          name: 'Demeter'
+        },
+        number: 555,
+        title: 'Refine Demeter data models',
+        htmlUrl: 'https://www.github.com/ls1intum/Demeter/pull/555'
+      }
+    ]
+  }
+};
+
+export const Empty: Story = {
+  args: {
+    reviewedPRs: []
+  }
+};


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Our Confluence meeting pages require listing your reviewed PRs. To ease this process, we want to provide the functionality of pasting all reviewed PRs within a certain timeframe.

### Description
<!-- Provide a brief summary of the changes. -->
This PR adds a popover to the "total reviewed PRs" displaying a list of the reviewed PRs. Additionally, it provides a copy-button to copy the list in a HTML-based format.

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Run the `application-server` and `webapp`
- Click on the new "total reviewed PRs"-button and scroll through the list of PRs
- Click on the copy-button and test the formatting by pasting it on Confluence

### Screenshots (if applicable)
<!-- Attach screenshots here. -->
![Screenshot 2024-11-15 064727](https://github.com/user-attachments/assets/b916aaac-e75d-4363-b48b-0e45e84c0521)

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [x] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [x] Added Storybook stories for new components
- [x] Components follow design system guidelines (if applicable)

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)
