### PR TITLE
Add new league icons

### DIFF
--- a/webapp/src/app/ui/league/icon/league-bronze-icon.component.ts
+++ b/webapp/src/app/ui/league/icon/league-bronze-icon.component.ts
@@ -1,0 +1,19 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-league-bronze-icon',
+  template: `
+    <svg [class]="class()" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M12 4.3094L5.33975 8.1547V15.8453L12 19.6906L18.6603 15.8453V8.1547L12 4.3094ZM20.6603 7L12 2L3.33975 7V17L12 22L20.6603 17V7Z"
+        fill="hsl(var(--league-bronze))"
+      />
+      <path d="M6.80385 12.7991V10.4897L12 13.4897L17.1962 10.4897V12.7991L12 15.7991L6.80385 12.7991Z" fill="hsl(var(--league-bronze))" />
+    </svg>
+  `
+})
+export class LeagueBronzeIconComponent {
+  class = input<string>('');
+}

--- a/webapp/src/app/ui/league/icon/league-diamond-icon.component.ts
+++ b/webapp/src/app/ui/league/icon/league-diamond-icon.component.ts
@@ -1,0 +1,24 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-league-diamond-icon',
+  template: `
+    <svg [class]="class()" width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M13 4.3094L6.33975 8.1547V15.8453L13 19.6906L19.6603 15.8453V8.1547L13 4.3094ZM21.6603 7L13 2L4.33975 7V17L13 22L21.6603 17V7Z"
+        fill="hsl(var(--league-diamond))"
+      />
+      <path d="M6.87564 3.8453L4.87564 2.6906L0.875641 5V9.6188L2.87564 10.7735V6.1547L6.87564 3.8453Z" fill="hsl(var(--league-diamond))" />
+      <path d="M9 21.3812L9 23.6906L13 26L17 23.6906V21.3812L13 23.6906L9 21.3812Z" fill="hsl(var(--league-diamond))" />
+      <path d="M23.1244 10.7735V6.1547L19.1244 3.8453L21.1244 2.6906L25.1244 5V9.61881L23.1244 10.7735Z" fill="hsl(var(--league-diamond))" />
+      <path d="M10.5371 7.42196L13 8.84392L15.4629 7.42196L17.4629 8.57666L13 11.1533L8.53708 8.57666L10.5371 7.42196Z" fill="hsl(var(--league-diamond))" />
+      <path d="M7.80383 11.6533V9.34392L13 12.3439L18.1961 9.34392V11.6533L13 14.6533L7.80383 11.6533Z" fill="hsl(var(--league-diamond))" />
+      <path d="M18.1961 12.8439V15L13 18L7.80383 15V12.8439L13 15.8439L18.1961 12.8439Z" fill="hsl(var(--league-diamond))" />
+    </svg>
+  `
+})
+export class LeagueDiamondIconComponent {
+  class = input<string>('');
+}

--- a/webapp/src/app/ui/league/icon/league-gold-icon.component.ts
+++ b/webapp/src/app/ui/league/icon/league-gold-icon.component.ts
@@ -1,0 +1,21 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-league-gold-icon',
+  template: `
+    <svg [class]="class()" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M12 4.3094L5.33975 8.1547V15.8453L12 19.6906L18.6603 15.8453V8.1547L12 4.3094ZM20.6603 7L12 2L3.33975 7V17L12 22L20.6603 17V7Z"
+        fill="hsl(var(--league-gold))"
+      />
+      <path d="M9.5371 7.42196L12 8.84392L14.4629 7.42196L16.4629 8.57666L12 11.1533L7.5371 8.57666L9.5371 7.42196Z" fill="hsl(var(--league-gold))" />
+      <path d="M6.80385 11.6533V9.34392L12 12.3439L17.1962 9.34392V11.6533L12 14.6533L6.80385 11.6533Z" fill="hsl(var(--league-gold))" />
+      <path d="M17.1962 12.8439V15L12 18L6.80385 15V12.8439L12 15.8439L17.1962 12.8439Z" fill="hsl(var(--league-gold))" />
+    </svg>
+  `
+})
+export class LeagueGoldIconComponent {
+  class = input<string>('');
+}

