### PR TITLE
fix: handle new team filter path format

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/team/TeamRepository.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/team/TeamRepository.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.hephaestus.gitprovider.team;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TeamRepository extends JpaRepository<Team, Long> {}
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    List<Team> findAllByName(String name);
+}


### PR DESCRIPTION
## Summary
- support leaderboards filtering by team path string or name
- derive visible team paths server-side for matching
- avoid loading all teams by querying team names on demand

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68c65cc082f0832ab70e85ce1566e2a8