### PR TITLE
chore(config): enable autocontinue for architect agent

### DIFF
--- a/.opencode/agent/architect.md
+++ b/.opencode/agent/architect.md
@@ -1,6 +1,7 @@
 ---
 description: Staff Engineer. Sets direction, provides context, amplifies builders.
 model: google/claude-opus-4-5-thinking-medium
+autocontinue: true
 permission:
   bash: allow
   edit: deny


### PR DESCRIPTION
## Summary
Enables the `autocontinue` capability for the architect agent.

## Changes
- Updates `.opencode/agent/architect.md` to set `autocontinue: true` in the frontmatter.

Note: No experimental tools (LSP, Batch) or additional websearch configurations were enabled, respecting the preference for stable defaults. The standard `websearch` tool remains available as part of the default toolset for the `opencode` provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings for enhanced system behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->