### PR TITLE
Fix: Change Milestone `description` Type

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/milestone/Milestone.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/milestone/Milestone.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -40,6 +41,7 @@ public class Milestone extends BaseGitServiceEntity {
     @NonNull
     private String title;
 
+    @Lob
     private String description;
 
     private OffsetDateTime closedAt;

--- a/server/application-server/src/main/resources/db/changelog/1739871861123_changelog.xml
+++ b/server/application-server/src/main/resources/db/changelog/1739871861123_changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="godrums" id="1739871861123-1">
+        <modifyDataType columnName="description" newDataType="oid" tableName="milestone"/>
+    </changeSet>
+</databaseChangeLog>

--- a/server/application-server/src/main/resources/db/master.xml
+++ b/server/application-server/src/main/resources/db/master.xml
@@ -11,4 +11,5 @@
     <include file="./changelog/1732966971482_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1733673611832_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1737749442154_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1739871861123_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fix an issue which caused the Github sync to fail if a milestone with a description of more than 255 chars exists. In this case the violating milestone is https://github.com/ls1intum/Artemis/milestone/313.

### Description
<!-- Provide a brief summary of the changes. -->
This PR changes the type of the `description` field of milestones to a large object type. 
This allows us to store descriptions with a length of more than 255 characters. 
We use the same notation for long text in other tables.

### Testing Instructions
<!-- Explain how to test the changes made in this PR. -->
- run `application-server` with `monitoring.run-on-startup: true`
- the server should start up without errors again

### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [ ] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Milestone descriptions now support longer, more detailed text entries for an improved experience.

- **Chores**
  - Adjusted database migration processes to accommodate the extended milestone description capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->