### PR TITLE
Show Parts of the Legend per default

### DIFF
--- a/webapp/src/app/home/leaderboard/legend/legend.component.html
+++ b/webapp/src/app/home/leaderboard/legend/legend.component.html
@@ -1,20 +1,7 @@
 <div hlmCard>
-  <div class="flex items-center group hover:cursor-pointer" (click)="toggleOpen()">
-    <div hlmCardHeader class="flex-1">
-      <h3 hlmCardTitle class="group-hover:underline">Leaderboard Legend</h3>
-      <p hlmCardDescription class="group-hover:underline">Explanation of the most important elements</p>
-    </div>
-    <div class="flex items-center gap-2 px-6">
-      @if (open()) {
-        <hlm-icon name="lucideChevronsUp" />
-      } @else {
-        <hlm-icon name="lucideChevronsDown" />
-      }
-    </div>
-  </div>
-  <div hlmCardContent [class]="contentClass()">
+  <div hlmCardContent class="flex flex-col gap-y-4">
     <div class="flex flex-col gap-2 sm:min-w-[250px]">
-      <h4 class="font-medium mb-2">Icons</h4>
+      <h4 class="mb-2 text-lg font-semibold leading-none tracking-tight">Icons</h4>
       <div class="flex items-center gap-2 text-github-muted-foreground">
         <ng-icon [svg]="octGitPullRequest" size="16" />
         Reviewed pull requests
@@ -36,7 +23,7 @@
         Code comments
       </div>
     </div>
-    <div class="max-w-[500px]">
+    <div [class]="contentClass()">
       <h4 class="font-medium mb-2">Scoring System</h4>
       <p class="text-sm text-github-muted-foreground">
         The score approximates your contribution activity by evaluating your review interactions and the complexity of the pull requests you've reviewed.
@@ -54,6 +41,17 @@
           [source]
         </a>
       </p>
+    </div>
+  </div>
+  <div class="flex items-center justify-center group hover:cursor-pointer hover:bg-muted/50" (click)="toggleOpen()">
+    <div class="flex items-center gap-2 px-6 py-1.5">
+      @if (open()) {
+        <hlm-icon name="lucideChevronUp" />
+        <p class="text-github-muted-foreground text-sm font-medium">Show less</p>
+      } @else {
+        <hlm-icon name="lucideChevronDown" />
+        <p class="text-github-muted-foreground text-sm font-medium">Show more</p>
+      }
     </div>
   </div>
 </div>

--- a/webapp/src/app/home/leaderboard/legend/legends.component.ts
+++ b/webapp/src/app/home/leaderboard/legend/legends.component.ts
@@ -4,7 +4,7 @@ import { octFileDiff, octCheck, octComment, octCommentDiscussion, octGitPullRequ
 import { HlmIconComponent } from '@spartan-ng/ui-icon-helm';
 import { HlmCardModule } from '@spartan-ng/ui-card-helm';
 import { provideIcons } from '@spartan-ng/ui-icon-helm';
-import { lucideChevronsDown, lucideChevronsUp } from '@ng-icons/lucide';
+import { lucideChevronDown, lucideChevronUp } from '@ng-icons/lucide';
 import { cn } from '@app/utils';
 import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
 
@@ -12,7 +12,7 @@ import { HlmButtonDirective } from '@spartan-ng/ui-button-helm';
   selector: 'app-leaderboard-legend',
   standalone: true,
   imports: [HlmCardModule, NgIconComponent, HlmIconComponent, HlmButtonDirective],
-  providers: [provideIcons({ lucideChevronsDown, lucideChevronsUp })],
+  providers: [provideIcons({ lucideChevronDown, lucideChevronUp })],
   templateUrl: './legend.component.html'
 })
 export class LeaderboardLegendComponent {
@@ -25,7 +25,7 @@ export class LeaderboardLegendComponent {
   isLoading = input<boolean>();
   open = signal(false);
 
-  contentClass = computed(() => cn('flex flex-wrap gap-y-4 gap-x-8 pt-2', { hidden: !this.open() }));
+  contentClass = computed(() => cn('max-w-[500px]', { hidden: !this.open() }));
 
   toggleOpen() {
     this.open.set(!this.open());


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes #173.

### Description
<!-- Provide a brief summary of the changes. -->
Change the leaderboard legend according to feedback:
- "Show more"-text in addition to the chevron-icon
- Icon explanations are visible per default
- Score explanation can be expanded (closed per default to avoid cluttering)

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->

### Screenshots (if applicable)
<!-- Attach screenshots here. -->
When loading the page:
![Screenshot 2024-11-19 234553](https://github.com/user-attachments/assets/4ef26c28-071a-43a1-99b5-ca945ea0fa4b)
When expanded by clicking on "show more":
![Screenshot 2024-11-19 234603](https://github.com/user-attachments/assets/fe8220a9-3726-4398-8e14-03b48fdfef19)

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [x] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
