### PR TITLE
Fix: Sort Teams in Metadata alphabetically

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/meta/MetaService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/meta/MetaService.java
@@ -1,15 +1,15 @@
 package de.tum.in.www1.hephaestus.meta;
 
+import de.tum.in.www1.hephaestus.gitprovider.team.TeamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import de.tum.in.www1.hephaestus.gitprovider.team.TeamService;
-
 @Service
 public class MetaService {
+
     private static final Logger logger = LoggerFactory.getLogger(MetaService.class);
 
     @Autowired
@@ -24,6 +24,10 @@ public class MetaService {
     public MetaDataDTO getMetaData() {
         logger.info("Getting meta data...");
         var teams = teamService.getAllTeams();
-        return new MetaDataDTO(teams, scheduledDay, scheduledTime);
+        return new MetaDataDTO(
+            teams.stream().sorted((team1, team2) -> team1.name().compareTo(team2.name())).toList(),
+            scheduledDay,
+            scheduledTime
+        );
     }
 }

--- a/webapp/src/app/home/leaderboard/filter/team/team.component.ts
+++ b/webapp/src/app/home/leaderboard/filter/team/team.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, input, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { Router } from '@angular/router';
 import { BrnSelectModule } from '@spartan-ng/ui-select-brain';
 import { HlmSelectModule } from '@spartan-ng/ui-select-helm';
 import { HlmLabelModule } from '@spartan-ng/ui-label-helm';
@@ -14,7 +14,7 @@ interface SelectOption {
 @Component({
   selector: 'app-leaderboard-filter-team',
   standalone: true,
-  imports: [RouterLink, BrnSelectModule, HlmSelectModule, HlmLabelModule, FormsModule],
+  imports: [BrnSelectModule, HlmSelectModule, HlmLabelModule, FormsModule],
   templateUrl: './team.component.html'
 })
 export class LeaderboardFilterTeamComponent {


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
The current list of teams in the "Select team"-filter can be super confusing due to a lack of ordering.
![image](https://github.com/user-attachments/assets/de3225c8-8ae0-4e63-8a97-b4e8ace3a4f7)


### Description
<!-- Provide a brief summary of the changes. -->
This PR sorts the list of teams in the metadata (GET `/meta`) alphabetically. The "all"-option will nevertheless always stay the first one and is selected as default.

### Screenshots (if applicable)
<!-- Attach screenshots here. -->
![image](https://github.com/user-attachments/assets/80f17fc6-304b-4fed-b268-f513ccb1da31)

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [x] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)
