### PR TITLE
chore(application-server): refine Slack leaderboard copy

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/SlackWeeklyLeaderboardTask.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/leaderboard/tasks/SlackWeeklyLeaderboardTask.java
@@ -189,11 +189,7 @@ public class SlackWeeklyLeaderboardTask implements Runnable {
 
             List<LayoutBlock> blocks = buildBlocks(workspace, topReviewers, currentDate, after, before);
             try {
-                slackMessageService.sendMessage(
-                    channelId,
-                    blocks,
-                    "Weekly review highlights"
-                );
+                slackMessageService.sendMessage(channelId, blocks, "Weekly review highlights");
             } catch (IOException | SlackApiException e) {
                 logger.error(
                     "Failed to send scheduled message for workspace {}: {}",


### PR DESCRIPTION
## Summary
- refresh the scheduled Slack leaderboard message copy to be clearer and more direct
- remove workspace slug from subject line while keeping the leaderboard link and top reviewer shoutout concise

## Testing
- not run (not needed for copy-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693895673ff4832abddcbb9d6a7989cc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refreshed Slack messages for weekly review leaderboards with clearer, more consistent headers ("Weekly review highlights").
  * Updated summary and section wording to be more congratulatory and engaging for top reviewers.
  * Improved leaderboard links to include timeframe and team filters so recipients can view a tailored results page.
  
<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->