### PR TITLE
Fix: Use correct After-queryParam when none specified

### DIFF
--- a/webapp/src/app/home/home.component.ts
+++ b/webapp/src/app/home/home.component.ts
@@ -44,24 +44,14 @@ export class HomeComponent {
     };
   });
 
-  protected afterParam = computed(
-    () =>
-      this.queryParams().get('after') ??
-      (() => {
-        let defaultDate = dayjs().isoWeekday(this.leaderboardSchedule().day).startOf('hour').hour(this.leaderboardSchedule().hour).minute(this.leaderboardSchedule().minute);
-        if (defaultDate.isAfter(dayjs())) {
-          defaultDate = defaultDate.subtract(1, 'week');
-        }
-        return defaultDate.format();
-      })()
-  );
+  protected afterParam = computed(() => this.queryParams().get('after'));
   protected beforeParam = computed(() => this.queryParams().get('before') ?? dayjs().format());
   protected teamParam = computed(() => this.queryParams().get('team') ?? 'all');
 
   query = injectQuery(() => ({
-    enabled: !!this.metaQuery.data(),
+    enabled: !!this.metaQuery.data() && !!this.afterParam() && !!this.beforeParam() && !!this.teamParam(),
     queryKey: ['leaderboard', { after: this.afterParam(), before: this.beforeParam(), team: this.teamParam() }],
-    queryFn: async () => lastValueFrom(this.leaderboardService.getLeaderboard(this.afterParam(), this.beforeParam(), this.teamParam() !== 'all' ? this.teamParam() : undefined))
+    queryFn: async () => lastValueFrom(this.leaderboardService.getLeaderboard(this.afterParam()!, this.beforeParam(), this.teamParam() !== 'all' ? this.teamParam() : undefined))
   }));
 
   protected teams = computed(() => this.metaQuery.data()?.teams?.map((team) => team.name) ?? []);

--- a/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
@@ -66,7 +66,15 @@ export class LeaderboardFilterTimeframeComponent {
     };
   });
 
-  after = computed(() => this.queryParams().get('after') ?? (this.leaderboardSchedule() ? this.leaderboardSchedule().full.format() : ''));
+  getDefaultDate() {
+    let defaultDate = dayjs().isoWeekday(this.leaderboardSchedule().day).startOf('hour').hour(this.leaderboardSchedule().hour).minute(this.leaderboardSchedule().minute);
+    if (defaultDate.isAfter(dayjs())) {
+      defaultDate = defaultDate.subtract(1, 'week');
+    }
+    return defaultDate;
+  }
+
+  after = computed(() => this.queryParams().get('after') ?? (this.leaderboardSchedule() ? this.getDefaultDate().format() : ''));
   before = computed(() => this.queryParams().get('before') ?? dayjs().format());
   selectValue = signal<string>(`${this.after()}.${this.before()}`);
 

--- a/webapp/src/app/workspace/teams/table/teams-table.component.ts
+++ b/webapp/src/app/workspace/teams/table/teams-table.component.ts
@@ -80,7 +80,7 @@ export class WorkspaceTeamsTableComponent {
   // Controls for mutations
   _newLabelName = new FormControl('');
   _newTeamName = new FormControl('');
-  _newTeamColor = new FormControl('');
+  _newTeamColor = new FormControl('#000000');
 
   displayLabelAlert = signal(false);
 


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes an issue where the after param is after the before param due to the week starting on Tuesdays. I.e. https://hephaestus.ase.cit.tum.de redirects to https://hephaestus.ase.cit.tum.de/?after=2024-11-26T09:00:00%2B01:00&before=2024-11-25T00:22:47%2B01:00 right now, making the default leaderboard data incorrect.

### Description
<!-- Provide a brief summary of the changes. -->
This fix moves the default date configuration to the leaderboard filter component, making sure dates are only changed in one place of the application.
Also fixes a small bug regarding the recently merged PR #124, where the default value of the Team-Color-Input had an invalid default value:
![Screenshot 2024-11-25 000613](https://github.com/user-attachments/assets/53f27f38-31dc-4f25-91ca-f403fbb53933)


### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Run `application-server` and `webapp`
- Go to `http://localhost:4200/` and check if the default leaderboard uses the correct timeframe.

### Screenshots (if applicable)
<!-- Attach screenshots here. -->

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)
