### PR TITLE
Fix: Lock Poetry version to 1.8.5

### DIFF
--- a/.github/workflows/generate-intelligence-service-client.yml
+++ b/.github/workflows/generate-intelligence-service-client.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.8.5
           virtualenvs-create: true
           virtualenvs-in-project: true
           virtualenvs-path: .venv

--- a/.github/workflows/intelligence-service-qa.yml
+++ b/.github/workflows/intelligence-service-qa.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.8.5
           virtualenvs-create: true
           virtualenvs-in-project: true
           virtualenvs-path: .venv

--- a/server/intelligence-service/Dockerfile
+++ b/server/intelligence-service/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12 as requirements-stage
 
 WORKDIR /tmp
 
-RUN pip install poetry
+RUN pip install poetry==1.8.5
 COPY ./pyproject.toml ./poetry.lock* /tmp/
 RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
 

--- a/server/webhook-ingest/Dockerfile
+++ b/server/webhook-ingest/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12 as requirements-stage
 
 WORKDIR /tmp
 
-RUN pip install poetry
+RUN pip install poetry==1.8.5
 COPY ./pyproject.toml ./poetry.lock* /tmp/
 RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
 


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes incompatibility issues caused by the Poetry v2.0 release.

### Description
<!-- Provide a brief summary of the changes. -->
Locks the Poetry version installed by Docker and the Github Action workflows to version 1.8.5, the last version before the breaking 2.0 release.

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [ ] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)
