### PR TITLE
fix(db): accept old Liquibase checksum for wipe-gitprovider changeset

### DIFF
--- a/server/application-server/src/main/resources/db/changelog/1768089179000_changelog.xml
+++ b/server/application-server/src/main/resources/db/changelog/1768089179000_changelog.xml
@@ -2210,6 +2210,8 @@
     -->
 
     <changeSet author="FelixTJDietrich" id="1768089179000-wipe-gitprovider-for-resync">
+        <!-- Accept the old checksum from before the FK drop/recreate fix was added -->
+        <validCheckSum>9:d597463d692611558a615031ebe54e5d</validCheckSum>
         <comment>
             Wipe all gitprovider data for fresh resync from GitHub.
             Users are preserved (stable GitHub IDs).


### PR DESCRIPTION
## Description

The staging application server is crash-looping because the changeset `1768089179000-wipe-gitprovider-for-resync` was modified after it was already applied to the staging database. Specifically, commit ee51df1fd added FK drop/recreate logic around the organization truncation, which changed the Liquibase checksum.

This PR adds a `validCheckSum` element to accept the old checksum (`9:d597463d692611558a615031ebe54e5d`) so Liquibase validates successfully on the staging database where the original version was already applied.

## How to Test

After deploying, verify the `app-application-server-1` container starts and becomes healthy on staging:
```
sudo docker ps --filter name=app-application-server-1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema validation to maintain consistency with existing migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->