### PR TITLE
Fix: Timeframe Parameter Consistency on Navigation

### DIFF
--- a/webapp/src/app/home/home.component.ts
+++ b/webapp/src/app/home/home.component.ts
@@ -45,13 +45,13 @@ export class HomeComponent {
   });
 
   protected afterParam = computed(() => this.queryParams().get('after'));
-  protected beforeParam = computed(() => this.queryParams().get('before') ?? dayjs().format());
+  protected beforeParam = computed(() => this.queryParams().get('before'));
   protected teamParam = computed(() => this.queryParams().get('team') ?? 'all');
 
   query = injectQuery(() => ({
     enabled: !!this.metaQuery.data() && !!this.afterParam() && !!this.beforeParam() && !!this.teamParam(),
     queryKey: ['leaderboard', { after: this.afterParam(), before: this.beforeParam(), team: this.teamParam() }],
-    queryFn: async () => lastValueFrom(this.leaderboardService.getLeaderboard(this.afterParam()!, this.beforeParam(), this.teamParam() !== 'all' ? this.teamParam() : undefined))
+    queryFn: async () => lastValueFrom(this.leaderboardService.getLeaderboard(this.afterParam()!, this.beforeParam()!, this.teamParam() !== 'all' ? this.teamParam() : undefined))
   }));
 
   protected teams = computed(() => this.metaQuery.data()?.teams?.map((team) => team.name) ?? []);

--- a/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/timeframe/timeframe.component.ts
@@ -43,6 +43,7 @@ function formatLabel(weekIndex: number) {
 })
 export class LeaderboardFilterTimeframeComponent {
   private readonly route = inject(ActivatedRoute);
+  private router = inject(Router);
   private queryParams = toSignal(this.route.queryParamMap, { requireSync: true });
 
   metaService = inject(MetaService);
@@ -56,13 +57,12 @@ export class LeaderboardFilterTimeframeComponent {
     const timeParts = this.dateQuery.data()?.scheduledTime.split(':') ?? ['09', '00'];
     const hour = Number.parseInt(timeParts[0]);
     const minute = Number.parseInt(timeParts[1] ?? '0');
-    const full = dayjs().isoWeekday(day).startOf('hour').hour(hour).minute(minute);
+    const formatted = dayjs().isoWeekday(day).startOf('hour').hour(hour).minute(minute).format('dddd, h:mm A');
     return {
       day,
       hour,
       minute,
-      full,
-      formatted: full.format('dddd, h:mm A')
+      formatted
     };
   });
 
@@ -74,14 +74,20 @@ export class LeaderboardFilterTimeframeComponent {
     return defaultDate;
   }
 
-  after = computed(() => this.queryParams().get('after') ?? (this.leaderboardSchedule() ? this.getDefaultDate().format() : ''));
-  before = computed(() => this.queryParams().get('before') ?? dayjs().format());
+  after = computed(() =>
+    this.queryParams().get('after') && this.queryParams().get('after')!.length > 0
+      ? this.queryParams().get('after')
+      : this.leaderboardSchedule()
+        ? this.getDefaultDate().format()
+        : ''
+  );
+  before = computed(() => this.queryParams().get('before') ?? (this.leaderboardSchedule() ? this.getDefaultDate().add(1, 'week').format() : dayjs().format()));
   selectValue = signal<string>(`${this.after()}.${this.before()}`);
 
   formattedDates = computed(() => {
     const [startDate, endDate] = [dayjs(this.after()), dayjs(this.before())];
     const sameMonth = startDate.month() === endDate.month();
-    const endDateFormatted = endDate.isSame(dayjs(), 'hour') ? 'Now' : sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A');
+    const endDateFormatted = endDate.isAfter(dayjs()) ? 'Now' : sameMonth ? endDate.format('D, h:mm A') : endDate.format('MMM D, h:mm A');
     if (sameMonth) {
       return `${startDate.format('MMM D, h:mm A')} - ${endDateFormatted}`;
     } else {
@@ -97,15 +103,12 @@ export class LeaderboardFilterTimeframeComponent {
   });
 
   options = computed(() => {
-    const now = dayjs();
-    let currentDate = dayjs().isoWeekday(this.leaderboardSchedule().day).startOf('hour').hour(this.leaderboardSchedule().hour).minute(this.leaderboardSchedule().minute);
-    if (currentDate.isAfter(now)) {
-      currentDate = currentDate.subtract(1, 'week');
-    }
+    let currentDate = this.getDefaultDate();
+    let endDate = currentDate.add(1, 'week');
     const options: SelectOption[] = [
       {
-        id: now.unix(),
-        value: `${currentDate.format()}.${now.format()}`,
+        id: endDate.unix(),
+        value: `${currentDate.format()}.${endDate.format()}`,
         label: formatLabel(0)
       }
     ];
@@ -123,19 +126,33 @@ export class LeaderboardFilterTimeframeComponent {
     return options;
   });
 
-  constructor(private router: Router) {
+  constructor() {
     // persist date changes in url
     effect(() => {
-      if (this.selectValue().length === 1) return;
+      this.persistDateChange();
+    });
 
-      const queryParams = this.router.parseUrl(this.router.url).queryParams;
-      const dates = this.selectValue().split('.');
-      queryParams['after'] = dates[0];
-      queryParams['before'] = dates[1];
+    // make sure navigation to the page sets the default date
+    this.route.queryParams.subscribe((params) => {
+      if (!params['after'] && !params['before']) {
+        this.selectValue.set(this.options()[0].value);
+        this.persistDateChange();
+      }
+    });
+  }
 
-      this.router.navigate([], {
-        queryParams
-      });
+  protected persistDateChange() {
+    if (this.selectValue().length === 1) return;
+
+    const queryParams = this.router.parseUrl(this.router.url).queryParams;
+    const dates = this.selectValue().split('.');
+    if (dates.length !== 2) return;
+
+    queryParams['after'] = dates[0];
+    queryParams['before'] = dates[1];
+
+    this.router.navigate([], {
+      queryParams
     });
   }
 }


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes a bug where the timeframe parameters assumed invalid states on browser tab change or same page-navigation, i.e. when clicking on the logo in the header.

### Description
<!-- Provide a brief summary of the changes. -->
This PR is a follow-up to #188 and fixes:
- after/before-param consistency in the URL:
  - when switching tabs
  - when navigating on the same page (e.g. removing query params without changing the page -> revelant for Hephaestus-logo in header) go back to default timeframe (i.e. current week)
- remove state logic from home component and move to timeframe component
- incorrect time ranges in current week ("Custom Range") - now uses the actual end date of the week instead of current minute

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Run `application-server` and `webapp`
- Navigate through different leaderboards
- Use the Hephaestus-Logo and check if you get navigated back to the default leaderboard
- Go to a different browser tab and back (state should stay the same)
- Leave the leaderboard open for a few minutes and check if the state stays valid after switching timeframes back and worth

### Screenshots (if applicable)
<!-- Attach screenshots here. -->

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
