### PR TITLE
fix(gitprovider): eliminate false-positive overflow warnings in paginated sync services

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuedependency/github/GitHubIssueDependencySyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuedependency/github/GitHubIssueDependencySyncService.java
@@ -420,15 +420,10 @@ public class GitHubIssueDependencySyncService {
             totalSynced += self.processIssueDependenciesPage(issueConnection, repo, scopeId);
         }
 
-        // Check for overflow
-        if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
-                "issues",
-                totalSynced,
-                reportedTotalCount,
-                "repoName=" + safeNameWithOwner
-            );
-        }
+        // Note: no overflow check here — totalSynced counts only issues that have
+        // dependency relationships (trackedIssues/closingIssuesReferences), while
+        // reportedTotalCount is the total issue count for the repository.
+        // Comparing them would always produce false-positive overflow warnings.
 
         return totalSynced;
     }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/project/github/GitHubProjectItemSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/project/github/GitHubProjectItemSyncService.java
@@ -142,6 +142,7 @@ public class GitHubProjectItemSyncService {
         HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
 
         int totalSynced = 0;
+        int totalFetched = 0;
         int reportedTotalCount = -1;
         String cursor = startCursor;
         boolean hasMore = true;
@@ -239,6 +240,8 @@ public class GitHubProjectItemSyncService {
                     break;
                 }
 
+                totalFetched += connection.getNodes().size();
+
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
@@ -283,11 +286,13 @@ public class GitHubProjectItemSyncService {
             }
         }
 
-        // Check for overflow
+        // Check for overflow: compare totalFetched (raw API node count) vs reportedTotalCount.
+        // We use totalFetched instead of totalSynced because some project items are legitimately
+        // filtered out during processing (e.g., items with null DTO conversions).
         if (reportedTotalCount >= 0) {
             GraphQlConnectionOverflowDetector.check(
                 "projectItems",
-                totalSynced,
+                totalFetched,
                 reportedTotalCount,
                 "itemNodeId=" + issueNodeId
             );

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewSyncService.java
@@ -190,6 +190,7 @@ public class GitHubPullRequestReviewSyncService {
         HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
 
         int totalSynced = 0;
+        int totalFetched = 0;
         int reportedTotalCount = -1;
         String cursor = startCursor;
         boolean hasMore = true;
@@ -319,6 +320,8 @@ public class GitHubPullRequestReviewSyncService {
                     break;
                 }
 
+                totalFetched += connection.getNodes().size();
+
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
@@ -390,11 +393,13 @@ public class GitHubPullRequestReviewSyncService {
             }
         }
 
-        // Check for overflow: did we fetch fewer items than GitHub reported?
+        // Check for overflow: compare totalFetched (raw API node count) vs reportedTotalCount.
+        // We use totalFetched instead of totalSynced because some reviews are legitimately
+        // filtered out during processing (e.g., bot reviews, dismissed reviews returning null DTOs).
         if (reportedTotalCount >= 0) {
             GraphQlConnectionOverflowDetector.check(
                 "reviews",
-                totalSynced,
+                totalFetched,
                 reportedTotalCount,
                 safeNameWithOwner + " PR #" + pullRequest.getNumber()
             );

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
@@ -145,6 +145,7 @@ public class GitHubPullRequestReviewCommentSyncService {
         int retryAttempt = 0;
         try {
             int totalSynced = 0;
+            int totalFetched = 0;
             String cursor = null;
             boolean hasNextPage = true;
             int pageCount = 0;
@@ -263,6 +264,8 @@ public class GitHubPullRequestReviewCommentSyncService {
                     break;
                 }
 
+                totalFetched += response.getNodes().size();
+
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = response.getTotalCount();
                 }
@@ -278,11 +281,13 @@ public class GitHubPullRequestReviewCommentSyncService {
                 retryAttempt = 0;
             }
 
-            // Check for overflow
+            // Check for overflow: compare totalFetched (raw API node count) vs reportedTotalCount.
+            // We use totalFetched instead of totalSynced because some threads are legitimately
+            // filtered out during processing (e.g., threads with no persistable comments).
             if (reportedTotalCount >= 0) {
                 GraphQlConnectionOverflowDetector.check(
                     "reviewThreads",
-                    totalSynced,
+                    totalFetched,
                     reportedTotalCount,
                     "prNumber=" + pullRequest.getNumber()
                 );
@@ -1050,6 +1055,7 @@ public class GitHubPullRequestReviewCommentSyncService {
 
         try {
             int totalSynced = 0;
+            int totalFetched = 0;
             String cursor = startCursor;
             boolean hasNextPage = true;
             int pageCount = 0;
@@ -1143,6 +1149,8 @@ public class GitHubPullRequestReviewCommentSyncService {
                     break;
                 }
 
+                totalFetched += response.getNodes().size();
+
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = response.getTotalCount();
                 }
@@ -1157,11 +1165,13 @@ public class GitHubPullRequestReviewCommentSyncService {
                 cursor = pageInfo != null ? pageInfo.getEndCursor() : null;
             }
 
-            // Check for overflow
+            // Check for overflow: compare totalFetched (raw API node count) vs reportedTotalCount.
+            // We use totalFetched instead of totalSynced because some threads are legitimately
+            // filtered out during processing (e.g., threads with no persistable comments).
             if (reportedTotalCount >= 0) {
                 GraphQlConnectionOverflowDetector.check(
                     "reviewThreads",
-                    totalSynced,
+                    totalFetched,
                     reportedTotalCount,
                     "prNumber=" + pullRequest.getNumber()
                 );


### PR DESCRIPTION
## Description

Fixes ~259 false-positive overflow detector warnings per sync cycle on production. The overflow detector compared `totalSynced` (items persisted after filtering/processing) against `reportedTotalCount` (API-reported total), but these numbers legitimately differ because items are filtered out during processing (null DTO conversions, bot reviews, dismissed reviews, etc.).

**Changes:**
- **`PullRequestReviewSyncService`**: Track `totalFetched` (raw API node count) separately from `totalSynced`, use `totalFetched` in overflow check
- **`PullRequestReviewCommentSyncService`**: Same fix for both overflow checks (primary sync + remaining thread sync)
- **`GitHubProjectItemSyncService`**: Same fix
- **`GitHubIssueDependencySyncService`**: Removed the overflow check entirely — it compared dependency count vs total issue count, which is fundamentally wrong

## How to Test

CI covers this. The fix can be verified on production after deployment by checking that the ~259 overflow WARN lines per sync cycle disappear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Enhanced GitHub synchronization overflow detection for issue dependencies, project items, pull request reviews, and review comments.
* Corrected overflow checks to use accurate API fetch counts, preventing false positives when items are filtered during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->