### PR TITLE
Fix: Schedule Index Test

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/LeaguePointsUpdateTask.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/LeaguePointsUpdateTask.java
@@ -62,7 +62,7 @@ public class LeaguePointsUpdateTask implements Runnable {
         OffsetDateTime before = OffsetDateTime.now()
             .with(TemporalAdjusters.previousOrSame(DayOfWeek.of(Integer.parseInt(scheduledDay))))
             .withHour(Integer.parseInt(timeParts[0]))
-            .withMinute(timeParts.length > 0 ? Integer.parseInt(timeParts[1]) : 0)
+            .withMinute(timeParts.length > 1 ? Integer.parseInt(timeParts[1]) : 0)
             .withSecond(0)
             .withNano(0);
         OffsetDateTime after = before.minusWeeks(1);


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes a bug, which caused an ArrayOutOfBounds-Exception in today's leaderboard launch.

### Description
<!-- Provide a brief summary of the changes. -->
Changes the length test to >1 (at least two) to guarantee an element exists at index 1.

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [ ] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)

#### Server (if applicable)

- [x] Code is performant and follows best practices
- [x] No security vulnerabilities introduced
- [x] Proper error handling has been implemented
- [ ] Added tests for new functionality
- [ ] Changes have been tested in different environments (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the way leaderboard update times are interpreted. Now, if the minute information is missing in scheduled times, it defaults to zero, ensuring more reliable leaderboard retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->