### PR TITLE
fix(ai): treat empty env strings as unset for optional fields

### DIFF
--- a/server/intelligence-service/src/env.ts
+++ b/server/intelligence-service/src/env.ts
@@ -15,6 +15,24 @@ expand(
 	}),
 );
 
+/**
+ * Optional string env var that treats empty strings as unset.
+ *
+ * Docker Compose and Kubernetes set env vars to "" when declared but not assigned.
+ * Zod treats "" as present (not undefined), so `.min(1).optional()` rejects it.
+ * This helper normalizes "" → undefined before validation so the field behaves
+ * as truly optional regardless of how the orchestrator represents "unset."
+ */
+const optionalString = z.preprocess(
+	(v) => (v === "" ? undefined : v),
+	z.string().min(1).optional(),
+);
+
+const optionalUrl = z.preprocess(
+	(v) => (v === "" ? undefined : v),
+	z.string().min(1).url().optional(),
+);
+
 const EnvSchema = z
 	.object({
 		NODE_ENV: z.string().default("development"),
@@ -36,18 +54,18 @@ const EnvSchema = z
 		VERBOSE_LOG_FILE: z.string().default("logs/verbose.log"),
 
 		// LLM Providers
-		OPENAI_API_KEY: z.string().min(1).optional(),
-		AZURE_RESOURCE_NAME: z.string().min(1).optional(), // Just the resource name (e.g., "myresource")
-		AZURE_API_KEY: z.string().min(1).optional(),
+		OPENAI_API_KEY: optionalString,
+		AZURE_RESOURCE_NAME: optionalString, // Just the resource name (e.g., "myresource")
+		AZURE_API_KEY: optionalString,
 
 		// Models
 		MODEL_NAME: z.string().min(1).default("openai:gpt-4o-mini"),
 		DETECTION_MODEL_NAME: z.string().min(1).default("openai:gpt-4o-mini"),
 
 		// LangFuse (optional)
-		LANGFUSE_SECRET_KEY: z.string().min(1).optional(),
-		LANGFUSE_PUBLIC_KEY: z.string().min(1).optional(),
-		LANGFUSE_BASE_URL: z.string().min(1).url().optional(),
+		LANGFUSE_SECRET_KEY: optionalString,
+		LANGFUSE_PUBLIC_KEY: optionalString,
+		LANGFUSE_BASE_URL: optionalUrl,
 	})
 	.superRefine((val, ctx) => {
 		const parseProvider = (modelName: string) => {


### PR DESCRIPTION
## Description

The intelligence-service on production is crash-looping because Langfuse env vars are set to empty strings (`""`) in the Docker Compose config. Zod treats `""` as present (not `undefined`), so `.min(1).optional()` rejects it at startup.

This adds `z.preprocess` helpers that normalize `""` → `undefined` for the 6 optional string fields (OPENAI_API_KEY, AZURE_RESOURCE_NAME, AZURE_API_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_PUBLIC_KEY, LANGFUSE_BASE_URL). Required fields like DATABASE_URL are intentionally NOT affected — an empty string there should still fail loud.

## How to Test

1. Set `LANGFUSE_SECRET_KEY=""` in environment → service should start without error (field treated as unset)
2. Omit `LANGFUSE_SECRET_KEY` entirely → same behavior as before (field is undefined, optional passes)
3. Set `LANGFUSE_SECRET_KEY="real-key"` → same behavior as before (field is present, min(1) passes)
4. CI covers lint/typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced flexibility in environment configuration by allowing empty string values for optional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->