### PR TITLE
fix(webhooks): correct entrypoint path in dockerfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,7 +1542,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4220,7 +4219,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5780,7 +5778,7 @@
     },
     "node_modules/@types/pg": {
       "version": "8.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5790,7 +5788,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5798,7 +5796,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -9234,7 +9232,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -13943,7 +13940,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.6",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -13982,7 +13978,6 @@
     },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.11",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15110,7 +15105,6 @@
     },
     "node_modules/rollup": {
       "version": "4.53.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -17160,7 +17154,6 @@
     },
     "node_modules/vite": {
       "version": "6.4.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/server/webhook-ingest/Dockerfile
+++ b/server/webhook-ingest/Dockerfile
@@ -45,5 +45,5 @@ HEALTHCHECK --interval=30s --timeout=10s --retries=5 --start-period=3s \
 # Use dumb-init as entrypoint for proper signal handling
 # This ensures SIGTERM is properly forwarded to the Node.js process
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "/app/dist/src/index.js"]
+CMD ["node", "/app/dist/index.js"]
 

--- a/server/webhook-ingest/package.json
+++ b/server/webhook-ingest/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc && tsc-alias",
-    "start": "node dist/src/index.js",
+    "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Description

Fixes the webhook-ingest container crash caused by incorrect entrypoint path in the Dockerfile. The CMD referenced `/app/dist/src/index.js` but TypeScript compiles to `/app/dist/index.js`, causing `MODULE_NOT_FOUND` errors on startup.

## How to Test

1. Build the Docker image: `docker build -t webhook-ingest-test server/webhook-ingest/`
2. Verify the container starts: `docker run --rm -e NATS_URL=nats://localhost:4222 -e WEBHOOK_SECRET=this-is-a-test-secret-with-32-chars webhook-ingest-test`
3. Container should attempt NATS connection (expected to fail without NATS) instead of crashing with MODULE_NOT_FOUND

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated webhook service build artifact paths in container and startup configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->