### PR TITLE
Add user story issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,7 +1,7 @@
 ---
 name: Thesis Epic
 about: Captures a core thesis objective, guiding you from identifying the problem through requirements into an architecture.
-title: "[Imperative Verb Phrase]: [Short Description]"
+title: "<Imperative Verb Phrase>: <Short Description>"
 labels: epic
 assignees: 
 ---

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,7 +1,7 @@
 ---
 name: Thesis Epic
 about: Captures a core thesis objective, guiding you from identifying the problem through requirements into an architecture.
-title: "<Imperative Verb Phrase>: <Short Description>"
+title: "[Imperative Verb Phrase]: [Short Description]"
 labels: epic
 assignees: 
 ---

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -61,7 +61,7 @@ consider breaking it down into smaller user stories.
 - [ ] Code reviewed and approved.
 - [ ] All CI checks passed (except Mend, it helps to identify security vulnerabilities).
 - [ ] Deployed to staging environment and functionality verified.
-- [ ] Documentation updated with information on how to use the wishlist feature.
+- [ ] Documentation updated with information on how to use the implemented functionality.
 - [ ] Merged to `develop` branch.
 
 <!-- 

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,7 +1,7 @@
 ---
 name: User Story
 about: Create a user story to capture functionality from an end user's perspective
-title: "<Imperative Verb Phrase>: <Short Description>"
+title: "[Imperative Verb Phrase]: [Short Description]"
 labels: "user story"
 assignees: 
 ---

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -6,11 +6,22 @@ labels: "user story"
 assignees: 
 ---
 
+<!-- 
+Example Title: "Add Repository Filter: Enable leaderboard filtering by specific repositories"
+-->
+
 ## User Story
 
 **As a** [role]  
 **I want** [goal/desire]  
 **So that** [benefit/value]
+
+<!-- 
+Example Story:
+**As a** team member using the code review leaderboard  
+**I want** to filter the leaderboard by specific repositories  
+**So that** I can focus on review activity relevant to the projects I care about
+-->
 
 ## Acceptance Criteria
 
@@ -20,6 +31,19 @@ Each criterion should be a specific, testable condition that must be met for the
 - [ ] **Given** [precondition], **When** [action], **Then** [expected result]
 - [ ] **Given** [precondition], **When** [action], **Then** [expected result]
 - [ ] **Given** [precondition], **When** [action], **Then** [expected result]
+
+<!--
+Example Acceptance Criteria:
+- [ ] **Given** I am on the weekly leaderboard page, **When** I select a repository from the filter dropdown, **Then** only reviews from that repository should display
+
+- [ ] **Given** I have filtered by a specific repository, **When** I navigate away and return to the page, **Then** my filter selection should be remembered
+
+- [ ] **Given** I select a repository with no review activity, **When** the leaderboard updates, **Then** I should see an appropriate "No data available" message
+
+- [ ] **Given** I am viewing filtered results, **When** I select "All Repositories" from the dropdown, **Then** I should see review activities across all repositories
+
+- [ ] Repository filter dropdown should only display repositories the user has access to
+-->
 
 ## Mockups / Wireframes
 
@@ -38,7 +62,7 @@ consider breaking it down into smaller user stories.
 - [ ] All CI checks passed (except Mend, it helps to identify security vulnerabilities).
 - [ ] Deployed to staging environment and functionality verified.
 - [ ] Documentation updated with information on how to use the wishlist feature.
-- [ ] Merged to development branch
+- [ ] Merged to `develop` branch.
 
 <!-- 
 ## Technical Notes

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,0 +1,55 @@
+---
+name: User Story
+about: Create a user story to capture functionality from an end user's perspective
+title: "<Imperative Verb Phrase>: <Short Description>"
+labels: "user story"
+assignees: 
+---
+
+## User Story
+
+**As a** [role]  
+**I want** [goal/desire]  
+**So that** [benefit/value]
+
+## Acceptance Criteria
+
+<!-- Use the Given-When-Then format for clear, testable criteria, but you are not limited to it.  
+Each criterion should be a specific, testable condition that must be met for the story to be considered complete. -->
+
+- [ ] **Given** [precondition], **When** [action], **Then** [expected result]
+- [ ] **Given** [precondition], **When** [action], **Then** [expected result]
+- [ ] **Given** [precondition], **When** [action], **Then** [expected result]
+
+## Mockups / Wireframes
+
+<!-- 
+Attach or link wireframes, sketches, or mockups that visualize this user story.
+Keep it low-fidelity as minimal requirement. If you need more than 2 screens to represent this story,
+consider breaking it down into smaller user stories.
+-->
+
+[Attach or link mockups here]
+
+## Definition of Done
+
+- [ ] All acceptance criteria are met.
+- [ ] Code reviewed and approved.
+- [ ] All CI checks passed.
+- [ ] Deployed to staging environment and functionality verified.
+- [ ] Documentation updated with information on how to use the wishlist feature.
+- [ ] Merged to development branch
+
+<!-- 
+## Technical Notes
+[Add technical implementation details or considerations]
+
+## Dependencies
+[Add any dependencies or blockers that need to be resolved]
+
+## Related Issues
+[Link to related issues or epics]
+
+## Testing Scenarios
+Detailed test cases:
+-->

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -35,7 +35,7 @@ consider breaking it down into smaller user stories.
 
 - [ ] All acceptance criteria are met.
 - [ ] Code reviewed and approved.
-- [ ] All CI checks passed.
+- [ ] All CI checks passed (except Mend, it helps to identify security vulnerabilities).
 - [ ] Deployed to staging environment and functionality verified.
 - [ ] Documentation updated with information on how to use the wishlist feature.
 - [ ] Merged to development branch


### PR DESCRIPTION
This pull request introduces a new issue template for creating user stories in the `.github/ISSUE_TEMPLATE` directory. The template is designed to standardize the process of capturing functionality from an end user's perspective, ensuring clarity and consistency.

### Addition of a User Story Template:

* **New user story issue template**: A new file, `user_story.md`, has been added to provide a structured format for documenting user stories. The template includes sections for the user story description, acceptance criteria (using the Given-When-Then format), mockups or wireframes, and the definition of done. It also provides examples to guide users in filling out the template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new GitHub issue template for user stories, featuring sections for user goals, acceptance criteria, mockups, and definition of done to standardize and clarify feature requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->