### PR TITLE
docs(config): use mvn instead of ./mvnw in agent-facing docs

### DIFF
--- a/.claude/skills/fix-ci/SKILL.md
+++ b/.claude/skills/fix-ci/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - Bash(gh *)
   - Bash(git *)
   - Bash(npm *)
-  - Bash(./mvnw *)
+  - Bash(mvn *)
   - Read
   - Grep
   - Glob
@@ -69,7 +69,7 @@ PAGER=cat gh api repos/$OWNER/$REPO/actions/jobs/$JOB_ID/logs 2>&1 | tail -100
 | Check Name | Likely Cause | Fix Command |
 |------------|--------------|-------------|
 | `docs-quality` | Markdown lint errors | `npm run lint:md` in `docs/` |
-| `application-server-quality` | Java compile/test failure | `./mvnw verify` |
+| `application-server-quality` | Java compile/test failure | `mvn verify` |
 | `webapp-quality` | TypeScript/lint errors | `npm run check` |
 | `openapi-validation` | Stale API specs | `npm run generate:api:application-server:specs` |
 | `database-*-validation` | Stale DB docs/models | `npm run db:generate-erd-docs` |

--- a/.github/copilot-environment.yml
+++ b/.github/copilot-environment.yml
@@ -66,11 +66,9 @@ preinstall: |
     echo "ℹ️ No .beads/issues.jsonl found, skipping bd init (not a beads-enabled project)"
   fi
   
-  # Verify Maven wrapper is executable
-  echo "✅ Verifying Maven wrapper..."
-  chmod +x server/application-server/mvnw
-  cd server/application-server && ./mvnw --version
-  cd ../..
+  # Verify Maven is available
+  echo "✅ Verifying Maven..."
+  mvn --version || apt-get install -y maven && mvn --version
   
   echo "✅ Environment setup complete!"
 

--- a/.github/prompts/fix-ci.prompt.md
+++ b/.github/prompts/fix-ci.prompt.md
@@ -55,7 +55,7 @@ PAGER=cat gh api repos/$OWNER/$REPO/actions/jobs/$JOB_ID/logs 2>&1 | tail -100
 | Check Name | Likely Cause | Fix Command |
 |------------|--------------|-------------|
 | `docs-quality` | Markdown lint errors | `npm run lint:md` in `docs/` |
-| `application-server-quality` | Java compile/test failure | `./mvnw verify` |
+| `application-server-quality` | Java compile/test failure | `mvn verify` |
 | `webapp-quality` | TypeScript/lint errors | `npm run check` |
 | `openapi-validation` | Stale API specs | `npm run generate:api:application-server:specs` |
 | `database-*-validation` | Stale DB docs/models | `npm run db:generate-erd-docs` |

--- a/.opencode/commands/fix-ci.md
+++ b/.opencode/commands/fix-ci.md
@@ -55,7 +55,7 @@ PAGER=cat gh api repos/$OWNER/$REPO/actions/jobs/$JOB_ID/logs 2>&1 | tail -100
 | Check Name | Likely Cause | Fix Command |
 |------------|--------------|-------------|
 | `docs-quality` | Markdown lint errors | `npm run lint:md` in `docs/` |
-| `application-server-quality` | Java compile/test failure | `./mvnw verify` |
+| `application-server-quality` | Java compile/test failure | `mvn verify` |
 | `webapp-quality` | TypeScript/lint errors | `npm run check` |
 | `openapi-validation` | Stale API specs | `npm run generate:api:application-server:specs` |
 | `database-*-validation` | Stale DB docs/models | `npm run db:generate-erd-docs` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ bd sync               # Force sync with JSONL
 ## 2. Toolchain & environment prerequisites
 
 - **Node.js**: Use the exact version from `.node-version` (currently 22.10.0). Stick with npm—the repo maintains `package-lock.json` and uses npm workspaces. The intelligence-service and webhook-ingest are TypeScript services that use npm.
-- **Java**: JDK 21 (see `pom.xml`). Maven wrapper is checked in; **always run builds through `./mvnw`** to ensure consistent Maven versions.
+- **Java**: JDK 21 (see `pom.xml`). Run builds with `mvn` from `server/application-server/`.
 - **Docker & Docker Compose**: Required for database helper scripts (`scripts/db-utils.sh`) and for spinning up Postgres/Keycloak/NATS locally.
 - **Databases**: Default PostgreSQL DSN is `postgresql://root:root@localhost:5432/hephaestus`. The database helpers spin this up for you via Docker.
 - **Environment variables**: When generating intelligence service OpenAPI specs locally, set `MODEL_NAME=fake:model` and `DETECTION_MODEL_NAME=fake:model` (the service settings expect a provider-qualified model name).
@@ -178,7 +178,7 @@ Run the relevant commands locally before opening a PR:
 | Webapp tests | `npm run test:webapp` |
 | Webapp typecheck | `npm run typecheck:webapp` |
 | Webapp Storybook | `npm -w webapp run build-storybook` |
