### PR TITLE
fix(server): use consistent APPLICATION_HOST_URL env var for CORS

### DIFF
--- a/server/application-server/src/main/resources/application.yml
+++ b/server/application-server/src/main/resources/application.yml
@@ -249,10 +249,10 @@ hephaestus:
 
     cors:
         allowed-origins:
-            - ${CLIENT_HOST:http://localhost:4200}
+            - ${APPLICATION_HOST_URL:http://localhost:4200}
 
     webapp:
-        url: ${CLIENT_HOST:http://localhost:4200}
+        url: ${APPLICATION_HOST_URL:http://localhost:4200}
 
     leaderboard:
         schedule:


### PR DESCRIPTION
## Summary

Fixes CORS still failing after PRs #670 and #673 because of inconsistent environment variable names.

## Root Cause

The CORS configuration used different environment variables:

| File | Variable | Default |
|------|----------|---------|
| `application.yml` | `CLIENT_HOST` | `http://localhost:4200` |
| `application-prod.yml` | `APPLICATION_HOST_URL` | (none) |

In production:
- `CLIENT_HOST` is NOT set
- `APPLICATION_HOST_URL` IS set to `https://hephaestus.felixdietrich.com`

Because `application.yml` had a default value, Spring used `http://localhost:4200` instead of looking at the prod profile override. This caused:

```
curl -X OPTIONS ... -H "Origin: https://hephaestus.felixdietrich.com"
< HTTP/1.1 403
Invalid CORS request
```

But localhost worked fine:
```
curl -X OPTIONS ... -H "Origin: http://localhost:4200"  
< HTTP/1.1 200
< Access-Control-Allow-Origin: http://localhost:4200
```

## The Fix

Standardize on `APPLICATION_HOST_URL` in both files:

```yaml
# application.yml (base config - for local dev)
cors:
    allowed-origins:
        - ${APPLICATION_HOST_URL:http://localhost:4200}  # default for local dev

# application-prod.yml (prod config)
cors:
    allowed-origins:
        - ${APPLICATION_HOST_URL}  # uses env var, no default needed
```

Now when `APPLICATION_HOST_URL=https://hephaestus.felixdietrich.com` is set, both configs resolve to the same correct value.

## Testing

After deployment, verify with:
```bash
curl -v -X OPTIONS https://api.hephaestus.felixdietrich.com/workspaces \
  -H "Origin: https://hephaestus.felixdietrich.com" \
  -H "Access-Control-Request-Method: GET"

# Should return 200 with Access-Control-Allow-Origin header
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration environment variable references for host URL settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->