--- a/webapp/src/app/ui/league/icon/league-icon.component.ts
+++ b/webapp/src/app/ui/league/icon/league-icon.component.ts
@@ -2,6 +2,12 @@ import { Component, computed, input } from '@angular/core';
 import { cn, getLeagueFromPoints } from '@app/utils';
 import { LucideAngularModule, Medal } from 'lucide-angular';
 import { type VariantProps, cva } from 'class-variance-authority';
+import { LeagueBronzeIconComponent } from './league-bronze-icon.component';
+import { LeagueNoneIconComponent } from './league-none-icon.component';
+import { LeagueSilverIconComponent } from './league-silver-icon.component';
+import { LeagueGoldIconComponent } from './league-gold-icon.component';
+import { LeagueDiamondIconComponent } from './league-diamond-icon.component';
+import { LeagueMasterIconComponent } from './league-master-icon.component';
 
 export const leagueVariants = cva('size-8', {
   variants: {
@@ -32,8 +38,37 @@ type LeagueVariants = VariantProps<typeof leagueVariants>;
 @Component({
   selector: 'app-icon-league',
   standalone: true,
-  imports: [LucideAngularModule],
-  template: ` <lucide-angular [img]="Medal" strokeWidth="2px" [class]="computedClass()" [title]="computedLeague()" /> `
+  imports: [
+    LucideAngularModule,
+    LeagueBronzeIconComponent,
+    LeagueNoneIconComponent,
+    LeagueSilverIconComponent,
+    LeagueGoldIconComponent,
+    LeagueDiamondIconComponent,
+    LeagueMasterIconComponent
+  ],
+  template: `
+    @switch (computedLeague()) {
+      @case ('none') {
+        <app-league-none-icon [class]="computedClass()" />
+      }
+      @case ('bronze') {
+        <app-league-bronze-icon [class]="computedClass()" />
+      }
+      @case ('silver') {
+        <app-league-silver-icon [class]="computedClass()" />
+      }
+      @case ('gold') {
+        <app-league-gold-icon [class]="computedClass()" />
+      }
+      @case ('diamond') {
+        <app-league-diamond-icon [class]="computedClass()" />
+      }
+      @case ('master') {
+        <app-league-master-icon [class]="computedClass()" />
+      }
+    }
+  `
 })
 export class LeagueIconComponent {
   protected Medal = Medal;

--- a/webapp/src/app/ui/league/icon/league-icon.stories.ts
+++ b/webapp/src/app/ui/league/icon/league-icon.stories.ts
@@ -1,0 +1,60 @@
+import { type Meta, type StoryObj } from '@storybook/angular';
+import { LeagueIconComponent } from './league-icon.component';
+
+const meta: Meta<LeagueIconComponent> = {
+  component: LeagueIconComponent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered'
+  },
+  args: {
+    leaguePoints: 1100
+  },
+  argTypes: {
+    leaguePoints: {
+      control: {
+        type: 'number'
+      },
+      description: 'Current League Points to be displayed'
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<LeagueIconComponent>;
+
+export const NoneIcon: Story = {
+  args: {
+    leaguePoints: undefined
+  }
+};
+
+export const BronzeIcon: Story = {
+  args: {
+    leaguePoints: 1000
+  }
+};
+
+export const SilverIcon: Story = {
+  args: {
+    leaguePoints: 1250
+  }
+};
+
+export const GoldIcon: Story = {
+  args: {
+    leaguePoints: 1500
+  }
+};
+
+export const DiamondIcon: Story = {
+  args: {
+    leaguePoints: 1750
+  }
+};
+
+export const MasterIcon: Story = {
+  args: {
+    leaguePoints: 2000
+  }
+};

--- a/webapp/src/app/ui/league/icon/league-master-icon.component.ts
+++ b/webapp/src/app/ui/league/icon/league-master-icon.component.ts
@@ -1,0 +1,27 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-league-master-icon',
+  template: `
+    <svg [class]="class()" width="26" height="28" viewBox="0 0 26 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M13 6.3094L6.33975 10.1547V17.8453L13 21.6906L19.6603 17.8453V10.1547L13 6.3094ZM21.6603 9L13 4L4.33975 9V19L13 24L21.6603 19V9Z"
+        fill="hsl(var(--league-master))"
+      />
+      <path d="M18.19 17.0036L15.69 18.4469V9.55307L18.19 10.9965V17.0036Z" fill="hsl(var(--league-master))" />
+      <path d="M7.81001 10.9964L10.31 9.55307V18.4469L7.81001 17.0036V10.9964Z" fill="hsl(var(--league-master))" />
+      <path d="M13 11.1155L11.5 10.4894V15.5913L13 16.2174L14.5 15.5913V10.4894L13 11.1155Z" fill="hsl(var(--league-master))" />
+      <path d="M19.1244 5.8453L23.1244 8.1547V12.7735L25.1244 11.6188V7L21.1244 4.6906L19.1244 5.8453Z" fill="hsl(var(--league-master))" />
+      <path d="M9 2.3094L13 0L17 2.3094V4.6188L13 2.3094L9 4.6188V2.3094Z" fill="hsl(var(--league-master))" />
+      <path d="M0.875641 11.6188V7L4.87564 4.6906L6.87564 5.8453L2.87564 8.1547V12.7735L0.875641 11.6188Z" fill="hsl(var(--league-master))" />
+      <path d="M4.87565 23.3094L0.875641 21V16.3812L2.87564 15.2265V19.8453L6.87565 22.1547L4.87565 23.3094Z" fill="hsl(var(--league-master))" />
+      <path d="M17 25.6906L13 28L9 25.6906V23.3812L13 25.6906L17 23.3812V25.6906Z" fill="hsl(var(--league-master))" />
+      <path d="M25.1244 16.3812V21L21.1244 23.3094L19.1244 22.1547L23.1244 19.8453V15.2265L25.1244 16.3812Z" fill="hsl(var(--league-master))" />
+    </svg>
+  `
+})
+export class LeagueMasterIconComponent {
+  class = input<string>('');
+}

--- a/webapp/src/app/ui/league/icon/league-none-icon.component.ts
+++ b/webapp/src/app/ui/league/icon/league-none-icon.component.ts
@@ -1,0 +1,22 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-league-none-icon',
+  template: `<svg [class]="class()" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M15.4641 20L17.1962 19L16.1962 17.268L14.4641 18.268L15.4641 20ZM9.5359 18.2679L7.80385 17.2679L6.80385 19L8.5359 20L9.5359 18.2679ZM3.33976 13H5.33976V11H3.33976V13ZM6.80386 5L7.80386 6.73205L9.53591 5.73205L8.53591 4L6.80386 5ZM20.6603 11H18.6603V13H20.6603V11ZM17.1962 5L15.4641 4L14.4641 5.73205L16.1962 6.73205L17.1962 5Z"
+      fill="hsl(var(--muted-foreground))"
+    />
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M14.1651 3.25L12 2L9.83494 3.25L10.8349 4.98205L12 4.3094L13.1651 4.98205L14.1651 3.25ZM3.33975 14.5H5.33975V15.8453L6.50482 16.5179L5.50482 18.25L3.33975 17V14.5ZM9.83494 20.75L12 22L14.1651 20.75L13.1651 19.018L12 19.6906L10.8349 19.018L9.83494 20.75ZM20.6603 9.5H18.6603V8.1547L17.4952 7.48205L18.4952 5.75L20.6603 7V9.5ZM20.6603 14.5H18.6603V15.8453L17.4952 16.5179L18.4952 18.25L20.6603 17V14.5ZM3.33975 9.5H5.33975V8.1547L6.50482 7.48205L5.50482 5.75L3.33975 7V9.5Z"
+      fill="hsl(var(--muted-foreground))"
+    />
+  </svg>`
+})
+export class LeagueNoneIconComponent {
+  class = input<string>('');
+}

--- a/webapp/src/app/ui/league/icon/league-silver-icon.component.ts
+++ b/webapp/src/app/ui/league/icon/league-silver-icon.component.ts
@@ -1,0 +1,20 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-league-silver-icon',
+  template: `
+    <svg [class]="class()" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M12 4.3094L5.33975 8.1547V15.8453L12 19.6906L18.6603 15.8453V8.1547L12 4.3094ZM20.6603 7L12 2L3.33975 7V17L12 22L20.6603 17V7Z"
+        fill="hsl(var(--league-silver))"
+      />
+      <path d="M6.80385 11.3133V9.00391L12 12.0039L17.1962 9.00391V11.3133L12 14.3133L6.80385 11.3133Z" fill="hsl(var(--league-silver))" />
+      <path d="M6.80385 14.8133V12.5039L12 15.5039L17.1962 12.5039V14.8133L12 17.8133L6.80385 14.8133Z" fill="hsl(var(--league-silver))" />
+    </svg>
+  `
+})
+export class LeagueSilverIconComponent {
+  class = input<string>('');
+}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -34,8 +34,8 @@
     --radius: 0.5rem;
 
     --league-bronze: 30 58% 54%;
