### PR TITLE
fix: GitHub user sync to refresh profile fields

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/user/github/GitHubUserSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/user/github/GitHubUserSyncService.java
@@ -52,30 +52,15 @@ public class GitHubUserSyncService {
      * repository or creating a new one.
      *
      * @param ghUser The GitHub user data to process.
-     * @return The updated or newly created User entity, or {@code null} if an error
-     *         occurred during update.
+     * @return The updated or newly created User entity.
      */
     @Transactional
     public User processUser(GHUser ghUser) {
-        var result = userRepository
+        var user = userRepository
             .findById(ghUser.getId())
-            .map(user -> {
-                try {
-                    if (user.getUpdatedAt() == null || user.getUpdatedAt().isBefore(ghUser.getUpdatedAt())) {
-                        return userConverter.update(ghUser, user);
-                    }
-                    return user;
-                } catch (IOException e) {
-                    logger.error("Failed to update repository {}: {}", ghUser.getId(), e.getMessage());
-                    return null;
-                }
-            })
+            .map(existingUser -> userConverter.update(ghUser, existingUser))
             .orElseGet(() -> userConverter.convert(ghUser));
 
-        if (result == null) {
-            return null;
-        }
-
-        return userRepository.save(result);
+        return userRepository.save(user);
     }
 }


### PR DESCRIPTION
## Summary
- always refresh an existing GitHub user's persisted data during sync so profile changes like display-name updates are not skipped when GitHub's `updated_at` timestamp remains unchanged

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Maven wrapper cannot download Maven distribution in the offline execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f8cb0eb11c832aaa1eb92aa247bb85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized user synchronization logic by simplifying the data processing flow and removing unnecessary error handling patterns, resulting in cleaner, more maintainable code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->