### PR TITLE
fix(security): allow unauthenticated access to actuator health endpoint + fix release config

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/SecurityConfig.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/SecurityConfig.java
@@ -91,6 +91,8 @@ public class SecurityConfig {
         );
 
         http.authorizeHttpRequests(requests -> {
+            // Actuator endpoints for Docker/K8s health checks and basic info
+            requests.requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll();
             // OpenAPI documentation endpoints (public for spec generation and dev access)
             requests
                 .requestMatchers("/v3/api-docs/**", "/v3/api-docs.yaml", "/swagger-ui/**", "/swagger-ui.html")


### PR DESCRIPTION
## Description

**Actuator Health Fix:**
Allows unauthenticated access to `/actuator/health`, `/actuator/health/**` (liveness/readiness probes), and `/actuator/info` endpoints. This fixes Docker health checks which were failing with 401 Unauthorized.

**Release Config Fix:**
Updates semantic-release configuration to properly trigger releases for:
- `security` scope - Security fixes are critical and must release
- `deps` scope - Production dependency updates include security patches
- `db` scope - Database migrations affect runtime

Previously these scopes incorrectly blocked releases.

## How to Test

1. Deploy and verify `curl http://localhost:8080/actuator/health` returns 200
2. Verify `/actuator/prometheus` still requires authentication
3. Verify a `fix(security): ...` commit triggers a patch release