-    --league-silver: 0 0% 77%;
-    --league-gold: 48 97% 48%;
+    --league-silver: 0 0% 50%;
+    --league-gold: 48 80% 48%;
     --league-diamond: 225 73% 53%;
     --league-master: 330 100% 71;
   }
@@ -60,6 +60,12 @@
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
+
+    --league-bronze: 30 58% 54%;
+    --league-silver: 0 0% 75%;
+    --league-gold: 48 97% 48%;
+    --league-diamond: 225 73% 53%;
+    --league-master: 330 100% 71;
   }
 }
 


### PR DESCRIPTION
This pull request includes significant updates to the league icon components in the web application. The changes involve the addition of new league icon components, modifications to the main league icon component to incorporate these new components, and updates to the styling and storybook configuration.

### Addition of New League Icon Components:
* Added `LeagueBronzeIconComponent`, `LeagueDiamondIconComponent`, `LeagueGoldIconComponent`, `LeagueMasterIconComponent`, `LeagueNoneIconComponent`, and `LeagueSilverIconComponent` with their respective SVG templates. [[1]](diffhunk://#diff-4379e00691a304255c3c546783f681c8a3a080abf593dbcc9c00b9585db4109eR1-R19) [[2]](diffhunk://#diff-41015e68a4b0d7dd5bcfb57b370b624e33665981e3f03c18c65ecfffb680e455R1-R24) [[3]](diffhunk://#diff-eeab0bebc954d3e8b2483f9e0128a04558e538f69e08c2f6615c1fe71c80b0d4R1-R21) [[4]](diffhunk://#diff-8bec498896f12bf05168c474990932d5e1ca2419b93151f11f4bc0dd61f0e66bR1-R27) [[5]](diffhunk://#diff-9daedc3882452f0ccd98e62fb84a7ead3a2ba564a6a5f7f87cfd5789efa8ed8cR1-R22) [[6]](diffhunk://#diff-90d1a0b8c52a1238c65c8af116bd512bd040faaab60f19741255a6325ca66351R1-R20)

### Modifications to Main League Icon Component:
* Updated `LeagueIconComponent` to import the new league icon components and use them in the template based on the computed league. [[1]](diffhunk://#diff-547cb80ca8ac7524a63e83222d92cd7262894d58585b5117882eccdc5f6396ffR5-R10) [[2]](diffhunk://#diff-547cb80ca8ac7524a63e83222d92cd7262894d58585b5117882eccdc5f6396ffL35-R71)

### Storybook Configuration:
* Added a new storybook configuration for `LeagueIconComponent` with different league points to display various league icons.

### Styling Updates:
* Adjusted the color variables for league silver and league gold in the `styles.css` file to improve visual consistency. [[1]](diffhunk://#diff-357be71fa60d780d28b42d58bdb0bbcb272d0ac5dfbb694594ee203f41d73de1L37-R38) [[2]](diffhunk://#diff-357be71fa60d780d28b42d58bdb0bbcb272d0ac5dfbb694594ee203f41d73de1R63-R68)