### PR TITLE
`Refactor`: Modularization of Task Scheduling

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardTaskScheduler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardTaskScheduler.java
@@ -1,0 +1,77 @@
+package de.tum.in.www1.hephaestus.leaderboard;
+
+import de.tum.in.www1.hephaestus.leaderboard.tasks.SlackWeeklyLeaderboardTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Service;
+
+@Order(value = Ordered.LOWEST_PRECEDENCE)
+@EnableScheduling
+@Service
+public class LeaderboardTaskScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(LeaderboardTaskScheduler.class);
+
+    @Value("${hephaestus.leaderboard.notification.enabled}")
+    private boolean runScheduledMessage;
+
+    @Value("${hephaestus.leaderboard.schedule.day}")
+    private String scheduledDay;
+
+    @Value("${hephaestus.leaderboard.schedule.time}")
+    private String scheduledTime;
+
+    @Autowired
+    private ThreadPoolTaskScheduler taskScheduler;
+
+    @Autowired
+    private SlackWeeklyLeaderboardTask slackWeeklyLeaderboardTask;
+
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void activateTaskScheduler() {
+
+        var timeParts = scheduledTime.split(":");
+
+        // CRON for the end of every leaderboard cycle
+        String cron = String.format(
+            "0 %s %s ? * %s",
+            timeParts.length > 1 ? timeParts[1] : 0,
+            timeParts[0],
+            scheduledDay
+        );
+
+        if (!CronExpression.isValidExpression(cron)) {
+            logger.error("Invalid cron expression: " + cron);
+            return;
+        }
+
+        scheduleSlackMessage(cron);
+        
+    }
+
+    /**
+     * Schedule a Slack message to be sent at the end of every leaderboard cycle.
+     */
+    private void scheduleSlackMessage(String cron) {
+        if (!runScheduledMessage) return;
+
+        if (!slackWeeklyLeaderboardTask.testSlackConnection()) {
+            logger.error("Failed to schedule Slack message");
+            return;
+        }
+
+        logger.info("Scheduling Slack message to run with {}", cron);
+        taskScheduler.schedule(slackWeeklyLeaderboardTask, new CronTrigger(cron));
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardTaskScheduler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardTaskScheduler.java
@@ -15,6 +15,10 @@ import org.springframework.scheduling.support.CronExpression;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Service;
 
+/**
+ * Schedules tasks to run at the end of every leaderboard cycle.
+ * @see SlackWeeklyLeaderboardTask
+ */
 @Order(value = Ordered.LOWEST_PRECEDENCE)
 @EnableScheduling
 @Service

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/SlackMessageService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/SlackMessageService.java
@@ -15,6 +15,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+/**
+ * Light wrapper around the Slack App to send messages to the Slack workspace.
+ * @implNote Use the exposed method to test the Slack connection beforehand.
+ */
 @Service
 public class SlackMessageService {
 
@@ -60,7 +64,8 @@ public class SlackMessageService {
     }
 
     /**
-     * Test if the Slack app is correctly initialized.
+     * Tests if the Slack app is correctly initialized and has access to the workspace.
+     * Does not guarantee that the app has the necessary permissions to send messages.
      */
     public boolean initTest() {
         logger.info("Testing Slack app initialization...");

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/SlackMessageService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/SlackMessageService.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.hephaestus.leaderboard;
 
-import static com.slack.api.model.block.Blocks.*;
-import static com.slack.api.model.block.composition.BlockCompositions.*;
-
 import com.slack.api.bolt.App;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
@@ -11,59 +8,33 @@ import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.model.User;
 import com.slack.api.model.block.LayoutBlock;
 import java.io.IOException;
-import java.time.DayOfWeek;
-import java.time.OffsetDateTime;
-import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.IntStream;
-import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.support.CronExpression;
-import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Service;
 
-@Order(value = Ordered.LOWEST_PRECEDENCE)
-@EnableScheduling
 @Service
 public class SlackMessageService {
 
     private static final Logger logger = LoggerFactory.getLogger(SlackMessageService.class);
 
-    @Value("${hephaestus.leaderboard.notification.channel-id}")
-    private String channelId;
-
-    @Value("${hephaestus.leaderboard.notification.enabled}")
-    private boolean runScheduledMessage;
-
-    @Value("${hephaestus.host-url:localhost:8080}")
-    private String hephaestusUrl;
-
-    @Value("${hephaestus.leaderboard.schedule.day}")
-    private String scheduledDay;
-
-    @Value("${hephaestus.leaderboard.schedule.time}")
-    private String scheduledTime;
-
     @Autowired
     private App slackApp;
 
-    @Autowired
-    private LeaderboardService leaderboardService;
-
-    @Autowired
-    private ThreadPoolTaskScheduler taskScheduler;
+    /**
+     * Gets all members of the Slack workspace.
+     * @return
+     */
+    public List<User> getAllMembers() {
+        try {
+            return slackApp.client().usersList(r -> r).getMembers();
+        } catch (IOException | SlackApiException e) {
+            logger.error("Failed to get all members from Slack: " + e.getMessage());
+            return new ArrayList<>();
+        }
+    }
 
     /**
      * Sends a message to the specified Slack channel.
@@ -88,39 +59,10 @@ public class SlackMessageService {
         }
     }
 
-    @EventListener(ApplicationReadyEvent.class)
-    public void activateTaskScheduler() {
-        if (!runScheduledMessage) {
-            return;
-        }
-
-        var timeParts = scheduledTime.split(":");
-
-        String cron = String.format(
-            "0 %s %s ? * %s",
-            timeParts.length > 1 ? timeParts[1] : 0,
-            timeParts[0],
-            scheduledDay
-        );
-
-        if (!CronExpression.isValidExpression(cron)) {
-            logger.error("Invalid cron expression: " + cron);
-            return;
-        }
-
-        logger.info("Scheduling Slack message to run with {}", cron);
-        taskScheduler.schedule(new SlackWeeklyLeaderboardTask(), new CronTrigger(cron));
-    }
-
     /**
-     * Test the Slack app initialization on application startup.
+     * Test if the Slack app is correctly initialized.
      */
-    @EventListener(ApplicationReadyEvent.class)
-    public void run() {
-        if (!runScheduledMessage) {
-            logger.info("Slack scheduled messages are disabled, skipping Slack app init test.");
-            return;
-        }
+    public boolean initTest() {
         logger.info("Testing Slack app initialization...");
         AuthTestResponse response;
         try {
@@ -132,132 +74,10 @@ public class SlackMessageService {
         }
         if (response.isOk()) {
             logger.info("Slack app is successfully initialized.");
+            return true;
         } else {
             logger.error("Failed to initialize Slack app: " + response.getError());
-        }
-    }
-
-    /**
-     * Task to send a weekly leaderboard message to the Slack channel.
-     * @see SlackMessageService#activateTaskScheduler()
-     */
-    private class SlackWeeklyLeaderboardTask implements Runnable {
-
-        /**
-         * Gets the Slack handles of the top 3 reviewers in the given time frame.
-         * @return
-         */
-        private List<User> getTop3SlackReviewers(OffsetDateTime after, OffsetDateTime before) {
-            var leaderboard = leaderboardService.createLeaderboard(after, before, Optional.empty());
-            var top3 = leaderboard.subList(0, Math.min(3, leaderboard.size()));
-            logger.debug("Top 3 Users of the last week: " + top3.stream().map(e -> e.user().name()).toList());
-
-            List<User> allSlackUsers;
-            try {
-                allSlackUsers = slackApp.client().usersList(r -> r).getMembers();
-            } catch (SlackApiException | IOException e) {
-                logger.error("Failed to get Slack users: " + e.getMessage());
-                return new ArrayList<>();
-            }
-
-            return top3.stream().map(mapToSlackUser(allSlackUsers)).filter(user -> user != null).toList();
-        }
-
-        private Function<LeaderboardEntryDTO, User> mapToSlackUser(List<User> allSlackUsers) {
-            return entry -> {
-                var exactUser = allSlackUsers
-                    .stream()
-                    .filter(
-                        user ->
-                            user.getName().equals(entry.user().name()) ||
-                            (user.getProfile().getEmail() != null &&
-                                user.getProfile().getEmail().equals(entry.user().email()))
-                    )
-                    .findFirst();
-                if (exactUser.isPresent()) {
-                    return exactUser.get();
-                }
-
-                // find through String edit distance
-                return allSlackUsers
-                    .stream()
-                    .min((a, b) ->
-                        Integer.compare(
-                            LevenshteinDistance.getDefaultInstance().apply(entry.user().name(), a.getName()),
-                            LevenshteinDistance.getDefaultInstance().apply(entry.user().name(), b.getName())
-                        )
-                    )
-                    .orElse(null);
-            };
-        }
-
-        private String formatDateForURL(OffsetDateTime date) {
-            return date.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME).replace("+", "%2B");
-        }
-
-        @Override
-        public void run() {
-            // get date in unix format
-            long currentDate = OffsetDateTime.now().toEpochSecond();
-            // Calculate the the last leaderboard schedule
-            String[] timeParts = scheduledTime.split(":");
-            OffsetDateTime before = OffsetDateTime.now()
-                .with(TemporalAdjusters.previousOrSame(DayOfWeek.of(Integer.parseInt(scheduledDay))))
-                .withHour(Integer.parseInt(timeParts[0]))
-                .withMinute(timeParts.length > 0 ? Integer.parseInt(timeParts[1]) : 0)
-                .withSecond(0)
-                .withNano(0);
-            OffsetDateTime after = before.minusWeeks(1);
-
-            var top3reviewers = getTop3SlackReviewers(after, before);
-
-            logger.info("Sending scheduled message to Slack channel...");
-
-            List<LayoutBlock> blocks = asBlocks(
-                header(header ->
-                    header.text(plainText(pt -> pt.text(":newspaper: Reviews of the last week :newspaper:")))
-                ),
-                context(context ->
-                    context.elements(
-                        List.of(
-                            markdownText(
-                                "<!date^" + currentDate + "^{date} at {time}| Today at 9:00AM CEST> | " + hephaestusUrl
-                            )
-                        )
-                    )
-                ),
-                divider(),
-                section(section ->
-                    section.text(
-                        markdownText(
-                            "Another *review leaderboard* has concluded. You can check out your placement <" +
-                            hephaestusUrl +
-                            "?after=" +
-                            formatDateForURL(after) +
-                            "&before=" +
-                            formatDateForURL(before) +
-                            "|here>."
-                        )
-                    )
-                ),
-                section(section -> section.text(markdownText("Special thanks to our top 3 reviewers of last week:"))),
-                section(section ->
-                    section.text(
-                        markdownText(
-                            IntStream.range(0, top3reviewers.size())
-                                .mapToObj(i -> ((i + 1) + ". <@" + top3reviewers.get(i).getId() + ">"))
-                                .reduce((a, b) -> a + "\n" + b)
-                                .orElse("")
-                        )
-                    )
-                ),
-                section(section -> section.text(markdownText("Happy coding and reviewing! :rocket:")))
-            );
-            try {
-                sendMessage(channelId, blocks, "Reviews of the last week");
-            } catch (IOException | SlackApiException e) {
-                logger.error("Failed to send scheduled message to Slack channel: " + e.getMessage());
-            }
+            return false;
         }
     }
 }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/SlackWeeklyLeaderboardTask.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/SlackWeeklyLeaderboardTask.java
@@ -1,0 +1,172 @@
+package de.tum.in.www1.hephaestus.leaderboard.tasks;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.*;
+
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.User;
+import com.slack.api.model.block.LayoutBlock;
+import de.tum.in.www1.hephaestus.leaderboard.LeaderboardEntryDTO;
+import de.tum.in.www1.hephaestus.leaderboard.LeaderboardService;
+import de.tum.in.www1.hephaestus.leaderboard.SlackMessageService;
+import java.io.IOException;
+import java.time.DayOfWeek;
+import java.time.OffsetDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Task to send a weekly leaderboard message to the Slack channel.
+ * @see SlackMessageService#activateTaskScheduler()
+ */
+@Component
+public class SlackWeeklyLeaderboardTask implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(SlackWeeklyLeaderboardTask.class);
+
+    @Value("${hephaestus.leaderboard.notification.channel-id}")
+    private String channelId;
+
+    @Value("${hephaestus.leaderboard.notification.enabled}")
+    private boolean runScheduledMessage;
+
+    @Value("${hephaestus.host-url:localhost:8080}")
+    private String hephaestusUrl;
+
+    @Value("${hephaestus.leaderboard.schedule.day}")
+    private String scheduledDay;
+
+    @Value("${hephaestus.leaderboard.schedule.time}")
+    private String scheduledTime;
+
+    @Autowired
+    private SlackMessageService slackMessageService;
+
+    @Autowired
+    private LeaderboardService leaderboardService;
+
+    /**
+     * Test the Slack connection.
+     * @return
+     */
+    public boolean testSlackConnection() {
+        return runScheduledMessage && slackMessageService.initTest();
+    }
+
+    /**
+     * Gets the Slack handles of the top 3 reviewers in the given time frame.
+     * @return
+     */
+    private List<User> getTop3SlackReviewers(OffsetDateTime after, OffsetDateTime before) {
+        var leaderboard = leaderboardService.createLeaderboard(after, before, Optional.empty());
+        var top3 = leaderboard.subList(0, Math.min(3, leaderboard.size()));
+        logger.debug("Top 3 Users of the last week: " + top3.stream().map(e -> e.user().name()).toList());
+
+        List<User> allSlackUsers = slackMessageService.getAllMembers();
+
+        return top3.stream().map(mapToSlackUser(allSlackUsers)).filter(user -> user != null).toList();
+    }
+
+    private Function<LeaderboardEntryDTO, User> mapToSlackUser(List<User> allSlackUsers) {
+        return entry -> {
+            var exactUser = allSlackUsers
+                .stream()
+                .filter(
+                    user ->
+                        user.getName().equals(entry.user().name()) ||
+                        (user.getProfile().getEmail() != null &&
+                            user.getProfile().getEmail().equals(entry.user().email()))
+                )
+                .findFirst();
+            if (exactUser.isPresent()) {
+                return exactUser.get();
+            }
+
+            // find through String edit distance
+            return allSlackUsers
+                .stream()
+                .min((a, b) ->
+                    Integer.compare(
+                        LevenshteinDistance.getDefaultInstance().apply(entry.user().name(), a.getName()),
+                        LevenshteinDistance.getDefaultInstance().apply(entry.user().name(), b.getName())
+                    )
+                )
+                .orElse(null);
+        };
+    }
+
+    private String formatDateForURL(OffsetDateTime date) {
+        return date.format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME).replace("+", "%2B");
+    }
+
+    @Override
+    public void run() {
+        // get date in unix format
+        long currentDate = OffsetDateTime.now().toEpochSecond();
+        // Calculate the the last leaderboard schedule
+        String[] timeParts = scheduledTime.split(":");
+        OffsetDateTime before = OffsetDateTime.now()
+            .with(TemporalAdjusters.previousOrSame(DayOfWeek.of(Integer.parseInt(scheduledDay))))
+            .withHour(Integer.parseInt(timeParts[0]))
+            .withMinute(timeParts.length > 0 ? Integer.parseInt(timeParts[1]) : 0)
+            .withSecond(0)
+            .withNano(0);
+        OffsetDateTime after = before.minusWeeks(1);
+
+        var top3reviewers = getTop3SlackReviewers(after, before);
+
+        logger.info("Sending scheduled message to Slack channel...");
+
+        List<LayoutBlock> blocks = asBlocks(
+            header(header -> header.text(plainText(pt -> pt.text(":newspaper: Reviews of the last week :newspaper:")))),
+            context(context ->
+                context.elements(
+                    List.of(
+                        markdownText(
+                            "<!date^" + currentDate + "^{date} at {time}| Today at 9:00AM CEST> | " + hephaestusUrl
+                        )
+                    )
+                )
+            ),
+            divider(),
+            section(section ->
+                section.text(
+                    markdownText(
+                        "Another *review leaderboard* has concluded. You can check out your placement <" +
+                        hephaestusUrl +
+                        "?after=" +
+                        formatDateForURL(after) +
+                        "&before=" +
+                        formatDateForURL(before) +
+                        "|here>."
+                    )
+                )
+            ),
+            section(section -> section.text(markdownText("Special thanks to our top 3 reviewers of last week:"))),
+            section(section ->
+                section.text(
+                    markdownText(
+                        IntStream.range(0, top3reviewers.size())
+                            .mapToObj(i -> ((i + 1) + ". <@" + top3reviewers.get(i).getId() + ">"))
+                            .reduce((a, b) -> a + "\n" + b)
+                            .orElse("")
+                    )
+                )
+            ),
+            section(section -> section.text(markdownText("Happy coding and reviewing! :rocket:")))
+        );
+        try {
+            slackMessageService.sendMessage(channelId, blocks, "Reviews of the last week");
+        } catch (IOException | SlackApiException e) {
+            logger.error("Failed to send scheduled message to Slack channel: " + e.getMessage());
+        }
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/SlackWeeklyLeaderboardTask.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/SlackWeeklyLeaderboardTask.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Task to send a weekly leaderboard message to the Slack channel.
- * @see SlackMessageService#activateTaskScheduler()
+ * @see SlackMessageService
  */
 @Component
 public class SlackWeeklyLeaderboardTask implements Runnable {
@@ -55,7 +55,7 @@ public class SlackWeeklyLeaderboardTask implements Runnable {
 
     /**
      * Test the Slack connection.
-     * @return
+     * @return {@code true} if the connection is valid, {@code false} otherwise.
      */
     public boolean testSlackConnection() {
         return runScheduledMessage && slackMessageService.initTest();


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
For future features (such as the leaderboard leagues) we need to be able to execute tasks easily at the end of each leaderboard cycle.
Implements task 3.1 of #170.

### Description
<!-- Provide a brief summary of the changes. -->
This PR reworks the original task scheduler used for the weekly Slack message to be more modular (separating the logic) and easily support adding new tasks:
- `LeaderboardTaskScheduler` now manages all tasks and schedules them for the end of a leaderboard cycle
- `SlackMessageService` is now only a light wrapper around the `SlackAppConfig`, providing implementations for sending messages and testing the connection
- `SlackWeeklyLeaderboardTask` is a runnable task, scheduled by the `LeaderboardTaskScheduler`, responsible for creating the Slack message and delegating the sending process

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
No manual testing required - Code reviews would be great though!
Would love to receive feedback on:
- folder structure
- potential for structural simplifications
- does the code need more comments?

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)
