### PR TITLE
feat(webapp): add team hierarchy display with member count rollup modes

### DIFF
--- a/webapp/src/components/admin/AdminTeamsTable.stories.tsx
+++ b/webapp/src/components/admin/AdminTeamsTable.stories.tsx
@@ -35,6 +35,17 @@ const labels = [
 	{ id: 104, name: "good first issue", color: "7057ff", repository: repos[2] },
 ];
 
+/**
+ * Teams with hierarchy structure for testing rollup counts.
+ * - Frontend (root): 2 members (Sarah, Alex)
+ *   - Backend (child): 1 member (Jamie)
+ *   - QA (child, hidden): 0 members
+ *
+ * Rollup counts:
+ * - Frontend: 3 (2 direct + 1 from Backend)
+ * - Backend: 1 (leaf)
+ * - QA: 0 (leaf, hidden)
+ */
 const teams: TeamInfo[] = [
 	{
 		id: 1,
@@ -105,6 +116,14 @@ const teams: TeamInfo[] = [
 	},
 ];
 
+/**
+ * AdminTeamsTable displays teams in a hierarchical tree structure with
+ * search, visibility toggles, and member count modes.
+ *
+ * Use the "Member Count" toggle to switch between:
+ * - **Direct**: Count only the team's own members
+ * - **Include Subteams**: Count unique members from team + all descendants
+ */
 const meta = {
 	component: AdminTeamsTable,
 	parameters: { layout: "centered" },
@@ -129,5 +148,52 @@ const meta = {
 export default meta;
 export type Story = StoryObj<typeof meta>;
 
+/**
+ * Default state with direct member counting.
+ * Toggle the "Include Subteams" button to see rollup counts.
+ */
 export const Default: Story = {};
+
+/**
+ * Loading state with skeleton placeholders.
+ */
 export const Loading: Story = { args: { isLoading: true, teams: [] } };
+
+/**
+ * Deep hierarchy with 3+ levels of nesting.
+ * Shows how member counts roll up through multiple levels.
+ */
+export const DeepHierarchy: Story = {
+	args: {
+		teams: [
+			...teams,
+			{
+				id: 4,
+				name: "API Team",
+				description: "",
+				htmlUrl: "https://github.com/orgs/org/teams/api",
+				organization: "org",
+				privacy: "CLOSED",
+				membershipCount: 2,
+				repoPermissionCount: 1,
+				hidden: false,
+				parentId: 2, // Child of Backend
+				repositories: [],
+				labels: [],
+				members: [
+					{ id: 4, login: "pat", name: "Pat", avatarUrl: "", htmlUrl: "" },
+					{ id: 5, login: "quinn", name: "Quinn", avatarUrl: "", htmlUrl: "" },
+				],
+			},
+		],
+	},
+};
+
+/**
+ * Flat structure with no hierarchy (all root teams).
+ */
+export const FlatStructure: Story = {
+	args: {
+		teams: teams.map((t) => ({ ...t, parentId: undefined })),
+	},
+};

--- a/webapp/src/components/admin/teams/MemberCountModeToggle.stories.tsx
+++ b/webapp/src/components/admin/teams/MemberCountModeToggle.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "storybook/test";
+import { MemberCountModeToggle } from "./MemberCountModeToggle";
+
+const meta = {
+	component: MemberCountModeToggle,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "centered",
+	},
+	argTypes: {
+		mode: {
+			description: 'Member counting mode: "direct" or "rollup"',
+			control: "radio",
+			options: ["direct", "rollup"],
+		},
+		onModeChange: {
+			description: "Callback when mode changes",
+			action: "mode changed",
+		},
+	},
+	args: {
+		onModeChange: fn(),
+	},
+} satisfies Meta<typeof MemberCountModeToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default state with direct member counting mode selected.
+ */
+export const Direct: Story = {
+	args: {
+		mode: "direct",
+	},
+};
+
+/**
+ * Rollup mode selected, showing members from team + all subteams.
+ */
+export const Rollup: Story = {
+	args: {
+		mode: "rollup",
+	},
+};

--- a/webapp/src/components/admin/teams/MemberCountModeToggle.tsx
+++ b/webapp/src/components/admin/teams/MemberCountModeToggle.tsx
@@ -1,0 +1,69 @@
+import { Users, UsersRound } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { MemberCountMode } from "@/lib/team-hierarchy";
+
+export interface MemberCountModeToggleProps {
+	mode: MemberCountMode;
+	onModeChange: (mode: MemberCountMode) => void;
+	className?: string;
+}
+
+/**
+ * Toggle control for switching between direct and rollup member counting modes.
+ *
+ * - **Direct**: Count only team's own members
+ * - **Rollup**: Count unique members from team + all subteams
+ */
+export function MemberCountModeToggle({
+	mode,
+	onModeChange,
+	className = "",
+}: MemberCountModeToggleProps) {
+	return (
+		<div className={`flex flex-col gap-1.5 ${className}`}>
+			<Label>Member Count</Label>
+			<ToggleGroup
+				type="single"
+				value={mode}
+				onValueChange={(value) => {
+					if (value) {
+						onModeChange(value as MemberCountMode);
+					}
+				}}
+				className="justify-start"
+			>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<ToggleGroupItem value="direct" aria-label="Direct members only" className="gap-1.5">
+							<Users className="h-4 w-4" />
+							<span className="hidden sm:inline">Direct</span>
+						</ToggleGroupItem>
+					</TooltipTrigger>
+					<TooltipContent>
+						<p>Count only direct team members</p>
+					</TooltipContent>
+				</Tooltip>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<ToggleGroupItem
+							value="rollup"
+							aria-label="Include subteam members"
+							className="gap-1.5"
+						>
+							<UsersRound className="h-4 w-4" />
+							<span className="hidden sm:inline">Include Subteams</span>
+						</ToggleGroupItem>
+					</TooltipTrigger>
+					<TooltipContent>
+						<p>Count unique members from team + all subteams</p>
+					</TooltipContent>
+				</Tooltip>
+			</ToggleGroup>
+		</div>
+	);
+}
+
+export default MemberCountModeToggle;

--- a/webapp/src/components/admin/teams/TeamCard.stories.tsx
+++ b/webapp/src/components/admin/teams/TeamCard.stories.tsx
@@ -5,11 +5,22 @@ import { TeamCard } from "./TeamCard";
 /**
  * TeamCard shows a team's basic info and a slot for repositories/children.
  * Use it to present a team header with visibility controls.
+ *
+ * Supports member count modes:
+ * - **direct**: Shows only direct team members
+ * - **rollup**: Shows unique members from team + all subteams
  */
 const meta = {
 	component: TeamCard,
 	parameters: { layout: "centered" },
 	tags: ["autodocs"],
+	argTypes: {
+		countMode: {
+			control: "radio",
+			options: ["direct", "rollup"],
+			description: "Member counting mode",
+		},
+	},
 	args: {
 		team: {
 			id: 1,
@@ -38,6 +49,7 @@ const meta = {
 			labels: [],
 		} satisfies TeamInfo,
 		memberCount: 1,
+		countMode: "direct",
 	},
 } satisfies Meta<typeof TeamCard>;
 
@@ -65,6 +77,67 @@ export const Hidden: Story = {
 			labels: [],
 		} satisfies TeamInfo,
 		memberCount: 5,
+		onToggleVisibility: () => {},
+		getCatalogLabels: () => [],
+	},
+};
+
+/**
+ * Rollup mode showing combined member count from team + subteams.
+ * When rollup count differs from direct count, shows "(X direct)" annotation.
+ */
+export const RollupMode: Story = {
+	args: {
+		team: {
+			id: 1,
+			name: "Engineering",
+			hidden: false,
+			membershipCount: 3,
+			repoPermissionCount: 0,
+			members: [
+				{ id: 10, login: "alice", name: "Alice", avatarUrl: "", htmlUrl: "" },
+				{ id: 11, login: "bob", name: "Bob", avatarUrl: "", htmlUrl: "" },
+				{
+					id: 12,
+					login: "charlie",
+					name: "Charlie",
+					avatarUrl: "",
+					htmlUrl: "",
+				},
+			],
+			repositories: [],
+			labels: [],
+		} satisfies TeamInfo,
+		memberCount: 3,
+		rollupMemberCount: 8, // Team has 3 direct + 5 from subteams (with some overlap)
+		countMode: "rollup",
+		onToggleVisibility: () => {},
+		getCatalogLabels: () => [],
+		children: <div className="text-sm text-muted-foreground">Subteams would appear here</div>,
+	},
+};
+
+/**
+ * Rollup mode where all members are direct (no subteam members).
+ */
+export const RollupModeNoSubteamMembers: Story = {
+	args: {
+		team: {
+			id: 1,
+			name: "Leaf Team",
+			hidden: false,
+			membershipCount: 2,
+			repoPermissionCount: 0,
+			members: [
+				{ id: 10, login: "alice", name: "Alice", avatarUrl: "", htmlUrl: "" },
+				{ id: 11, login: "bob", name: "Bob", avatarUrl: "", htmlUrl: "" },
+			],
+			repositories: [],
+			labels: [],
+		} satisfies TeamInfo,
+		memberCount: 2,
+		rollupMemberCount: 2, // Same as direct - no subteam members
+		countMode: "rollup",
 		onToggleVisibility: () => {},
 		getCatalogLabels: () => [],
 	},

--- a/webapp/src/components/admin/teams/TeamTree.stories.tsx
+++ b/webapp/src/components/admin/teams/TeamTree.stories.tsx
@@ -1,18 +1,35 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type { LabelInfo, RepositoryInfo, TeamInfo } from "@/api/types.gen";
+import type { LabelInfo, RepositoryInfo, TeamInfo, UserInfo } from "@/api/types.gen";
 import { TeamTree } from "./TeamTree";
 
 /**
  * TeamTree renders a team with its repositories and nested child teams.
+ * Supports member count modes for displaying direct vs rollup counts.
  */
 const meta = {
 	component: TeamTree,
 	parameters: { layout: "centered" },
 	tags: ["autodocs"],
+	argTypes: {
+		countMode: {
+			control: "radio",
+			options: ["direct", "rollup"],
+			description: "Member counting mode",
+		},
+	},
 } satisfies Meta<typeof TeamTree>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+// Helper to create members
+const createMember = (id: number, login: string): UserInfo => ({
+	id,
+	login,
+	name: login.charAt(0).toUpperCase() + login.slice(1),
+	avatarUrl: "",
+	htmlUrl: `https://github.com/${login}`,
+});
 
 const repoA: RepositoryInfo = {
 	id: 100,
@@ -38,29 +55,22 @@ const bug: LabelInfo = {
 const child: TeamInfo = {
 	id: 2,
 	name: "Frontend",
+	parentId: 1,
 	hidden: false,
-	membershipCount: 0,
+	membershipCount: 2,
 	repoPermissionCount: 0,
 	repositories: [repoB],
 	labels: [],
-	members: [],
+	members: [createMember(102, "charlie"), createMember(103, "diana")],
 };
 
 const parent: TeamInfo = {
 	id: 1,
 	name: "Platform",
 	hidden: false,
-	membershipCount: 1,
+	membershipCount: 2,
 	repoPermissionCount: 1,
-	members: [
-		{
-			id: 10,
-			login: "alice",
-			name: "Alice",
-			avatarUrl: "",
-			htmlUrl: "https://github.com/alice",
-		},
-	],
+	members: [createMember(100, "alice"), createMember(101, "bob")],
 	repositories: [repoA],
 	labels: [bug],
 };
@@ -68,12 +78,93 @@ const parent: TeamInfo = {
 const childrenMap = new Map<number, TeamInfo[]>([[1, [child]]]);
 const displaySet = new Set<number>([1, 2]);
 
+// Member counts: parent has 2 direct, 4 rollup (2 + 2 from child)
+const memberCounts = new Map([
+	[1, { direct: 2, rollup: 4 }],
+	[2, { direct: 2, rollup: 2 }],
+]);
+
 export const Default: Story = {
 	args: {
 		team: parent,
 		childrenMap,
 		displaySet,
 		getCatalogLabels: (repoId: number) => (repoId === 100 ? [bug] : []),
+		onToggleVisibility: () => {},
+		onToggleRepositoryVisibility: () => {},
+	},
+};
+
+/**
+ * Direct mode: Shows only the team's own member count.
+ */
+export const DirectCountMode: Story = {
+	args: {
+		team: parent,
+		childrenMap,
+		displaySet,
+		memberCounts,
+		countMode: "direct",
+		getCatalogLabels: (repoId: number) => (repoId === 100 ? [bug] : []),
+		onToggleVisibility: () => {},
+		onToggleRepositoryVisibility: () => {},
+	},
+};
+
+/**
+ * Rollup mode: Shows unique members from team + all subteams.
+ * Parent shows "4 members (2 direct)" since it has 2 own members
+ * plus 2 unique from the child team.
+ */
+export const RollupCountMode: Story = {
+	args: {
+		team: parent,
+		childrenMap,
+		displaySet,
+		memberCounts,
+		countMode: "rollup",
+		getCatalogLabels: (repoId: number) => (repoId === 100 ? [bug] : []),
+		onToggleVisibility: () => {},
+		onToggleRepositoryVisibility: () => {},
+	},
+};
+
+// Deep hierarchy example: 3 levels
+const grandchild: TeamInfo = {
+	id: 3,
+	name: "React Components",
+	parentId: 2,
+	hidden: false,
+	membershipCount: 1,
+	repoPermissionCount: 0,
+	repositories: [],
+	labels: [],
+	members: [createMember(104, "eve")],
+};
+
+const deepChildrenMap = new Map<number, TeamInfo[]>([
+	[1, [child]],
+	[2, [grandchild]],
+]);
+const deepDisplaySet = new Set<number>([1, 2, 3]);
+const deepMemberCounts = new Map([
+	[1, { direct: 2, rollup: 5 }], // 2 + 2 + 1
+	[2, { direct: 2, rollup: 3 }], // 2 + 1
+	[3, { direct: 1, rollup: 1 }],
+]);
+
+/**
+ * Deep hierarchy: 3 levels of nesting (Platform > Frontend > React Components).
+ * Shows how rollup counts aggregate through the hierarchy.
+ */
+export const DeepHierarchy: Story = {
+	args: {
+		team: parent,
+		childrenMap: deepChildrenMap,
+		displaySet: deepDisplaySet,
+		memberCounts: deepMemberCounts,
+		countMode: "rollup",
+		getCatalogLabels: () => [],
 		onToggleVisibility: () => {},
 		onToggleRepositoryVisibility: () => {},
 	},

--- a/webapp/src/components/admin/teams/TeamTree.tsx
+++ b/webapp/src/components/admin/teams/TeamTree.tsx
@@ -1,4 +1,5 @@
 import type { LabelInfo, TeamInfo } from "@/api/types.gen";
+import type { MemberCountMode } from "@/lib/team-hierarchy";
 import { RepositoryCard } from "./RepositoryCard";
 import { TeamCard } from "./TeamCard";
 
@@ -6,6 +7,10 @@ export interface TeamTreeProps {
 	team: TeamInfo;
 	childrenMap: Map<number, TeamInfo[]>;
 	displaySet: Set<number>;
+	/** Precomputed member counts per team: { direct, rollup } */
+	memberCounts?: Map<number, { direct: number; rollup: number }>;
+	/** Current member count mode */
+	countMode?: MemberCountMode;
 	onToggleVisibility: (teamId: number, hidden: boolean) => void | Promise<void>;
 	onToggleRepositoryVisibility: (
 		teamId: number,
@@ -21,6 +26,8 @@ export function TeamTree({
 	team,
 	childrenMap,
 	displaySet,
+	memberCounts,
+	countMode = "direct",
 	onToggleVisibility,
 	onToggleRepositoryVisibility,
 	onAddLabel,
@@ -28,10 +35,15 @@ export function TeamTree({
 	getCatalogLabels,
 }: TeamTreeProps) {
 	const children = (childrenMap.get(team.id) ?? []).filter((c) => displaySet.has(c.id));
+	const counts = memberCounts?.get(team.id);
+	const directCount = counts?.direct ?? (team.members ?? []).length;
+	const rollupCount = counts?.rollup;
 	return (
 		<TeamCard
 			team={team}
-			memberCount={(team.members ?? []).length}
+			memberCount={directCount}
+			rollupMemberCount={rollupCount}
+			countMode={countMode}
 			onToggleVisibility={(hidden) => onToggleVisibility(team.id, hidden)}
 			getCatalogLabels={getCatalogLabels}
 		>
@@ -67,6 +79,8 @@ export function TeamTree({
 							team={child}
 							childrenMap={childrenMap}
 							displaySet={displaySet}
+							memberCounts={memberCounts}
+							countMode={countMode}
 							onToggleVisibility={onToggleVisibility}
 							onToggleRepositoryVisibility={onToggleRepositoryVisibility}
 							onAddLabel={onAddLabel}

--- a/webapp/src/lib/team-hierarchy.test.ts
+++ b/webapp/src/lib/team-hierarchy.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildChildrenMap,
+	collectRollupMemberIds,
+	computeMemberCounts,
+	findRootTeams,
+	getDescendantIds,
+	getMemberCount,
+	type HierarchyTeam,
+	hasCycle,
+	validateHierarchy,
+} from "./team-hierarchy";
+
+// Helper to create test teams
+function createTeam(id: number, parentId: number | undefined, memberIds: number[]): HierarchyTeam {
+	return {
+		id,
+		parentId,
+		members: memberIds.map((memberId) => ({ id: memberId })),
+	};
+}
+
+describe("team-hierarchy", () => {
+	describe("buildChildrenMap", () => {
+		it("builds correct parent-child mappings", () => {
+			const teams = [
+				createTeam(1, undefined, []),
+				createTeam(2, 1, []),
+				createTeam(3, 1, []),
+				createTeam(4, 2, []),
+			];
+
+			const map = buildChildrenMap(teams);
+
+			expect(map.get(1)?.map((t) => t.id)).toEqual([2, 3]);
+			expect(map.get(2)?.map((t) => t.id)).toEqual([4]);
+			expect(map.has(3)).toBe(false);
+			expect(map.has(4)).toBe(false);
+		});
+
+		it("ignores orphaned parent references", () => {
+			const teams = [
+				createTeam(1, undefined, []),
+				createTeam(2, 99, []), // parent 99 doesn't exist
+			];
+
+			const map = buildChildrenMap(teams);
+
+			expect(map.has(99)).toBe(false);
+			expect(map.has(1)).toBe(false);
+		});
+
+		it("handles empty input", () => {
+			const map = buildChildrenMap([]);
+			expect(map.size).toBe(0);
+		});
+	});
+
+	describe("findRootTeams", () => {
+		it("finds teams without parents", () => {
+			const teams = [
+				createTeam(1, undefined, []),
+				createTeam(2, 1, []),
+				createTeam(3, undefined, []),
+			];
+
+			const roots = findRootTeams(teams);
+
+			expect(roots.map((t) => t.id).sort()).toEqual([1, 3]);
+		});
+
+		it("treats orphaned parents as roots", () => {
+			const teams = [
+				createTeam(1, 99, []), // parent 99 doesn't exist
+				createTeam(2, 1, []),
+			];
+
+			const roots = findRootTeams(teams);
+
+			expect(roots.map((t) => t.id)).toEqual([1]);
+		});
+	});
+
+	describe("hasCycle", () => {
+		it("returns false for valid hierarchy", () => {
+			const teams = [createTeam(1, undefined, []), createTeam(2, 1, []), createTeam(3, 2, [])];
+			const teamsById = new Map(teams.map((t) => [t.id, t]));
+
+			expect(hasCycle(1, teamsById)).toBe(false);
+			expect(hasCycle(2, teamsById)).toBe(false);
+			expect(hasCycle(3, teamsById)).toBe(false);
+		});
+
+		it("detects self-referencing cycle", () => {
+			const teams = [createTeam(1, 1, [])]; // self-reference
+			const teamsById = new Map(teams.map((t) => [t.id, t]));
+
+			expect(hasCycle(1, teamsById)).toBe(true);
+		});
+
+		it("detects two-node cycle", () => {
+			const team1 = createTeam(1, 2, []);
+			const team2 = createTeam(2, 1, []);
+			const teamsById = new Map([
+				[1, team1],
+				[2, team2],
+			]);
+
+			expect(hasCycle(1, teamsById)).toBe(true);
+			expect(hasCycle(2, teamsById)).toBe(true);
+		});
+
+		it("detects multi-node cycle", () => {
+			const team1 = createTeam(1, 3, []);
+			const team2 = createTeam(2, 1, []);
+			const team3 = createTeam(3, 2, []);
+			const teamsById = new Map([
+				[1, team1],
+				[2, team2],
+				[3, team3],
+			]);
+
+			expect(hasCycle(1, teamsById)).toBe(true);
+			expect(hasCycle(2, teamsById)).toBe(true);
+			expect(hasCycle(3, teamsById)).toBe(true);
+		});
+	});
+
+	describe("getDescendantIds", () => {
+		it("returns all descendants", () => {
+			const teams = [
+				createTeam(1, undefined, []),
+				createTeam(2, 1, []),
+				createTeam(3, 1, []),
+				createTeam(4, 2, []),
+				createTeam(5, 4, []),
+			];
+			const childrenMap = buildChildrenMap(teams);
+
+			const descendants = getDescendantIds(1, childrenMap);
+
+			expect([...descendants].sort()).toEqual([2, 3, 4, 5]);
+		});
+
+		it("returns empty set for leaf nodes", () => {
+			const teams = [createTeam(1, undefined, []), createTeam(2, 1, [])];
+			const childrenMap = buildChildrenMap(teams);
+
+			const descendants = getDescendantIds(2, childrenMap);
+
+			expect(descendants.size).toBe(0);
+		});
+
+		it("handles cycles gracefully", () => {
+			// Create a cycle in the children map manually
+			const team1 = createTeam(1, undefined, []);
+			const team2 = createTeam(2, 1, []);
+			const childrenMap = new Map<number, HierarchyTeam[]>();
+			childrenMap.set(1, [team2]);
+			childrenMap.set(2, [team1]); // cycle
+
+			// Should not throw and should not infinite loop
+			const descendants = getDescendantIds(1, childrenMap);
+			expect(descendants.has(2)).toBe(true);
+		});
+	});
+
+	describe("collectRollupMemberIds", () => {
+		it("collects direct members only for leaf team", () => {
+			const teams = [createTeam(1, undefined, [100, 101])];
+			const teamsById = new Map(teams.map((t) => [t.id, t]));
+			const childrenMap = buildChildrenMap(teams);
+
+			const members = collectRollupMemberIds(1, teamsById, childrenMap);
+
+			expect([...members].sort()).toEqual([100, 101]);
+		});
+
+		it("collects unique members from team and descendants", () => {
+			const teams = [
+				createTeam(1, undefined, [100, 101]),
+				createTeam(2, 1, [102, 103]),
+				createTeam(3, 1, [101, 104]), // 101 is duplicate
+			];
+			const teamsById = new Map(teams.map((t) => [t.id, t]));
+			const childrenMap = buildChildrenMap(teams);
+
+			const members = collectRollupMemberIds(1, teamsById, childrenMap);
+
+			// Should have unique members: 100, 101, 102, 103, 104
+			expect([...members].sort()).toEqual([100, 101, 102, 103, 104]);
+		});
+
+		it("prevents double counting across nested levels", () => {
+			const teams = [
+				createTeam(1, undefined, [100]),
+				createTeam(2, 1, [100, 101]), // 100 in both parent and child
+				createTeam(3, 2, [100, 101, 102]), // all duplicates except 102
+			];
+			const teamsById = new Map(teams.map((t) => [t.id, t]));
+			const childrenMap = buildChildrenMap(teams);
+
+			const members = collectRollupMemberIds(1, teamsById, childrenMap);
+
+			expect([...members].sort()).toEqual([100, 101, 102]);
+		});
+
+		it("handles cycles without infinite loop", () => {
+			const team1 = createTeam(1, 2, [100]);
+			const team2 = createTeam(2, 1, [101]);
+			const teamsById = new Map([
+				[1, team1],
+				[2, team2],
+			]);
+			// Manually create children map with cycle
+			const childrenMap = new Map<number, HierarchyTeam[]>();
+			childrenMap.set(1, [team2]);
+			childrenMap.set(2, [team1]);
+
+			const members = collectRollupMemberIds(1, teamsById, childrenMap);
+
+			// Should collect members without infinite loop
+			expect(members.has(100)).toBe(true);
+			expect(members.has(101)).toBe(true);
+		});
+	});
+
+	describe("computeMemberCounts", () => {
+		it("computes both direct and rollup counts", () => {
+			const teams = [
+				createTeam(1, undefined, [100, 101]),
+				createTeam(2, 1, [102]),
+				createTeam(3, 2, [103, 104]),
+			];
+
+			const counts = computeMemberCounts(teams);
+
+			expect(counts.get(1)).toEqual({ direct: 2, rollup: 5 });
+			expect(counts.get(2)).toEqual({ direct: 1, rollup: 3 });
+			expect(counts.get(3)).toEqual({ direct: 2, rollup: 2 });
+		});
+
+		it("handles shared members correctly", () => {
+			const teams = [
+				createTeam(1, undefined, [100]),
+				createTeam(2, 1, [100, 101]), // 100 is shared
+			];
+
+			const counts = computeMemberCounts(teams);
+
+			// Rollup for team 1 should be 2 (100, 101) not 3
+			expect(counts.get(1)).toEqual({ direct: 1, rollup: 2 });
+			expect(counts.get(2)).toEqual({ direct: 2, rollup: 2 });
+		});
+	});
+
+	describe("getMemberCount", () => {
+		it("returns direct count for direct mode", () => {
+			const team = createTeam(1, undefined, [100, 101, 102]);
+
+			const count = getMemberCount(team, "direct");
+
+			expect(count).toBe(3);
+		});
+
+		it("returns rollup count from precomputed map", () => {
+			const team = createTeam(1, undefined, [100]);
+			const memberCounts = new Map([[1, { direct: 1, rollup: 5 }]]);
+
+			const count = getMemberCount(team, "rollup", memberCounts);
+
+			expect(count).toBe(5);
+		});
+
+		it("computes rollup count if teams provided", () => {
+			const teams = [createTeam(1, undefined, [100]), createTeam(2, 1, [101, 102])];
+
+			const count = getMemberCount(teams[0], "rollup", undefined, teams);
+
+			expect(count).toBe(3);
+		});
+
+		it("falls back to direct count if no data available", () => {
+			const team = createTeam(1, undefined, [100, 101]);
+
+			const count = getMemberCount(team, "rollup");
+
+			expect(count).toBe(2); // Falls back to direct
+		});
+	});
+
+	describe("validateHierarchy", () => {
+		it("returns empty array for valid hierarchy", () => {
+			const teams = [createTeam(1, undefined, []), createTeam(2, 1, []), createTeam(3, 2, [])];
+
+			const issues = validateHierarchy(teams);
+
+			expect(issues).toEqual([]);
+		});
+
+		it("detects orphaned parent references", () => {
+			const teams = [createTeam(1, 99, [])];
+
+			const issues = validateHierarchy(teams);
+
+			expect(issues).toContainEqual({
+				teamId: 1,
+				issue: "Parent team 99 not found",
+			});
+		});
+
+		it("detects self-reference", () => {
+			const teams = [createTeam(1, 1, [])];
+
+			const issues = validateHierarchy(teams);
+
+			expect(issues).toContainEqual({
+				teamId: 1,
+				issue: "Team references itself as parent",
+			});
+		});
+
+		it("detects cycles", () => {
+			const teams = [createTeam(1, 2, []), createTeam(2, 1, [])];
+
+			const issues = validateHierarchy(teams);
+
+			// Both teams should report cycle issues
+			expect(issues.filter((i) => i.issue.includes("cycle"))).toHaveLength(2);
+		});
+	});
+
+	describe("real-world scenarios", () => {
+		it("handles deep hierarchy (5+ levels)", () => {
+			const teams = [
+				createTeam(1, undefined, [100]),
+				createTeam(2, 1, [101]),
+				createTeam(3, 2, [102]),
+				createTeam(4, 3, [103]),
+				createTeam(5, 4, [104]),
+				createTeam(6, 5, [105]),
+			];
+
+			const counts = computeMemberCounts(teams);
+
+			expect(counts.get(1)).toEqual({ direct: 1, rollup: 6 });
+			expect(counts.get(6)).toEqual({ direct: 1, rollup: 1 });
+		});
+
+		it("handles wide hierarchy (many siblings)", () => {
+			const teams = [
+				createTeam(1, undefined, [100]),
+				createTeam(2, 1, [101]),
+				createTeam(3, 1, [102]),
+				createTeam(4, 1, [103]),
+				createTeam(5, 1, [104]),
+				createTeam(6, 1, [105]),
+			];
+
+			const counts = computeMemberCounts(teams);
+
+			expect(counts.get(1)).toEqual({ direct: 1, rollup: 6 });
+		});
+
+		it("handles diamond pattern (shared descendants)", () => {
+			// This tests the pattern where a member exists in multiple paths
+			const teams = [
+				createTeam(1, undefined, [100]),
+				createTeam(2, 1, [101]),
+				createTeam(3, 1, [102]),
+				createTeam(4, 2, [103]), // child of 2
+				// Note: true diamond would need multiple parents, which isn't supported
+			];
+
+			const counts = computeMemberCounts(teams);
+
+			expect(counts.get(1)).toEqual({ direct: 1, rollup: 4 });
+		});
+	});
+});

--- a/webapp/src/lib/team-hierarchy.ts
+++ b/webapp/src/lib/team-hierarchy.ts
@@ -1,0 +1,264 @@
+/**
+ * Team hierarchy utilities for managing parent-child relationships,
+ * member counting with rollup modes, and cycle detection.
+ */
+
+/** Minimal team structure needed for hierarchy operations */
+export interface HierarchyTeam {
+	id: number;
+	parentId?: number;
+	members: Array<{ id: number }>;
+}
+
+/** Member counting mode */
+export type MemberCountMode = "direct" | "rollup";
+
+/**
+ * Builds a map from team ID to its direct children.
+ * @param teams - Array of teams with id and parentId
+ * @returns Map from parent ID to array of child teams
+ */
+export function buildChildrenMap<T extends HierarchyTeam>(teams: T[]): Map<number, T[]> {
+	const teamIds = new Set(teams.map((t) => t.id));
+	const map = new Map<number, T[]>();
+
+	for (const team of teams) {
+		const parentId = team.parentId;
+		if (parentId !== undefined && teamIds.has(parentId)) {
+			const children = map.get(parentId) ?? [];
+			children.push(team);
+			map.set(parentId, children);
+		}
+	}
+
+	return map;
+}
+
+/**
+ * Identifies root teams (teams without a valid parent in the dataset).
+ * @param teams - Array of teams
+ * @returns Array of root teams
+ */
+export function findRootTeams<T extends HierarchyTeam>(teams: T[]): T[] {
+	const teamIds = new Set(teams.map((t) => t.id));
+	return teams.filter((t) => t.parentId === undefined || !teamIds.has(t.parentId));
+}
+
+/**
+ * Detects if there's a cycle in the team hierarchy starting from a given team.
+ * Uses Floyd's cycle detection algorithm (tortoise and hare).
+ * @param teamId - Starting team ID
+ * @param teamsById - Map of team ID to team
+ * @returns true if a cycle is detected
+ */
+export function hasCycle<T extends HierarchyTeam>(
+	teamId: number,
+	teamsById: Map<number, T>,
+): boolean {
+	const visited = new Set<number>();
+	let current: number | undefined = teamId;
+
+	while (current !== undefined) {
+		if (visited.has(current)) {
+			return true;
+		}
+		visited.add(current);
+		const team = teamsById.get(current);
+		current = team?.parentId;
+	}
+
+	return false;
+}
+
+/**
+ * Gets all descendant team IDs for a given team, with cycle detection.
+ * @param teamId - Team ID to get descendants for
+ * @param childrenMap - Map from parent ID to children
+ * @param visited - Set of already visited IDs (for cycle detection)
+ * @returns Set of descendant team IDs (not including the team itself)
+ */
+export function getDescendantIds<T extends HierarchyTeam>(
+	teamId: number,
+	childrenMap: Map<number, T[]>,
+	visited: Set<number> = new Set(),
+): Set<number> {
+	const result = new Set<number>();
+
+	// Prevent cycles
+	if (visited.has(teamId)) {
+		return result;
+	}
+	visited.add(teamId);
+
+	const children = childrenMap.get(teamId) ?? [];
+	for (const child of children) {
+		result.add(child.id);
+		const grandchildren = getDescendantIds(child.id, childrenMap, visited);
+		for (const id of grandchildren) {
+			result.add(id);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Collects unique member IDs from a team and all its descendants.
+ * Handles cycles by tracking visited teams.
+ * @param teamId - Team ID to collect members from
+ * @param teamsById - Map of team ID to team
+ * @param childrenMap - Map from parent ID to children
+ * @param visited - Set of already visited team IDs (for cycle detection)
+ * @returns Set of unique member IDs
+ */
+export function collectRollupMemberIds<T extends HierarchyTeam>(
+	teamId: number,
+	teamsById: Map<number, T>,
+	childrenMap: Map<number, T[]>,
+	visited: Set<number> = new Set(),
+): Set<number> {
+	const result = new Set<number>();
+
+	// Prevent cycles
+	if (visited.has(teamId)) {
+		return result;
+	}
+	visited.add(teamId);
+
+	const team = teamsById.get(teamId);
+	if (!team) {
+		return result;
+	}
+
+	// Add direct members
+	for (const member of team.members) {
+		result.add(member.id);
+	}
+
+	// Recursively add members from children
+	const children = childrenMap.get(teamId) ?? [];
+	for (const child of children) {
+		const childMembers = collectRollupMemberIds(child.id, teamsById, childrenMap, visited);
+		for (const id of childMembers) {
+			result.add(id);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Computes member counts for all teams in both direct and rollup modes.
+ * Rollup mode counts unique members from the team and all descendants.
+ * @param teams - Array of teams
+ * @returns Map from team ID to { direct: number, rollup: number }
+ */
+export function computeMemberCounts<T extends HierarchyTeam>(
+	teams: T[],
+): Map<number, { direct: number; rollup: number }> {
+	const teamsById = new Map<number, T>();
+	for (const team of teams) {
+		teamsById.set(team.id, team);
+	}
+
+	const childrenMap = buildChildrenMap(teams);
+	const result = new Map<number, { direct: number; rollup: number }>();
+
+	// Cache for rollup counts to avoid recomputation
+	const rollupCache = new Map<number, Set<number>>();
+
+	const getRollupMembers = (teamId: number): Set<number> => {
+		const cached = rollupCache.get(teamId);
+		if (cached !== undefined) {
+			return cached;
+		}
+
+		const members = collectRollupMemberIds(teamId, teamsById, childrenMap, new Set());
+		rollupCache.set(teamId, members);
+		return members;
+	};
+
+	for (const team of teams) {
+		const direct = team.members.length;
+		const rollup = getRollupMembers(team.id).size;
+		result.set(team.id, { direct, rollup });
+	}
+
+	return result;
+}
+
+/**
+ * Gets the member count for a team based on the selected mode.
+ * @param team - The team to count members for
+ * @param mode - "direct" or "rollup"
+ * @param memberCounts - Precomputed member counts (optional, will compute if not provided)
+ * @param teams - All teams (required if memberCounts not provided)
+ * @returns Member count
+ */
+export function getMemberCount<T extends HierarchyTeam>(
+	team: T,
+	mode: MemberCountMode,
+	memberCounts?: Map<number, { direct: number; rollup: number }>,
+	teams?: T[],
+): number {
+	if (mode === "direct") {
+		return team.members.length;
+	}
+
+	if (memberCounts) {
+		const counts = memberCounts.get(team.id);
+		return counts?.rollup ?? team.members.length;
+	}
+
+	if (teams) {
+		const counts = computeMemberCounts(teams);
+		return counts.get(team.id)?.rollup ?? team.members.length;
+	}
+
+	// Fallback to direct count
+	return team.members.length;
+}
+
+/**
+ * Validates the team hierarchy and returns any issues found.
+ * @param teams - Array of teams to validate
+ * @returns Array of validation issues
+ */
+export function validateHierarchy<T extends HierarchyTeam>(
+	teams: T[],
+): Array<{ teamId: number; issue: string }> {
+	const issues: Array<{ teamId: number; issue: string }> = [];
+	const teamsById = new Map<number, T>();
+
+	for (const team of teams) {
+		teamsById.set(team.id, team);
+	}
+
+	for (const team of teams) {
+		// Check for orphaned parent references
+		if (team.parentId !== undefined && !teamsById.has(team.parentId)) {
+			issues.push({
+				teamId: team.id,
+				issue: `Parent team ${team.parentId} not found`,
+			});
+		}
+
+		// Check for self-reference
+		if (team.parentId === team.id) {
+			issues.push({
+				teamId: team.id,
+				issue: "Team references itself as parent",
+			});
+		}
+
+		// Check for cycles
+		if (hasCycle(team.id, teamsById)) {
+			issues.push({
+				teamId: team.id,
+				issue: "Team is part of a hierarchy cycle",
+			});
+		}
+	}
+
+	return issues;
+}


### PR DESCRIPTION
## Summary

Adds team hierarchy display improvements with member counting rollup modes, addressing the needs outlined in heph-0g4:

- **Team hierarchy visualization**: Uses existing `parentId` relationships to display nested teams
- **Rollup mode toggle**: Switch between "Direct members only" vs "Include subteam members" counting
- **No double-counting**: Rollup mode shows unique members across team + all descendants
- **Cycle detection**: Handles hierarchy loops gracefully without infinite loops
- **Comprehensive tests**: 29 unit tests for hierarchy operations
- **Storybook stories**: Full coverage for visual testing

## Implementation Details

### New Files
- `webapp/src/lib/team-hierarchy.ts` - Core utilities for hierarchy operations
- `webapp/src/lib/team-hierarchy.test.ts` - Comprehensive test suite (29 tests)
- `webapp/src/components/admin/teams/MemberCountModeToggle.tsx` - Toggle component

### Updated Components
- `AdminTeamsTable` - Adds toggle and computes rollup counts
- `TeamCard` - Shows rollup count with "(X direct)" annotation
- `TeamTree` - Passes member counts through hierarchy

### Key Features
1. **Member Count Modes**:
   - **Direct**: Count only the team's own members
   - **Rollup**: Count unique members from team + all subteams (no duplicates)

2. **Visual Feedback**:
   - Different icons for each mode (Users vs UsersRound)
   - Tooltip explaining current mode
   - Shows "(X direct)" when in rollup mode with subteam members

3. **Cycle Safety**:
   - Uses visited set tracking to prevent infinite loops
   - Gracefully handles malformed hierarchies

## How to test

1. Navigate to Admin > Teams
2. Use the "Member Count" toggle to switch between modes
3. Observe how counts change for parent teams with subteams
4. Storybook: View the new stories for `MemberCountModeToggle`, `TeamCard`, `TeamTree`, and `AdminTeamsTable`

## Screenshots

The toggle appears next to the search bar in the admin teams view. When in rollup mode, parent teams show their total unique member count with a visual indicator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a member count mode toggle to switch between direct member counts (team only) and rollup counts (team plus subteams)
  * Team displays now show member counts based on the selected mode with contextual tooltips describing each option

* **Tests**
  * Added comprehensive test coverage for team hierarchy functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->