### PR TITLE
fix(gitprovider): workaround for GitLab includeSubgroups bug dropping direct projects

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/organization/gitlab/GitLabGroupSyncService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/organization/gitlab/GitLabGroupSyncService.java
@@ -4,6 +4,7 @@ import static de.tum.in.www1.hephaestus.core.LoggingUtils.sanitizeForLog;
 import static de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabSyncConstants.GROUP_PROJECTS_PAGE_SIZE;
 import static de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabSyncConstants.MAX_PAGINATION_PAGES;
 import static de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabSyncConstants.adaptPageSize;
+import static de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabSyncConstants.extractEntityId;
 
 import de.tum.in.www1.hephaestus.gitprovider.common.GitProvider;
 import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderRepository;
@@ -19,8 +20,10 @@ import de.tum.in.www1.hephaestus.gitprovider.repository.Repository;
 import de.tum.in.www1.hephaestus.gitprovider.repository.gitlab.GitLabProjectProcessor;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -403,13 +406,37 @@ public class GitLabGroupSyncService {
                 );
             }
 
+            // Reconciliation pass: re-query with includeSubgroups=false to recover
+            // any direct projects silently dropped by the GitLab includeSubgroups bug.
+            // See: https://gitlab.com/gitlab-org/gitlab/-/issues/33419
+            int projectsReconciled = 0;
+            if (!hadApiFailure && topLevelOrganization != null) {
+                Set<Long> seenNativeIds = new HashSet<>();
+                for (Repository repo : syncedRepositories) {
+                    seenNativeIds.add(repo.getNativeId());
+                }
+
+                List<Repository> reconciled = reconcileDirectProjects(
+                    scopeId,
+                    groupFullPath,
+                    topLevelOrganization,
+                    provider,
+                    providerId,
+                    seenNativeIds
+                );
+                projectsReconciled = reconciled.size();
+                syncedRepositories.addAll(reconciled);
+            }
+
             log.info(
-                "Synced group projects: scopeId={}, groupPath={}, synced={}, failed={}, redacted={}, pages={}",
+                "Synced group projects: scopeId={}, groupPath={}, synced={}, failed={}, redacted={}, " +
+                    "reconciled={}, pages={}",
                 scopeId,
                 safeGroupPath,
                 syncedRepositories.size(),
                 projectsSkipped,
                 projectsRedacted,
+                projectsReconciled,
                 totalPages
             );
 
@@ -424,9 +451,15 @@ public class GitLabGroupSyncService {
             }
             // Both processing failures and redacted (null) projects indicate incomplete sync
             if (projectsSkipped > 0 || projectsRedacted > 0) {
-                return GitLabSyncResult.withErrors(syncedRepositories, totalPages, projectsSkipped, projectsRedacted);
+                return GitLabSyncResult.withErrors(
+                    syncedRepositories,
+                    totalPages,
+                    projectsSkipped,
+                    projectsRedacted,
+                    projectsReconciled
+                );
             }
-            return GitLabSyncResult.completed(syncedRepositories, totalPages, projectsRedacted);
+            return GitLabSyncResult.completed(syncedRepositories, totalPages, projectsRedacted, projectsReconciled);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("Interrupted during group project sync: scopeId={}, groupPath={}", scopeId, safeGroupPath);
@@ -452,6 +485,140 @@ public class GitLabGroupSyncService {
                 projectsSkipped
             );
         }
