### PR TITLE
Fix: Show new Leaderboard instantly

### DIFF
--- a/webapp/src/app/home/home.component.ts
+++ b/webapp/src/app/home/home.component.ts
@@ -49,7 +49,7 @@ export class HomeComponent {
     if (afterParam) return afterParam;
 
     let defaultDate = dayjs().isoWeekday(this.leaderboardSchedule().day).startOf('hour').hour(this.leaderboardSchedule().hour).minute(this.leaderboardSchedule().minute);
-    if (defaultDate.isAfter(dayjs()) || defaultDate.isSame(dayjs(), 'day')) {
+    if (defaultDate.isAfter(dayjs())) {
       defaultDate = defaultDate.subtract(1, 'week');
     }
     return defaultDate.format();


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes a bug where the new leaderboard did not get shown per default on it's first day.

### Description
<!-- Provide a brief summary of the changes. -->
When using no leaderboard parameters, the defaults still displayed last week's leaderboard instead of the new one.

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Start `application-server` and `webapp`
- Check if the default page displays the current leaderboard (only relevant on Tuesdays)

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [ ] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
