### PR TITLE
refactor: separate Keycloak relative paths

### DIFF
--- a/docker/preview/compose.shared-infra.yaml
+++ b/docker/preview/compose.shared-infra.yaml
@@ -122,9 +122,10 @@ services:
       # Admin
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_ADMIN_USERNAME:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_ADMIN_PASSWORD:?Required}
-      # Hostname - full URL with path for proper URL generation
-      # Proxy strips /keycloak, but Keycloak generates URLs with it
-      KC_HOSTNAME: https://${PREVIEW_DOMAIN:?Required}/keycloak
+      # Hostname (path is handled by KC_HTTP_RELATIVE_PATH)
+      KC_HOSTNAME: ${PREVIEW_DOMAIN:?Required}
+      # Serve endpoints under /keycloak path (matches KEYCLOAK_INTERNAL_URL)
+      KC_HTTP_RELATIVE_PATH: /keycloak
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
       KC_PROXY_HEADERS: xforwarded


### PR DESCRIPTION
<!--
TITLE FORMAT (required):
  <type>(<scope>): <description>

  Types: feat | fix | docs | refactor | test | chore | ci | perf | revert
  Scopes: webapp | server | ai | webhooks | docs | ci | deps | docker | db
          leaderboard | mentor | profile | workspace | teams | github | notifications
  Breaking: Add ! before colon (feat!: or feat(scope)!:)

  ✓ Good: feat(leaderboard): add weekly ranking filter
  ✗ Bad:  Added weekly ranking filter to leaderboard

BEFORE PUSHING:
  npm run format && npm run check     # Format + lint + typecheck all services

AFTER API CHANGES:
  npm run generate:api                # Regenerate all OpenAPI clients

AFTER DATABASE/ENTITY CHANGES:
  npm run db:draft-changelog          # Generate Liquibase migration
  npm run db:generate-erd-docs        # Update ERD documentation  
  npm run db:generate-models:intelligence-service  # Sync SQLAlchemy models
-->

## Description

<!-- Use "Copilot Summary" button in toolbar above, or write 1-2 sentences. -->
This pull request updates the Keycloak service configuration in the `docker/preview/compose.shared-infra.yaml` file to improve how URLs and endpoint paths are handled. The main change is to separate the hostname and relative path configuration, making it clearer and more flexible.

Keycloak configuration improvements:

* Changed the `KC_HOSTNAME` environment variable to use just the domain (without the `/keycloak` path), and added `KC_HTTP_RELATIVE_PATH` to serve endpoints under the `/keycloak` path, aligning with the internal URL structure.

Fixes # <!-- Link issue if applicable, or delete this line -->

## How to test

<!-- Manual steps to verify, OR "CI covers this" for config/docs changes. -->
Deploy to preview environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Keycloak authentication service configuration to separate hostname and relative path settings for improved configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->