+    }
+
+    /**
+     * Reconciliation pass: fetches direct projects (excludeSubgroups) and processes any that
+     * were missing from the primary sync. This works around a GitLab bug where
+     * {@code includeSubgroups: true} can silently drop direct projects on certain versions.
+     *
+     * @see <a href="https://gitlab.com/gitlab-org/gitlab/-/issues/33419">GitLab #33419</a>
+     */
+    private List<Repository> reconcileDirectProjects(
+        Long scopeId,
+        String groupFullPath,
+        Organization topLevelOrganization,
+        GitProvider provider,
+        Long providerId,
+        Set<Long> seenNativeIds
+    ) {
+        String safeGroupPath = sanitizeForLog(groupFullPath);
+        List<Repository> reconciled = new ArrayList<>();
+
+        try {
+            String reconCursor = null;
+            int reconPageCount = 0;
+
+            do {
+                // Canonical rate limit pattern: acquirePermission + waitIfRateLimitLow per page.
+                // This waits up to 70s for rate limit reset (GitLab resets every 60s) instead
+                // of skipping reconciliation — consistent with all other GitLab sync services.
+                graphQlClientProvider.acquirePermission();
+                try {
+                    graphQlClientProvider.waitIfRateLimitLow(scopeId);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Interrupted during reconciliation rate limit wait: groupPath={}", safeGroupPath);
+                    break;
+                }
+
+                int pageSize = adaptPageSize(
+                    GROUP_PROJECTS_PAGE_SIZE,
+                    graphQlClientProvider.getRateLimitRemaining(scopeId)
+                );
+                HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
+
+                ClientGraphQlResponse response = client
+                    .documentName(GET_GROUP_PROJECTS_DOCUMENT)
+                    .variable("fullPath", groupFullPath)
+                    .variable("first", pageSize)
+                    .variable("after", reconCursor)
+                    .variable("includeSubgroups", false)
+                    .execute()
+                    .block(gitLabProperties.extendedGraphqlTimeout());
+
+                if (response == null || !response.isValid()) {
+                    log.warn(
+                        "Reconciliation query failed: groupPath={}, page={}, errors={}",
+                        safeGroupPath,
+                        reconPageCount,
+                        response != null ? response.getErrors() : "null response"
+                    );
+                    graphQlClientProvider.recordFailure(new GitLabSyncException("Invalid GraphQL response"));
+                    break;
+                }
+
+                graphQlClientProvider.recordSuccess();
+
+                List<GitLabProjectResponse> projects = response
+                    .field("group.projects.nodes")
+                    .toEntityList(GitLabProjectResponse.class);
+
+                for (GitLabProjectResponse project : projects) {
+                    if (project == null || project.id() == null) {
+                        continue;
+                    }
+                    try {
+                        long nativeId = extractEntityId(project.id());
+                        if (seenNativeIds.contains(nativeId)) {
+                            continue;
+                        }
+                        // Direct projects belong to the top-level group
+                        Repository repo = projectProcessor.processGraphQlResponse(
+                            project,
+                            topLevelOrganization,
+                            provider
+                        );
+                        if (repo != null) {
+                            reconciled.add(repo);
+                            seenNativeIds.add(nativeId);
+                        }
+                    } catch (Exception e) {
+                        log.warn(
+                            "Failed to reconcile project: fullPath={}, error={}",
+                            sanitizeForLog(project.fullPath()),
+                            e.getMessage()
+                        );
+                    }
+                }
+
+                GitLabPageInfo pageInfo = response.field("group.projects.pageInfo").toEntity(GitLabPageInfo.class);
+
+                if (pageInfo == null || !pageInfo.hasNextPage()) {
+                    break;
+                }
+
+                reconCursor = pageInfo.endCursor();
+                if (reconCursor == null) {
+                    log.warn(
+                        "Reconciliation cursor null despite hasNextPage=true: groupPath={}, page={}",
+                        safeGroupPath,
+                        reconPageCount
+                    );
+                    break;
+                }
+                reconPageCount++;
+
+                Thread.sleep(gitLabProperties.paginationThrottle().toMillis());
+            } while (reconPageCount < MAX_PAGINATION_PAGES);
+
+            if (!reconciled.isEmpty()) {
+                log.warn(
+                    "Reconciliation recovered {} direct project(s) missing from includeSubgroups query: " +
+                        "groupPath={} (GitLab bug https://gitlab.com/gitlab-org/gitlab/-/issues/33419)",
+                    reconciled.size(),
+                    safeGroupPath
+                );
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted during reconciliation: groupPath={}", safeGroupPath);
+        } catch (Exception e) {
+            graphQlClientProvider.recordFailure(e);
+            log.warn("Reconciliation failed (primary sync results preserved): groupPath={}", safeGroupPath, e);
+        }
+
+        return reconciled;
     }
 
     /**

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/organization/gitlab/GitLabSyncResult.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/organization/gitlab/GitLabSyncResult.java
@@ -10,18 +10,21 @@ import java.util.List;
  * Provides structured feedback about the sync outcome, including partial success
  * scenarios where some projects were synced but others failed.
  *
- * @param status            the overall sync outcome
- * @param synced            successfully synced repositories (unmodifiable)
- * @param pagesCompleted    number of pagination pages successfully fetched
- * @param projectsSkipped   number of individual projects that failed to process
- * @param projectsRedacted  number of projects returned as null by GitLab due to access restrictions
+ * @param status              the overall sync outcome
+ * @param synced              successfully synced repositories (unmodifiable)
+ * @param pagesCompleted      number of pagination pages successfully fetched
+ * @param projectsSkipped     number of individual projects that failed to process
+ * @param projectsRedacted    number of projects returned as null by GitLab due to access restrictions
+ * @param projectsReconciled  number of direct projects recovered by the reconciliation pass
+ *                            (workaround for <a href="https://gitlab.com/gitlab-org/gitlab/-/issues/33419">GitLab #33419</a>)
  */
 public record GitLabSyncResult(
     Status status,
     List<Repository> synced,
     int pagesCompleted,
     int projectsSkipped,
-    int projectsRedacted
+    int projectsRedacted,
+    int projectsReconciled
 ) {
     public enum Status {
         /** All projects synced successfully. */
@@ -35,13 +38,19 @@ public record GitLabSyncResult(
     }
 
     /** Successful sync with no errors. */
-    public static GitLabSyncResult completed(List<Repository> synced, int pagesCompleted, int projectsRedacted) {
+    public static GitLabSyncResult completed(
+        List<Repository> synced,
+        int pagesCompleted,
+        int projectsRedacted,
+        int projectsReconciled
+    ) {
         return new GitLabSyncResult(
             Status.COMPLETED,
             Collections.unmodifiableList(synced),
             pagesCompleted,
             0,
-            projectsRedacted
+            projectsRedacted,
+            projectsReconciled
         );
     }
 
@@ -50,14 +59,16 @@ public record GitLabSyncResult(
         List<Repository> synced,
         int pagesCompleted,
         int projectsSkipped,
-        int projectsRedacted
+        int projectsRedacted,
+        int projectsReconciled
     ) {
         return new GitLabSyncResult(
             Status.COMPLETED_WITH_ERRORS,
             Collections.unmodifiableList(synced),
             pagesCompleted,
             projectsSkipped,
-            projectsRedacted
+            projectsRedacted,
+            projectsReconciled
         );
     }
 
@@ -73,6 +84,7 @@ public record GitLabSyncResult(
             Collections.unmodifiableList(syncedSoFar),
             pagesCompleted,
             projectsSkipped,
+            0,
             0
         );
     }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceActivationService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceActivationService.java
@@ -268,12 +268,14 @@ public class WorkspaceActivationService {
                                 workspace.getAccountLogin()
                             );
                             log.info(
-                                "GitLab sync result: workspaceId={}, status={}, synced={}, failed={}, redacted={}, pages={}",
+                                "GitLab sync result: workspaceId={}, status={}, synced={}, failed={}, " +
+                                    "redacted={}, reconciled={}, pages={}",
                                 workspace.getId(),
                                 result.status(),
                                 result.synced().size(),
                                 result.projectsSkipped(),
                                 result.projectsRedacted(),
+                                result.projectsReconciled(),
                                 result.pagesCompleted()
                             );
                             // Link workspace to organization after sync (org was created during sync)

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/organization/gitlab/GitLabGroupSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/organization/gitlab/GitLabGroupSyncServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -253,10 +254,8 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             when(groupProcessor.process(any(), anyLong())).thenReturn(org);
             when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
 
-            Repository repo1 = new Repository();
-            repo1.setId(10L);
-            Repository repo2 = new Repository();
-            repo2.setId(20L);
+            Repository repo1 = createTestRepository(10L);
+            Repository repo2 = createTestRepository(20L);
             when(projectProcessor.processGraphQlResponse(eq(proj1), any(), any())).thenReturn(repo1);
             when(projectProcessor.processGraphQlResponse(eq(proj2), any(), any())).thenReturn(repo2);
 
@@ -267,6 +266,7 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             assertThat(result.synced()).extracting(Repository::getId).containsExactly(10L, 20L);
             assertThat(result.projectsSkipped()).isZero();
             assertThat(result.projectsRedacted()).isZero();
+            assertThat(result.projectsReconciled()).isZero();
         }
 
         @Test
@@ -286,10 +286,8 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             when(groupProcessor.process(any(), anyLong())).thenReturn(org);
             when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
 
-            Repository repo1 = new Repository();
-            repo1.setId(10L);
-            Repository repo2 = new Repository();
-            repo2.setId(20L);
+            Repository repo1 = createTestRepository(10L);
+            Repository repo2 = createTestRepository(20L);
             when(projectProcessor.processGraphQlResponse(eq(proj1), any(), any())).thenReturn(repo1);
             when(projectProcessor.processGraphQlResponse(eq(proj2), any(), any())).thenReturn(repo2);
 
@@ -313,8 +311,7 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             when(groupProcessor.process(any(), anyLong())).thenReturn(org);
             when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
 
-            Repository repo1 = new Repository();
-            repo1.setId(10L);
+            Repository repo1 = createTestRepository(10L);
             when(projectProcessor.processGraphQlResponse(eq(proj1), any(), any())).thenReturn(repo1);
             when(projectProcessor.processGraphQlResponse(eq(proj2), any(), any())).thenReturn(null);
 
@@ -338,8 +335,7 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             when(groupProcessor.process(any(), anyLong())).thenReturn(org);
             when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
 
-            Repository repo2 = new Repository();
-            repo2.setId(20L);
+            Repository repo2 = createTestRepository(20L);
             when(projectProcessor.processGraphQlResponse(eq(proj1), any(), any())).thenThrow(
                 new RuntimeException("DB error")
             );
@@ -371,8 +367,7 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             when(groupProcessor.process(any(), anyLong())).thenReturn(org);
             when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
 
-            Repository repo1 = new Repository();
-            repo1.setId(10L);
+            Repository repo1 = createTestRepository(10L);
             when(projectProcessor.processGraphQlResponse(eq(proj1), any(), any())).thenReturn(repo1);
 
             GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
@@ -426,8 +421,7 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             when(groupProcessor.process(eq(subGroupResponse), anyLong())).thenReturn(subOrg);
             when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
 
-            Repository repo1 = new Repository();
-            repo1.setId(10L);
+            Repository repo1 = createTestRepository(10L);
             when(projectProcessor.processGraphQlResponse(eq(proj1), eq(subOrg), any())).thenReturn(repo1);
 
             GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
@@ -459,7 +453,187 @@ class GitLabGroupSyncServiceTest extends BaseUnitTest {
             assertThat(result.status()).isEqualTo(GitLabSyncResult.Status.ABORTED_ERROR);
         }
 
+        // -- Reconciliation Tests (GitLab #33419 workaround) --
+
+        @Test
+        @DisplayName("reconciliation recovers direct projects dropped by includeSubgroups bug")
+        void reconciliation_recoversDroppedDirectProjects() {
+            // Subgroup query returns only proj-a (simulates bug dropping proj-b)
+            var projA = createMinimalProject("gid://gitlab/Project/10", "my-org/proj-a", "proj-a");
+            var projB = createMinimalProject("gid://gitlab/Project/20", "my-org/proj-b", "proj-b");
+
+            // Phase 1: includeSubgroups=true — returns only projA (bug drops projB)
+            ClientGraphQlResponse mainPage = mockProjectsPageWithGroup(List.of(projA), null);
+            // Phase 2: includeSubgroups=false — returns both projA and projB
+            ClientGraphQlResponse reconPage = mockProjectsPage(List.of(projA, projB), null);
+
+            HttpGraphQlClient client = mockClient();
+            mockSequentialExecute(client, mainPage, reconPage);
+            when(groupProcessor.process(any(), anyLong())).thenReturn(org);
+            when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
+
+            Repository repoA = createTestRepository(10L);
+            Repository repoB = createTestRepository(20L);
+            when(projectProcessor.processGraphQlResponse(eq(projA), any(), any())).thenReturn(repoA);
+            when(projectProcessor.processGraphQlResponse(eq(projB), any(), any())).thenReturn(repoB);
+
+            GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
+
+            assertThat(result.status()).isEqualTo(GitLabSyncResult.Status.COMPLETED);
+            assertThat(result.synced()).hasSize(2);
+            assertThat(result.synced()).extracting(Repository::getNativeId).containsExactlyInAnyOrder(10L, 20L);
+            assertThat(result.projectsReconciled()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("no reconciliation needed when all projects present in subgroup query")
+        void noReconciliationNeeded_whenAllProjectsPresent() {
+            var projA = createMinimalProject("gid://gitlab/Project/10", "my-org/proj-a", "proj-a");
+            var projB = createMinimalProject("gid://gitlab/Project/20", "my-org/proj-b", "proj-b");
+
+            // Phase 1: returns both projects
+            ClientGraphQlResponse mainPage = mockProjectsPageWithGroup(List.of(projA, projB), null);
+            // Phase 2: returns same projects (all duplicates, nothing to reconcile)
+            ClientGraphQlResponse reconPage = mockProjectsPage(List.of(projA, projB), null);
+
+            HttpGraphQlClient client = mockClient();
+            mockSequentialExecute(client, mainPage, reconPage);
+            when(groupProcessor.process(any(), anyLong())).thenReturn(org);
+            when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
+
+            Repository repoA = createTestRepository(10L);
+            Repository repoB = createTestRepository(20L);
+            when(projectProcessor.processGraphQlResponse(eq(projA), any(), any())).thenReturn(repoA);
+            when(projectProcessor.processGraphQlResponse(eq(projB), any(), any())).thenReturn(repoB);
+
+            GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
+
+            assertThat(result.status()).isEqualTo(GitLabSyncResult.Status.COMPLETED);
+            assertThat(result.synced()).hasSize(2);
+            assertThat(result.projectsReconciled()).isZero();
+        }
+
+        @Test
+        @DisplayName("subgroup query succeeds but reconciliation fails gracefully")
+        void subgroupSucceeds_reconciliationFails_preservesSubgroupResults() {
+            var projA = createMinimalProject("gid://gitlab/Project/10", "my-org/proj-a", "proj-a");
+
+            // Phase 1: succeeds
+            ClientGraphQlResponse mainPage = mockProjectsPageWithGroup(List.of(projA), null);
+            // Phase 2: invalid response
+            ClientGraphQlResponse reconPage = mock(ClientGraphQlResponse.class);
+            when(reconPage.isValid()).thenReturn(false);
+            when(reconPage.getErrors()).thenReturn(List.of());
+
+            HttpGraphQlClient client = mockClient();
+            mockSequentialExecute(client, mainPage, reconPage);
+            when(groupProcessor.process(any(), anyLong())).thenReturn(org);
+            when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
+
+            Repository repoA = createTestRepository(10L);
+            when(projectProcessor.processGraphQlResponse(eq(projA), any(), any())).thenReturn(repoA);
+
+            GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
+
+            // Primary results preserved despite reconciliation failure
+            assertThat(result.status()).isEqualTo(GitLabSyncResult.Status.COMPLETED);
+            assertThat(result.synced()).hasSize(1);
+            assertThat(result.projectsReconciled()).isZero();
+        }
+
+        @Test
+        @DisplayName("reconciliation waits for rate limit reset then proceeds")
+        void reconciliationWaitsForRateLimit_thenProceeds() throws InterruptedException {
+            var projA = createMinimalProject("gid://gitlab/Project/10", "my-org/proj-a", "proj-a");
+            var projB = createMinimalProject("gid://gitlab/Project/20", "my-org/proj-b", "proj-b");
+
+            // Phase 1: returns only projA (bug drops projB)
+            ClientGraphQlResponse mainPage = mockProjectsPageWithGroup(List.of(projA), null);
+            // Phase 2: reconciliation finds projB after rate limit wait
+            ClientGraphQlResponse reconPage = mockProjectsPage(List.of(projA, projB), null);
+
+            HttpGraphQlClient client = mockClient();
+            mockSequentialExecute(client, mainPage, reconPage);
+            when(groupProcessor.process(any(), anyLong())).thenReturn(org);
+            when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
+            // waitIfRateLimitLow is called unconditionally — it handles the wait internally
+            when(graphQlClientProvider.waitIfRateLimitLow(1L)).thenReturn(true);
+
+            Repository repoA = createTestRepository(10L);
+            Repository repoB = createTestRepository(20L);
+            when(projectProcessor.processGraphQlResponse(eq(projA), any(), any())).thenReturn(repoA);
+            when(projectProcessor.processGraphQlResponse(eq(projB), any(), any())).thenReturn(repoB);
+
+            GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
+
+            assertThat(result.status()).isEqualTo(GitLabSyncResult.Status.COMPLETED);
+            assertThat(result.synced()).hasSize(2);
+            assertThat(result.projectsReconciled()).isEqualTo(1);
+            // Verify canonical rate limit pattern: waitIfRateLimitLow called during reconciliation
+            verify(graphQlClientProvider, atLeast(1)).waitIfRateLimitLow(1L);
+            // Verify circuit breaker checked per page during reconciliation
+            verify(graphQlClientProvider, atLeast(2)).acquirePermission();
+        }
+
+        @Test
+        @DisplayName("extreme bug: all projects only in direct query")
+        void allProjectsOnlyInDirect_extremeBugManifestation() {
+            var projA = createMinimalProject("gid://gitlab/Project/10", "my-org/proj-a", "proj-a");
+            var projB = createMinimalProject("gid://gitlab/Project/20", "my-org/proj-b", "proj-b");
+
+            // Phase 1: includeSubgroups=true returns empty (extreme bug)
+            ClientGraphQlResponse mainPage = mockProjectsPageWithGroup(List.of(), null);
+            // Phase 2: includeSubgroups=false returns all direct projects
+            ClientGraphQlResponse reconPage = mockProjectsPage(List.of(projA, projB), null);
+
+            HttpGraphQlClient client = mockClient();
+            mockSequentialExecute(client, mainPage, reconPage);
+            when(groupProcessor.process(any(), anyLong())).thenReturn(org);
+            when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
+
+            Repository repoA = createTestRepository(10L);
+            Repository repoB = createTestRepository(20L);
+            when(projectProcessor.processGraphQlResponse(eq(projA), any(), any())).thenReturn(repoA);
+            when(projectProcessor.processGraphQlResponse(eq(projB), any(), any())).thenReturn(repoB);
+
+            GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
+
+            assertThat(result.status()).isEqualTo(GitLabSyncResult.Status.COMPLETED);
+            assertThat(result.synced()).hasSize(2);
+            assertThat(result.projectsReconciled()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("reconciliation skipped when primary sync had API failure")
+        void reconciliationSkipped_whenPrimarySyncHadApiFailure() {
+            HttpGraphQlClient client = mockClient();
+            ClientGraphQlResponse invalidResp = mock(ClientGraphQlResponse.class);
+            when(invalidResp.isValid()).thenReturn(false);
+            when(invalidResp.getErrors()).thenReturn(List.of());
+
+            HttpGraphQlClient.RequestSpec requestSpec = mock(HttpGraphQlClient.RequestSpec.class);
+            when(client.documentName(anyString())).thenReturn(requestSpec);
+            when(requestSpec.variable(anyString(), any())).thenReturn(requestSpec);
+            when(requestSpec.execute()).thenReturn(Mono.just(invalidResp));
+
+            when(graphQlClientProvider.getRateLimitRemaining(1L)).thenReturn(100);
+
+            GitLabSyncResult result = service.syncGroupProjects(1L, "my-org");
+
+            // API failure → hadApiFailure=true → reconciliation not attempted
+            assertThat(result.status()).isEqualTo(GitLabSyncResult.Status.ABORTED_ERROR);
+            assertThat(result.synced()).isEmpty();
+            assertThat(result.projectsReconciled()).isZero();
+        }
+
         // -- SyncGroupProjects Helpers --
+
+        private static Repository createTestRepository(long nativeId) {
+            Repository repo = new Repository();
+            repo.setId(nativeId);
+            repo.setNativeId(nativeId);
+            return repo;
+        }
 
         private static final GitLabGroupResponse DEFAULT_GROUP = new GitLabGroupResponse(
             "gid://gitlab/Group/1",


### PR DESCRIPTION
## Description

Adds a reconciliation pass after the main group project sync to recover any direct projects silently dropped by the known GitLab `includeSubgroups` bug ([gitlab#33419](https://gitlab.com/gitlab-org/gitlab/-/issues/33419)). After fetching with `includeSubgroups=true`, a second query with `includeSubgroups=false` deduplicates by `nativeId` and processes only the delta.

Closes #775

## Changes

- **`GitLabGroupSyncService`**: Added `reconcileDirectProjects()` method using canonical rate limit pattern (`acquirePermission` + `waitIfRateLimitLow` per page)
- **`GitLabSyncResult`**: Added `projectsReconciled` field to track recovery count
- **`WorkspaceActivationService`**: Added `reconciled={}` to sync result log
- **`GitLabGroupSyncServiceTest`**: Added 7 new reconciliation tests (23 total)

## How to Test

1. Run unit tests: `mvn test -Dtest=GitLabGroupSyncServiceTest`
2. Full sync: configure a GitLab group, run sync, verify `reconciled=0` in logs (on unaffected instances)
3. On affected GitLab versions, reconciliation would recover dropped direct projects and log `reconciled=N`
4. Rate limit behavior: reconciliation waits for rate limit reset (consistent with all other GitLab sync services)

## Validation

- All 23 unit tests pass
- Full end-to-end sync tested against `gitlab.lrz.de` (59 projects, 1122 issues, 1071 MRs — 100% match with API)
- Zero NULL `provider_id` or `native_id` across all entities
- Zero errors in GitLab sync logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed GitLab group project synchronization to automatically recover projects that were previously dropped during sync operations.

* **Improvements**
  * Enhanced synchronization reporting with additional metrics tracking recovered projects and reconciliation activity.

* **Tests**
  * Added comprehensive test coverage for project recovery and synchronization edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->