### PR TITLE
chore: force GitHub identity provider sync mode

### DIFF
--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -358,7 +358,7 @@ configs:
             "linkOnly": false,
             "hideOnLogin": false,
             "config": {
-              "syncMode": "LEGACY",
+              "syncMode": "FORCE",
               "clientSecret": "${KEYCLOAK_GITHUB_CLIENT_SECRET}",
               "clientId": "${KEYCLOAK_GITHUB_CLIENT_ID}",
               "guiOrder": "1"


### PR DESCRIPTION
## Summary
- set the Keycloak GitHub identity provider sync mode to FORCE so user data refreshes on each login

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68fa70212e88832a91320776cdf86c44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated identity provider configuration for improved synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->