### PR TITLE
Fix: No Nats Connection Attempts if Disabled

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/NatsConfig.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/NatsConfig.java
@@ -13,6 +13,9 @@ import io.nats.client.Options;
 @Configuration
 public class NatsConfig {
 
+    @Value("${nats.enabled}")
+    private boolean isNatsEnabled;
+    
     @Value("${nats.server}")
     private String natsServer;
 
@@ -21,7 +24,7 @@ public class NatsConfig {
 
     @Bean
     public Connection natsConnection() throws Exception {
-        if (environment.matchesProfiles("specs")) {
+        if (environment.matchesProfiles("specs") || !isNatsEnabled) {
             return null;
         }
 


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
If the NATS-server is unavailable, running the application-server will still fail due to unrelated connection attempts even if it's disabled. We want to make sure setting "nats.enabled: false" means there is no connection to the NATS-server made at all.

### Description
<!-- Provide a brief summary of the changes. -->
During Application Startup, there are connection attempts made regardless of the `nats.enabled`-setting. This PR adds an additional check to avoid initializing the `@Bean` for the NATS-server when `nats.enabled` is set to `false`.

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Enter an invalid connection-string in `application-local.yml` -> `nats.server` and set `nats.enabled` to `false`.
- Start the `application-server` and check if it starts without errors

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)
