### PR TITLE
Fix: Colspan of Leaderboard Empty Data-State

### DIFF
--- a/webapp/src/app/home/leaderboard/leaderboard.component.html
+++ b/webapp/src/app/home/leaderboard/leaderboard.component.html
@@ -37,7 +37,7 @@
       }
     } @else if (!leaderboard() || leaderboard()?.length === 0) {
       <tr appTableRow>
-        <td appTableCell colspan="4">
+        <td appTableCell colspan="5">
           <div class="flex flex-col items-center justify-center gap-2 mt-1">
             <ng-icon [svg]="octNoEntry" size="32" class="text-github-danger-foreground" />
             <span class="font-semibold text-muted-foreground">No entries found</span>


### PR DESCRIPTION
### Description
<!-- Provide a brief summary of the changes. -->
Fixes a visual bug caused by the addition of leagues to the leaderbord, where the placeholder for the "empty data"-state was not spanning all columns

### Screenshots (if applicable)
<!-- Attach screenshots here. -->
Before this PR:
![image](https://github.com/user-attachments/assets/b371ad52-e0ff-4482-9215-4a9bb6850edf)
After this PR:
![image](https://github.com/user-attachments/assets/9b0f8bb2-c988-464f-af03-e1b0d1857ca4)


### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [x] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Client (if applicable)

- [x] UI changes look good on all screen sizes and browsers
- [x] No console errors or warnings
- [x] User experience and accessibility have been tested
- [ ] Added Storybook stories for new components
- [ ] Components follow design system guidelines (if applicable)
