### PR TITLE
fix(server): permit OPTIONS requests for CORS preflight

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/SecurityConfig.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/SecurityConfig.java
@@ -91,6 +91,9 @@ public class SecurityConfig {
         );
 
         http.authorizeHttpRequests(requests -> {
+            // CORS preflight requests must be permitted for cross-origin requests to work.
+            // Without this, OPTIONS requests are rejected with 403 before CORS headers can be added.
+            requests.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
             // Actuator endpoints for Docker/K8s health checks and basic info
             requests.requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll();
             // OpenAPI documentation endpoints (public for spec generation and dev access)


### PR DESCRIPTION
## Summary

Fixes CORS preflight requests returning 403 Forbidden without CORS headers, which prevents the webapp from making authenticated API calls.

## Root Cause Analysis

PR #670 added CORS `allowed-origins` configuration to `application-prod.yml`, but that only tells Spring **which origins are allowed**. It doesn't fix the authorization flow.

**The actual bug**: In Spring Security 6, the `authorizeHttpRequests` chain processes requests BEFORE the CORS filter can add response headers. Since there was no explicit `permitAll()` for OPTIONS requests, they fell through to `anyRequest().authenticated()` which returned 403.

```
Browser                  Spring Security
   |                           |
   |-- OPTIONS /workspaces --->|
   |                           | ❌ No rule matches OPTIONS
   |                           | ❌ Falls to anyRequest().authenticated()
   |                           | ❌ No auth token (preflight can't have one)
   |<-- 403 Forbidden ---------|   (No CORS headers!)
   |                           |
   | Browser blocks actual GET |
```

## The Fix

Add `requests.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()` as the first authorization rule:

```java
http.authorizeHttpRequests(requests -> {
    // CORS preflight requests must be permitted for cross-origin requests to work.
    // Without this, OPTIONS requests are rejected with 403 before CORS headers can be added.
    requests.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
    // ... rest of rules
});
```

Now the flow works:

```
Browser                  Spring Security
   |                           |
   |-- OPTIONS /workspaces --->|
   |                           | ✅ OPTIONS matches permitAll()
   |                           | ✅ CORS filter adds headers
   |<-- 200 OK + CORS headers -|
   |                           |
   |-- GET /workspaces ------->| (with Authorization header)
   |<-- 200 OK + data ---------|
```

## Testing

Verified compilation succeeds. The fix is a standard Spring Security 6 pattern for CORS support.

## Checklist

- [x] Single-line fix with clear comment explaining why
- [x] Follows established patterns in Spring Security documentation
- [x] No security regression (OPTIONS requests don't expose data, only negotiate CORS)