### PR TITLE
chore: handle missing env vars in webapp substitution script

### DIFF
--- a/webapp/substitute_env_variables.sh
+++ b/webapp/substitute_env_variables.sh
@@ -63,7 +63,7 @@ replace_vars() {
   # If the environment variable is not set, skip the replacement to avoid
   # exiting because of `set -u`. This keeps the behaviour consistent with the
   # earlier validation step that only warns about missing variables.
-  if [[ -z "${!env_var+x}" ]]; then
+  if [[ ! -v "$env_var" ]]; then
     log "⚠️ Skipping placeholder '${placeholder}' because environment variable '${env_var}' is not set."
     return
   fi

--- a/webapp/substitute_env_variables.sh
+++ b/webapp/substitute_env_variables.sh
@@ -60,6 +60,14 @@ escape_js_string() {
 replace_vars() {
   local placeholder="$1"
   local env_var="${placeholder#${ENV_PREFIX}}"
+  # If the environment variable is not set, skip the replacement to avoid
+  # exiting because of `set -u`. This keeps the behaviour consistent with the
+  # earlier validation step that only warns about missing variables.
+  if [[ -z "${!env_var+x}" ]]; then
+    log "⚠️ Skipping placeholder '${placeholder}' because environment variable '${env_var}' is not set."
+    return
+  fi
+
   local value="${!env_var}"
 
   # Log the substitution process


### PR DESCRIPTION
## Summary
- avoid crashing the webapp container when optional WEB_ENV placeholders are not backed by environment variables
- log a warning and skip substitutions for missing variables so the substitution script can complete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dea6698588832a99de1497f4756d9e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of environment variable handling during setup and runtime: when a variable is unset the system now logs a warning and safely skips substitution instead of failing. This prevents crashes under strict settings and aligns behavior with prior validation, leading to smoother deployments and more predictable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->