### PR TITLE
Fix: Parse Custom Date Range Query Params

### DIFF
--- a/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.html
+++ b/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.html
@@ -8,7 +8,7 @@
       <span *brnTooltipContent>Week starts {{ leaderboardSchedule().formatted }}</span>
     </hlm-tooltip>
   </div>
-  <hlm-select [placeholder]="placeholder()" [(ngModel)]="value" name="value">
+  <hlm-select [placeholder]="placeholder()" [(ngModel)]="selectValue" name="value">
     <hlm-select-trigger class="w-56">
       <hlm-select-value />
     </hlm-select-trigger>


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes #176.

### Description
<!-- Provide a brief summary of the changes. -->
This PR adapts the supporting logic of the timeframe-selector to parse custom date range from the query params correctly.
If called with custom query params, it now:
- Displays "Custom Range" in the select-placeholder, such that every option is still selectable
- Parses the query parameters directly for the desciption text

This PR is the foundation for supporting a custom range input. Subject to a follow-up PR.

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Run `application-server` and `webapp`
- Open the page with a custom range through query params, e.g. http://localhost:4200/?after=2024-11-13T09:00:00%2B01:00&before=2024-11-20T02:41:47%2B01:00 (11/13 - 11/20)

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
