### PR TITLE
fix(server): add cors config to production profile

### DIFF
--- a/server/application-server/src/main/resources/application-prod.yml
+++ b/server/application-server/src/main/resources/application-prod.yml
@@ -31,6 +31,10 @@ spring:
 hephaestus:
     host-url: ${APPLICATION_HOST_URL}
 
+    cors:
+        allowed-origins:
+            - ${APPLICATION_HOST_URL}
+
     webapp:
         url: ${APPLICATION_HOST_URL}
 


### PR DESCRIPTION
## Summary

- Add missing CORS `allowed-origins` config to `application-prod.yml`
- Fix for CORS preflight (OPTIONS) requests returning 403 Forbidden in production deployments (e.g., Coolify)
- Also includes Java formatting fixes from Prettier

## Problem

The production profile (`application-prod.yml`) was missing the `hephaestus.cors.allowed-origins` configuration. The base `application.yml` uses `${CLIENT_HOST}` for CORS, but the Docker compose files (`docker/preview/compose.app.yaml` and `docker/compose.app.yaml`) set `APPLICATION_HOST_URL` instead, not `CLIENT_HOST`.

This meant CORS defaulted to `http://localhost:4200` in production, causing all cross-origin requests from the actual webapp domain to be rejected.

## Solution

Add CORS config to `application-prod.yml` using `APPLICATION_HOST_URL`:

```yaml
hephaestus:
    cors:
        allowed-origins:
            - ${APPLICATION_HOST_URL}
```

This is consistent with how `hephaestus.webapp.url` and `hephaestus.host-url` are already configured in the same file.

## Testing

- [ ] Deploy to Coolify test server and verify workspaces load
- [ ] Verify OPTIONS requests return 200 instead of 403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production configuration with Cross-Origin Resource Sharing (CORS) settings. The application now accepts requests from the configured host URL, improving compatibility with external services and enabling proper cross-origin communication for client applications in production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->