### PR TITLE
fix: add resource limits and message retention policies to nats

### DIFF
--- a/server/webhook-ingest/nats-server.conf
+++ b/server/webhook-ingest/nats-server.conf
@@ -4,7 +4,15 @@ http_port: 8222
 
 jetstream {
   store_dir: "/data"
+  max_file_store: 50GB
+  max_memory_store: 1GB
+  
+  limits {
+    max_age: "180d"
+    max_msgs: 2000000
+  }
 }
+
 
 tls {
   cert_file: $TLS_CERT_FILE


### PR DESCRIPTION
This pull request updates the JetStream configuration in `nats-server.conf` to add resource limits and message retention policies for improved stability and data management.

JetStream resource and retention configuration:

* Added `max_file_store` (50GB) and `max_memory_store` (1GB) to restrict disk and memory usage for JetStream data (`nats-server.conf`).
* Introduced a `limits` block with `max_age` (180 days) and `max_msgs` (2,000,000) to automatically expire old messages and cap the total message count (`nats-server.conf`).