### PR TITLE
perf: add BuildKit cache mounts to all Dockerfiles

### DIFF
--- a/server/application-server/Dockerfile
+++ b/server/application-server/Dockerfile
@@ -1,15 +1,21 @@
+# syntax=docker/dockerfile:1.4
+
 FROM maven:3.9.8-eclipse-temurin-21 AS build
 
 WORKDIR /app
 
 COPY pom.xml .
 
-# This step is to cache dependencies, avoiding re-downloading them every time
-RUN mvn -B -U dependency:go-offline
+# Use BuildKit cache mount for Maven repository to speed up rebuilds
+# Remove -U flag to allow offline resolution from cache
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B dependency:go-offline
 
 COPY src ./src
 
-RUN mvn clean package -DskipTests
+# Use BuildKit cache mount for Maven repository during build
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn clean package -DskipTests
 
 FROM eclipse-temurin:21
 

--- a/server/intelligence-service/Dockerfile
+++ b/server/intelligence-service/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 FROM python:3.13-alpine
 
 RUN apk update && \
@@ -5,10 +7,17 @@ RUN apk update && \
 
 RUN pip install poetry==2.1.1
 
+# Configure Poetry to not create virtualenv (use system Python in container)
+ENV POETRY_VIRTUALENVS_CREATE=false
+
 WORKDIR /app
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --no-root
+
+# Use BuildKit cache mounts for pip and Poetry caches to speed up rebuilds
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pypoetry \
+    poetry install --no-root --no-interaction
 
 COPY app/ ./app
 
-CMD ["poetry", "run",  "fastapi", "run", "app/main.py", "--port", "5000"]
+CMD ["fastapi", "run", "app/main.py", "--port", "5000"]

--- a/server/webhook-ingest/Dockerfile
+++ b/server/webhook-ingest/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 FROM python:3.13-alpine
 
 # For healthcheck
@@ -5,10 +7,17 @@ RUN apk add --no-cache curl
 
 RUN pip install poetry==2.1.1
 
+# Configure Poetry to not create virtualenv (use system Python in container)
+ENV POETRY_VIRTUALENVS_CREATE=false
+
 WORKDIR /app
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --no-root
+
+# Use BuildKit cache mounts for pip and Poetry caches to speed up rebuilds
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pypoetry \
+    poetry install --no-root --no-interaction
 
 COPY app/ ./app
 
-CMD ["poetry", "run",  "fastapi", "run", "app/main.py", "--port", "4200"]
+CMD ["fastapi", "run", "app/main.py", "--port", "4200"]

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 # Stage 1: Build the React application
 FROM node:22-alpine AS build
 
@@ -6,7 +8,9 @@ WORKDIR /app
 # Copy and install dependencies early to leverage Docker layer caching
 COPY package.json package-lock.json* /app/
 
-RUN npm ci
+# Use BuildKit cache mount for npm cache to speed up rebuilds
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --prefer-offline
 
 # Copy the rest of the application code
 COPY ./ /app/


### PR DESCRIPTION
## Summary

- Add BuildKit cache mounts to all 4 Dockerfiles to persist dependency caches across builds
- Expected to reduce rebuild times from ~4-8 minutes to seconds when dependencies haven't changed

## Motivation

Deployment logs from Coolify showed builds taking 4-8+ minutes, with the majority of time spent on:
- `npm install`: ~148 seconds
- Maven `dependency:go-offline`: ~68 seconds  
- Python/Poetry installs: ~25 seconds each

Without BuildKit cache mounts, every build downloads all dependencies from scratch, even when nothing has changed.

## Changes

### All Dockerfiles
- Add `# syntax=docker/dockerfile:1.4` directive to enable BuildKit features

### webapp/Dockerfile (Node.js)
- Cache npm packages in `/root/.npm` via `--mount=type=cache`
- Add `--prefer-offline` flag to use cached packages when available

### application-server/Dockerfile (Maven/Java)
- Cache Maven repository in `/root/.m2` via `--mount=type=cache`
- Remove `-U` (force updates) flag to allow offline resolution from cache

### intelligence-service/Dockerfile & webhook-ingest/Dockerfile (Python/Poetry)
- Cache pip packages in `/root/.cache/pip`
- Cache Poetry packages in `/root/.cache/pypoetry`
- Set `POETRY_VIRTUALENVS_CREATE=false` (virtualenvs are unnecessary in containers)
- Run `fastapi` directly instead of via `poetry run` (simpler with system Python)

## Testing

All 4 Dockerfiles were built and verified locally:
1. First build: Full dependency download (normal time)
2. Second build: All steps cached, completes in ~2-3 seconds

```
#10 [stage-0 6/7] RUN --mount=type=cache,target=/root/.cache/pip ...
#10 CACHED
```

## Note on Coolify

For these cache mounts to be effective in Coolify, ensure:
1. BuildKit is enabled (should be by default in modern Docker)
2. The build cache volume is persisted between deployments

---

**Checklist**
- [x] Dockerfiles build successfully
- [x] Cache mounts verified working locally
- [x] No changes to application logic