### PR TITLE
Fix: Refresh Token in Custom Interceptor

### DIFF
--- a/webapp/src/app/core/security/security-interceptor.ts
+++ b/webapp/src/app/core/security/security-interceptor.ts
@@ -1,19 +1,26 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { SecurityStore } from './security-store.service';
+import { from, switchMap } from 'rxjs';
 
 export const securityInterceptor: HttpInterceptorFn = (req, next) => {
   const keycloakService = inject(SecurityStore);
 
-  const bearer = keycloakService.user()?.bearer;
+  // update access token to prevent 401s
+  return from(keycloakService.updateToken()).pipe(
+    switchMap(() => {
+      // add bearer token to request
+      const bearer = keycloakService.user()?.bearer;
 
-  if (!bearer) {
-    return next(req);
-  }
+      if (!bearer) {
+        return next(req);
+      }
 
-  return next(
-    req.clone({
-      headers: req.headers.set('Authorization', `Bearer ${bearer}`)
+      return next(
+        req.clone({
+          headers: req.headers.set('Authorization', `Bearer ${bearer}`)
+        })
+      );
     })
   );
 };

--- a/webapp/src/app/core/security/security-store.service.ts
+++ b/webapp/src/app/core/security/security-store.service.ts
@@ -53,4 +53,14 @@ export class SecurityStore {
   async signOut() {
     await this.keycloakService.logout();
   }
+
+  async updateToken() {
+    await this.keycloakService.updateToken();
+    // update bearer in user with new token
+    const user = this.user();
+    if (user && this.keycloakService.profile) {
+      user.bearer = this.keycloakService.profile.token;
+      this.user.set(user);
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Follow-up on #190. Tokens previously did not get refreshed correctly when minimizing or losing the focus of the tab.

### Description
<!-- Provide a brief summary of the changes. -->
This PR changes how access tokens are refreshed: the HTTP Interceptor now checks if the access token has to get refreshed before a request to the Spring Boot-server is made.

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- Run `application-server` and `webapp`
- Login on the website
- Wait for the access token to expire (exact time can be checked via the dev tools, should be 300s)
- Make a new request, e.g. a different leaderboard, and check for failure

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)
