### PR TITLE
Enable HTTP/3 support for Traefik reverse proxy

### DIFF
--- a/docker/compose.proxy.yaml
+++ b/docker/compose.proxy.yaml
@@ -7,6 +7,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "443:443/udp"
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -18,6 +19,7 @@ services:
       - "--api.insecure=false"
       - "--entrypoints.http.address=:80"
       - "--entrypoints.https.address=:443"
+      - "--entrypoints.https.http3=true"
       - "--entrypoints.http.http.encodequerysemicolons=true"
       - "--entryPoints.http.http2.maxConcurrentStreams=50"
       - "--entrypoints.https.http.encodequerysemicolons=true"


### PR DESCRIPTION
## Summary
- expose the Traefik HTTPS entrypoint over UDP so HTTP/3 clients can connect
- enable HTTP/3 on the HTTPS entrypoint in the Traefik static configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f60cc99f38832aa3d97f7676c7bb7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reverse-proxy configuration with UDP port mapping for enhanced protocol support.
  * Enabled HTTP/3 to improve connection performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->