-| Application-server tests | **Three test tiers:** <br>• `./mvnw test` runs unit tests (`@Tag("unit")`) <br>• `./mvnw verify` runs unit + integration tests (`@Tag("integration")`) <br>• `./mvnw test -Plive-tests` runs live GitHub API tests (`@Tag("live")`) <br><br>Live tests require GitHub App credentials configured in `application-live-local.yml` (gitignored). The Maven profile is the single guard—tests only run when explicitly activated. |
+| Application-server tests | **Three test tiers:** <br>• `mvn test` runs unit tests (`@Tag("unit")`) <br>• `mvn verify` runs unit + integration tests (`@Tag("integration")`) <br>• `mvn test -Plive-tests` runs live GitHub API tests (`@Tag("live")`) <br><br>Live tests require GitHub App credentials configured in `application-live-local.yml` (gitignored). The Maven profile is the single guard—tests only run when explicitly activated. |
 
 **Script naming conventions:**
 
@@ -198,7 +198,7 @@ We rely heavily on generated artifacts. Never hand-edit these directories—rege
 
 | Artifact | Source command |
 | --- | --- |
-| `server/application-server/openapi.yaml` | `npm run generate:api:application-server:specs` (runs `./mvnw verify -DskipTests=true -Dapp.profiles=specs`). |
+| `server/application-server/openapi.yaml` | `npm run generate:api:application-server:specs` (runs `mvn verify -DskipTests=true -Dapp.profiles=specs`). |
 | `webapp/src/api/**/*`, `webapp/src/api/@tanstack/react-query.gen.ts`, `webapp/src/api/client.gen.ts`, `webapp/src/api/types.gen.ts` | `npm run generate:api:application-server:client` (wraps `npm -w webapp run openapi-ts`). |
 | `server/application-server/src/main/java/de/tum/in/www1/hephaestus/intelligenceservice/**` | `npm run generate:api:intelligence-service:client` (OpenAPI Generator CLI). |
 | `server/intelligence-service/openapi.yaml` | `npm run generate:api:intelligence-service:specs` (runs `npm -w server/intelligence-service run openapi:export`). |

--- a/server/application-server/AGENTS.md
+++ b/server/application-server/AGENTS.md
@@ -6,17 +6,17 @@ Spring Boot 3.5 backend providing the REST API for Hephaestus.
 
 | Task | Command |
 |------|---------|
-| Run locally | `./mvnw spring-boot:run` |
-| Unit tests | `./mvnw test` |
-| Integration tests | `./mvnw verify` |
-| Live GitHub tests | `./mvnw test -Plive-tests` |
+| Run locally | `mvn spring-boot:run` |
+| Unit tests | `mvn test` |
+| Integration tests | `mvn verify` |
+| Live GitHub tests | `mvn test -Plive-tests` |
 | Format | `npm run format:java` |
 | Generate OpenAPI | `npm run generate:api:application-server:specs` |
 
 ## Boundaries
 
 ### Always
-- Run `./mvnw test` before committing
+- Run `mvn test` before committing
 - Use constructor injection (via `@RequiredArgsConstructor`)
 - Return `ResponseEntity` with proper status codes
 - Tag tests appropriately (`@Tag("unit")`, etc.)
@@ -111,9 +111,9 @@ public record UserDTO(
 
 | Tag | Purpose | Base Class | Command |
 |-----|---------|------------|---------|
-| `@Tag("unit")` | Fast, no Spring context | `BaseUnitTest` | `./mvnw test` |
-| `@Tag("integration")` | Full Spring Boot + Testcontainers | `BaseIntegrationTest` | `./mvnw verify` |
-| `@Tag("live")` | Real GitHub API calls | - | `./mvnw test -Plive-tests` |
+| `@Tag("unit")` | Fast, no Spring context | `BaseUnitTest` | `mvn test` |
+| `@Tag("integration")` | Full Spring Boot + Testcontainers | `BaseIntegrationTest` | `mvn verify` |
+| `@Tag("live")` | Real GitHub API calls | - | `mvn test -Plive-tests` |
 
 ### Test Structure (AAA Pattern)
 


### PR DESCRIPTION
## Summary

- Simplify Maven commands in agent-facing documentation by using `mvn` directly instead of `./mvnw`
- Scoped to files AI agents read (AGENTS.md, skills, prompts, copilot config)
- Keeps `./mvnw` in CI, scripts, and contributor docs for reproducibility

## Rationale

Per [Apache Maven docs](https://maven.apache.org/tools/wrapper/) and [GitHub Actions docs](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven), the Maven wrapper is a convenience feature, not a mandate. For agents in environments with Maven installed, `mvn` is simpler (no `./` prefix, no permission issues).

## Test plan

- [x] Verified `mvn test` works identically to `./mvnw test`
- [x] Only agent-facing files modified (CI, scripts, contributor docs unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build commands across CI/CD guides and troubleshooting documentation to use system Maven instead of the Maven wrapper.
  * Simplified build invocation guidance and removed directory navigation requirements for improved clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->