### PR TITLE
Fix: League Info Infinity Points

### DIFF
--- a/webapp/src/app/ui/league/info-modal/info-modal.component.html
+++ b/webapp/src/app/ui/league/info-modal/info-modal.component.html
@@ -14,7 +14,7 @@
           <div class="flex items-center text-sm text-github-muted-foreground gap-1">
             <ng-icon name="lucideStar" class="text-base" />
             @if (league.maxPoints === Infinity) {
-              <span>{{ league.maxPoints }}+</span>
+              <span>{{ league.minPoints }}+</span>
             } @else {
               <span>{{ league.minPoints }} - {{ league.maxPoints }}</span>
             }


### PR DESCRIPTION
### Motivation
<!-- Explain why this change is necessary. What problem does it solve? -->
<!-- Link to the issue this PR addresses (e.g., `Fixes #123`, `Closes #123`, etc.) -->
Fixes a bug in the info modal for leagues.

### Description
<!-- Provide a brief summary of the changes. -->
Fixes an issue, where "Infinity+" is displayed as points range for the highest league.

### Screenshots
<!-- Attach screenshots here. -->
![image](https://github.com/user-attachments/assets/d76266c9-91f6-4f60-8443-44583296a548)


### Checklist

#### General

- [x] PR title is clear and descriptive
- [x] PR description explains the purpose and changes
- [x] Code follows project coding standards
- [x] Self-review of the code has been done
- [x] Changes have been tested locally
- [x] Screenshots have been attached (if applicable)
- [ ] Documentation has been updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the league points display. For leagues without a defined maximum, the points now show as the minimum value followed by a plus sign for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->