### PR TITLE
fix(docs): configure dynamic base url for surge.sh previews

### DIFF
--- a/.github/workflows/cd-docs-teardown.yml
+++ b/.github/workflows/cd-docs-teardown.yml
@@ -19,11 +19,21 @@ jobs:
   teardown:
     name: Teardown Preview
     runs-on: ubuntu-latest
+    env:
+      PREVIEW_URL: ls1intum-hephaestus-docs-pr-${{ github.event.number }}.surge.sh
     steps:
+      - name: Install Surge
+        run: npm install -g surge
+
       - name: Teardown Surge.sh preview
-        uses: afc163/surge-preview@v1
+        run: surge teardown ${{ env.PREVIEW_URL }} --token ${{ secrets.SURGE_TOKEN }}
+        continue-on-error: true
+
+      - name: Update PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          teardown: true
-          build: echo "Teardown only"
+          header: docs-preview
+          message: |
+            ## 📚 Documentation Preview
+
+            ~~Preview has been removed~~ (PR closed)

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -44,9 +44,10 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Build docs (shared between preview and production)
-  build:
-    name: Build
+  # Build docs for PR preview (baseUrl = '/')
+  build-preview:
+    name: Build (Preview)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -59,63 +60,116 @@ jobs:
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
-      # Docusaurus-specific caching for faster rebuilds
       - name: Cache Docusaurus build
         uses: actions/cache@v4
         with:
           path: |
             docs/.docusaurus
             docs/node_modules/.cache
-          key: ${{ runner.os }}-docusaurus-${{ hashFiles('docs/package-lock.json') }}-${{ hashFiles('docs/**/*.md', 'docs/**/*.mdx', 'docs/**/*.ts') }}
+          key: ${{ runner.os }}-docusaurus-preview-${{ hashFiles('docs/package-lock.json') }}-${{ hashFiles('docs/**/*.md', 'docs/**/*.mdx', 'docs/**/*.ts') }}
           restore-keys: |
-            ${{ runner.os }}-docusaurus-${{ hashFiles('docs/package-lock.json') }}-
-            ${{ runner.os }}-docusaurus-
+            ${{ runner.os }}-docusaurus-preview-${{ hashFiles('docs/package-lock.json') }}-
+            ${{ runner.os }}-docusaurus-preview-
 
       - name: Install dependencies
         run: npm ci --no-audit --progress=false
         working-directory: docs
 
-      - name: Build documentation
+      - name: Build documentation (preview)
+        run: npm run build
+        working-directory: docs
+        env:
+          DOCUSAURUS_BASE_URL: '/'
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-build-preview
+          path: docs/build
+          retention-days: 1
+
+  # Build docs for production (baseUrl = '/Hephaestus/')
+  build-production:
+    name: Build (Production)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Cache Docusaurus build
+        uses: actions/cache@v4
+        with:
+          path: |
+            docs/.docusaurus
+            docs/node_modules/.cache
+          key: ${{ runner.os }}-docusaurus-prod-${{ hashFiles('docs/package-lock.json') }}-${{ hashFiles('docs/**/*.md', 'docs/**/*.mdx', 'docs/**/*.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-docusaurus-prod-${{ hashFiles('docs/package-lock.json') }}-
+            ${{ runner.os }}-docusaurus-prod-
+
+      - name: Install dependencies
+        run: npm ci --no-audit --progress=false
+        working-directory: docs
+
+      - name: Build documentation (production)
         run: npm run build
         working-directory: docs
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: docs-build
+          name: docs-build-production
           path: docs/build
           retention-days: 1
 
-  # PR Preview: Deploy to Surge.sh with comment
+  # PR Preview: Deploy to Surge.sh with custom comment
   preview:
     name: PR Preview
-    needs: build
+    needs: build-preview
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      PREVIEW_URL: ls1intum-hephaestus-docs-pr-${{ github.event.number }}.surge.sh
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: docs-build
+          name: docs-build-preview
           path: docs-build
 
+      - name: Install Surge
+        run: npm install -g surge
+
       - name: Deploy to Surge.sh
-        id: surge
-        uses: afc163/surge-preview@v1
+        run: surge ./docs-build ${{ env.PREVIEW_URL }} --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: docs-build
-          failOnError: false
-          teardown: false
-          build: echo "Build already completed"
+          header: docs-preview
+          message: |
+            ## 📚 Documentation Preview
+
+            This PR includes documentation changes. A preview has been deployed:
+
+            🔗 **[View Docs Preview](https://${{ env.PREVIEW_URL }})**
+
+            <sub>Preview for commit ${{ github.event.pull_request.head.sha }}. Updates automatically on new commits.</sub>
 
   # Teardown handled by cd-docs-teardown.yml (separate workflow for reliability)
 
   # Production: Deploy to GitHub Pages
   deploy:
     name: GitHub Pages
-    needs: build
+    needs: build-production
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
@@ -125,7 +179,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: docs-build
+          name: docs-build-production
           path: docs-build
 
       - name: Upload to GitHub Pages

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -26,7 +26,8 @@ const config: Config = {
   },
 
   url: 'https://ls1intum.github.io',
-  baseUrl: '/Hephaestus/',
+  // PR previews on Surge.sh need '/', production GitHub Pages needs '/Hephaestus/'
+  baseUrl: process.env.DOCUSAURUS_BASE_URL || '/Hephaestus/',
   organizationName: 'ls1intum',
   projectName: 'Hephaestus',
 


### PR DESCRIPTION
## Summary

Fixes the Docusaurus preview deployment issue where the site shows "Your Docusaurus site did not load properly" due to baseUrl mismatch.

## Changes

### 1. Dynamic baseUrl Configuration
- Made `baseUrl` in `docusaurus.config.ts` read from `DOCUSAURUS_BASE_URL` environment variable
- Defaults to `/Hephaestus/` for GitHub Pages production
- Preview builds set `DOCUSAURUS_BASE_URL=/` for Surge.sh

### 2. Custom PR Comment
Replaced the generic `surge-preview` action with:
- Direct `surge` CLI for deployment/teardown
- `marocchino/sticky-pull-request-comment@v2` for a cleaner, branded comment

**New comment format:**
> ## 📚 Documentation Preview
> 
> This PR includes documentation changes. A preview has been deployed:
> 
> 🔗 **[View Docs Preview](https://ls1intum-hephaestus-docs-pr-XXX.surge.sh)**

### 3. Separate Build Jobs
- `build-preview`: Uses `baseUrl: '/'` for Surge.sh
- `build-production`: Uses default `baseUrl: '/Hephaestus/'` for GitHub Pages

## Testing
- [ ] Verify this PR's docs preview loads correctly
- [ ] Verify comment format is clean and branded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized documentation build pipeline with separate workflows for preview and production builds.
  * Enhanced PR preview generation and deployment with improved notification system for contributors.
  * Updated documentation configuration for flexible base URL handling across different deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->