### PR TITLE
fix(profile): use static Tailwind classes for league badge background

### DIFF
--- a/webapp/src/components/profile/ProfileHeader.tsx
+++ b/webapp/src/components/profile/ProfileHeader.tsx
@@ -35,6 +35,14 @@ export function ProfileHeader({
 	const rawTier = getLeagueTier(leaguePoints);
 	const leagueTier = rawTier === "none" ? "bronze" : rawTier;
 
+	const leagueBgColor = {
+		bronze: "bg-league-bronze",
+		silver: "bg-league-silver",
+		gold: "bg-league-gold",
+		diamond: "bg-league-diamond",
+		master: "bg-league-master",
+	}[leagueTier];
+
 	return (
 		<div className="flex items-start justify-between gap-6 mx-8">
 			{/* Left section: Avatar + User Info + XP */}
@@ -64,7 +72,7 @@ export function ProfileHeader({
 										<div
 											className={cn(
 												"absolute -bottom-1 -right-1 flex size-7 items-center justify-center rounded-full border-2 border-background text-primary-foreground font-bold text-xs",
-												`bg-league-${leagueTier}`,
+												leagueBgColor,
 											)}
 										/>
 									}


### PR DESCRIPTION
## Description

Dynamic class interpolation (`bg-league-${leagueTier}`) is invisible to Tailwind's JIT scanner, so the utility was never emitted and the level badge on the profile page rendered with a transparent background. This replaces the dynamic string with a static lookup map so all five `bg-league-*` classes are statically analysable.

## How to Test

- Open the profile page for a user with master league points (≥2000)
- Verify the level badge (bottom-right of avatar) shows a pink/magenta background instead of transparent
- Check other league tiers (bronze, silver, gold, diamond) also render colored badges
- Alternatively, open Storybook → ProfileHeader stories (BronzeLeague through MasterLeague) and verify all badges have colored backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)