### PR TITLE
Fix: Ignore own Issue Comments for Score Calculation

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
@@ -117,6 +117,7 @@ public class LeaderboardService {
                 List<PullRequestInfoDTO> reviewedPullRequests = userReviews
                     .stream()
                     .map(review -> review.getPullRequest())
+                    .filter(pullRequest -> pullRequest.getAuthor().getId() != userId)
                     // First collect to a map keyed by PR ID to ensure uniqueness
                     .collect(
                         Collectors.groupingBy(

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/LeaderboardService.java
@@ -90,7 +90,7 @@ public class LeaderboardService {
                 Collectors.toMap(Map.Entry::getKey, entry ->
                     calculateTotalScore(
                         entry.getValue(),
-                        issueCommentsByUserId.getOrDefault(entry.getKey(), List.of()).size()
+                        issueCommentsByUserId.getOrDefault(entry.getKey(), List.of())
                     )
                 )
             );
@@ -179,7 +179,8 @@ public class LeaderboardService {
         return leaderboard;
     }
 
-    private int calculateTotalScore(List<PullRequestReview> reviews, int numberOfIssueComments) {
+    private int calculateTotalScore(List<PullRequestReview> reviews, List<IssueComment> issueComments) {
+        int numberOfIssueComments = issueComments.stream().filter(issueComment -> issueComment.getIssue().getAuthor().getId() != issueComment.getAuthor().getId()).collect(Collectors.toList()).size();
         // Could contain multiple reviews for the same pull request
         Map<Long, List<PullRequestReview>> reviewsByPullRequestId = reviews
             .stream()

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/ScoringService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/ScoringService.java
@@ -71,6 +71,9 @@ public class ScoringService {
             }
             pullRequest = optionalPR.get();
         }
+        if (pullRequest.getAuthor().getId() == issueComment.getAuthor().getId()) {
+            return 0;
+        }
         
         int complexityScore = calculateComplexityScore(pullRequest);
         


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes https://ls1tum.slack.com/archives/C07CZNLULQN/p1733604651504789

### Description
<!-- Provide a brief summary of the changes. -->
This PR fixes bugs where:
- issue comments on own PRs count towards the total leaderboard score
- activity on own PRs were assigned with more than 0 points on the profile/user page
- own PRs were not filtered correctly from the list of reviewed PRs

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
Test by comparing this week's leaderboard:
`SimonEntholzer` has more than 500 points on https://hephaestus.ase.cit.tum.de, with this PR his points should be reduced to about 300.

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)
