### PR TITLE
fix(server): use internal url for keycloak admin client

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/KeycloakConfig.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/KeycloakConfig.java
@@ -20,7 +20,7 @@ public class KeycloakConfig {
     @Bean
     public Keycloak keycloakClient() {
         return KeycloakBuilder.builder()
-            .serverUrl(keycloakProperties.url())
+            .serverUrl(keycloakProperties.effectiveInternalUrl())
             .realm(keycloakProperties.realm())
             .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
             .clientId(keycloakProperties.clientId())

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/KeycloakHealthIndicator.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/KeycloakHealthIndicator.java
@@ -48,7 +48,7 @@ public class KeycloakHealthIndicator implements HealthIndicator {
 
     @Override
     public Health health() {
-        String url = keycloakProperties.url();
+        String internalUrl = keycloakProperties.effectiveInternalUrl();
         String realm = keycloakProperties.realm();
         CircuitBreaker.State circuitState = circuitBreaker.getState();
 
@@ -56,7 +56,7 @@ public class KeycloakHealthIndicator implements HealthIndicator {
         if (circuitState == CircuitBreaker.State.OPEN) {
             log.debug("Keycloak health check skipped: circuit breaker is OPEN");
             return Health.down()
-                .withDetail("url", url)
+                .withDetail("url", internalUrl)
                 .withDetail("realm", realm)
                 .withDetail("circuitBreaker", circuitState.name())
                 .withDetail("error", "Circuit breaker is OPEN - Keycloak unavailable")
@@ -69,14 +69,14 @@ public class KeycloakHealthIndicator implements HealthIndicator {
 
             log.debug("Keycloak health check succeeded: realm={}", realm);
             return Health.up()
-                .withDetail("url", url)
+                .withDetail("url", internalUrl)
                 .withDetail("realm", realm)
                 .withDetail("circuitBreaker", circuitState.name())
                 .build();
         } catch (Exception e) {
             log.warn("Keycloak health check failed: realm={}, error={}", realm, e.getMessage());
             return Health.down()
-                .withDetail("url", url)
+                .withDetail("url", internalUrl)
                 .withDetail("realm", realm)
                 .withDetail("circuitBreaker", circuitState.name())
                 .withDetail("error", e.getMessage())


### PR DESCRIPTION
## Summary

- Use `effectiveInternalUrl()` instead of `url()` for Keycloak admin client connections
- Fixes deployment failures where health check fails due to Docker DNS resolution issues

## Problem

In Docker environments, the public domain (`hephaestus.felixdietrich.com`) can resolve to the wrong container because the postfix container has `hostname: ${PREVIEW_DOMAIN}` set, which registers it in Docker's embedded DNS. This caused the Keycloak admin client to connect to postfix instead of the Traefik proxy, resulting in connection failures and unhealthy application-server status.

## Solution

Changed both `KeycloakConfig.java` and `KeycloakHealthIndicator.java` to use `keycloakProperties.effectiveInternalUrl()` which returns the internal URL (`http://keycloak:8080`) when configured, enabling proper container-to-container communication.

## How to Test

Deploy to Coolify test environment - the application-server should now be healthy and all containers should start successfully.