### PR TITLE
feat(server): inject contributor practice history into agent context

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
@@ -10,7 +10,9 @@ import de.tum.in.www1.hephaestus.gitprovider.git.GitRepositoryManager;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.PullRequestReviewCommentRepository;
 import de.tum.in.www1.hephaestus.practices.PracticeRepository;
+import de.tum.in.www1.hephaestus.practices.finding.ContributorHistoryProvider;
 import de.tum.in.www1.hephaestus.practices.finding.PracticeDetectionProperties;
+import de.tum.in.www1.hephaestus.practices.finding.PracticeFindingRepository;
 import de.tum.in.www1.hephaestus.practices.review.PracticeReviewDeliveryGate;
 import de.tum.in.www1.hephaestus.practices.review.PracticeReviewProperties;
 import de.tum.in.www1.hephaestus.workspace.WorkspaceRepository;
@@ -33,17 +35,20 @@ public class JobTypeHandlerConfiguration {
 
     private final ObjectMapper objectMapper;
     private final GitRepositoryManager gitRepositoryManager;
+    private final PracticeFindingRepository practiceFindingRepository;
     private final PracticeReviewDeliveryGate deliveryGate;
     private final PracticeReviewProperties reviewProperties;
 
     JobTypeHandlerConfiguration(
         ObjectMapper objectMapper,
         GitRepositoryManager gitRepositoryManager,
+        PracticeFindingRepository practiceFindingRepository,
         PracticeReviewDeliveryGate deliveryGate,
         PracticeReviewProperties reviewProperties
     ) {
         this.objectMapper = objectMapper;
         this.gitRepositoryManager = gitRepositoryManager;
+        this.practiceFindingRepository = practiceFindingRepository;
         this.deliveryGate = deliveryGate;
         this.reviewProperties = reviewProperties;
     }
@@ -51,6 +56,11 @@ public class JobTypeHandlerConfiguration {
     @Bean
     public PracticeDetectionResultParser practiceDetectionResultParser(PracticeDetectionProperties properties) {
         return new PracticeDetectionResultParser(objectMapper, properties.maxFindingsPerJob());
+    }
+
+    @Bean
+    ContributorHistoryProvider contributorHistoryProvider() {
+        return new ContributorHistoryProvider(practiceFindingRepository, objectMapper);
     }
 
     @Bean
@@ -106,6 +116,9 @@ public class JobTypeHandlerConfiguration {
             pullRequestRepository,
             reviewCommentRepository,
             practiceRepository,
+            // CGLIB proxy call: returns the singleton bean. Not a @Bean parameter to stay
+            // within the architecture test limit of 6 parameters per @Bean method.
+            contributorHistoryProvider(),
             resultParser,
             deliveryService,
             feedbackService

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -17,11 +17,13 @@ import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequest;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.PullRequestReviewCommentRepository;
 import de.tum.in.www1.hephaestus.practices.PracticeRepository;
+import de.tum.in.www1.hephaestus.practices.finding.ContributorHistoryProvider;
 import de.tum.in.www1.hephaestus.practices.model.Practice;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,12 +37,13 @@ import org.slf4j.LoggerFactory;
  * <p>Container workspace layout:
  * <pre>
  * /workspace/
- * ├── repo/                  # Real git repo (read-only bind mount)
+ * ├── repo/                           # Real git repo (read-only bind mount)
  * ├── .context/
- * │   ├── metadata.json      # Title, body, author, branches, stats
- * │   └── comments.json      # Review comments (ordered by creation time)
- * ├── .prompt                # Written by executor from buildPrompt()
- * └── .output/               # Agent writes results here
+ * │   ├── metadata.json               # Title, body, author, branches, stats
+ * │   ├── comments.json               # Review comments (ordered by creation time)
+ * │   └── contributor_history.json    # Aggregated practice verdict history (optional)
+ * ├── .prompt                         # Written by executor from buildPrompt()
+ * └── .output/                        # Agent writes results here
  * </pre>
  */
 public class PullRequestReviewHandler implements JobTypeHandler {
@@ -55,6 +58,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
     private final PullRequestRepository pullRequestRepository;
     private final PullRequestReviewCommentRepository reviewCommentRepository;
     private final PracticeRepository practiceRepository;
+    private final ContributorHistoryProvider contributorHistoryProvider;
     private final PracticeDetectionResultParser resultParser;
     private final PracticeDetectionDeliveryService deliveryService;
     private final FeedbackDeliveryService feedbackService;
@@ -65,6 +69,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         PullRequestRepository pullRequestRepository,
         PullRequestReviewCommentRepository reviewCommentRepository,
         PracticeRepository practiceRepository,
+        ContributorHistoryProvider contributorHistoryProvider,
         PracticeDetectionResultParser resultParser,
         PracticeDetectionDeliveryService deliveryService,
         FeedbackDeliveryService feedbackService
@@ -74,6 +79,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         this.pullRequestRepository = pullRequestRepository;
         this.reviewCommentRepository = reviewCommentRepository;
         this.practiceRepository = practiceRepository;
+        this.contributorHistoryProvider = contributorHistoryProvider;
         this.resultParser = resultParser;
         this.deliveryService = deliveryService;
         this.feedbackService = feedbackService;
@@ -134,8 +140,13 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         // Ensure repo is cloned/fetched before volumeMounts() resolves the path
         ensureRepositoryCloned(metadata, repositoryId);
 
-        // Only inject DB-sourced context (metadata + comments)
-        storeMetadataAndComments(files, pullRequestId, metadata);
+        // Load PR entity once — shared by metadata, comments, and contributor history
+        PullRequest pullRequest = pullRequestRepository.findByIdWithAllForGate(pullRequestId).orElse(null);
+
+        // Inject DB-sourced context (metadata + comments + contributor history)
+        storeMetadataAndComments(files, pullRequest, pullRequestId, metadata);
+        storeContributorHistory(files, pullRequest, job);
+        verifyActivePractices(job);
 
         long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000;
         log.info(
@@ -311,6 +322,13 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         sb.append("You are working in a git repository at `/workspace/repo/`.\n");
         sb.append("PR metadata and review comments are at `/workspace/.context/metadata.json` ");
         sb.append("and `/workspace/.context/comments.json`.\n");
+        sb.append('\n');
+        sb.append("**Contributor history:** If `/workspace/.context/contributor_history.json` exists, ");
+        sb.append("it contains aggregated practice verdict counts from this contributor's prior PRs. ");
+        sb.append("Use this to calibrate your `guidanceMethod`: if a contributor has repeated NEGATIVE ");
+        sb.append("findings for a practice, escalate from MODELING to COACHING or SCAFFOLDING. ");
+        sb.append("If they show sustained POSITIVE verdicts, use REFLECTION or EXPLORATION. ");
+        sb.append("If the file is absent, this is a new contributor — default to COACHING.\n");
         sb.append('\n');
         sb.append("Write your final findings to `/workspace/.output/result.json`.\n");
         sb.append('\n');
@@ -555,8 +573,13 @@ public class PullRequestReviewHandler implements JobTypeHandler {
     }
 
     /** Build and store pull request metadata and review comments as context JSON files. */
-    private void storeMetadataAndComments(Map<String, byte[]> files, long pullRequestId, JsonNode metadata) {
-        ObjectNode pullRequestMetadata = buildPullRequestMetadata(pullRequestId, metadata);
+    private void storeMetadataAndComments(
+        Map<String, byte[]> files,
+        PullRequest pullRequest,
+        long pullRequestId,
+        JsonNode metadata
+    ) {
+        ObjectNode pullRequestMetadata = buildPullRequestMetadata(pullRequest, metadata);
         try {
             files.put(
                 ".context/metadata.json",
@@ -577,11 +600,71 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         }
     }
 
+    /**
+     * Build and store aggregated contributor practice history as a context JSON file.
+     *
+     * <p>Skips silently if the PR has no author or the contributor has no prior findings —
+     * the absence of the file signals a first-time contributor to the agent.
+     *
+     * <p>Note: the contributor is always the PR author for PULL_REQUEST_REVIEW jobs.
+     * If a future job type evaluates reviewers, this lookup must change.
+     */
+    private void storeContributorHistory(Map<String, byte[]> files, PullRequest pullRequest, AgentJob job) {
+        if (pullRequest == null || pullRequest.getAuthor() == null || job.getWorkspace() == null) {
+            if (pullRequest != null && pullRequest.getAuthor() == null) {
+                log.debug("Skipping contributor history: PR has no author, pullRequestId={}", pullRequest.getId());
+            }
+            return;
+        }
+        Long contributorId = pullRequest.getAuthor().getId();
+        Long workspaceId = job.getWorkspace().getId();
+
+        try {
+            Optional<byte[]> historyJson = contributorHistoryProvider.buildHistoryJson(contributorId, workspaceId);
+            historyJson.ifPresent(json -> {
+                files.put(".context/contributor_history.json", json);
+                log.info(
+                    "Injected contributor history: {} bytes, contributorId={}, workspaceId={}",
+                    json.length,
+                    contributorId,
+                    workspaceId
+                );
+            });
+        } catch (Exception e) {
+            log.warn(
+                "Failed to build contributor history, continuing without it: contributorId={}, workspaceId={}",
+                contributorId,
+                workspaceId,
+                e
+            );
+        }
+    }
+
+    /** Verify the job's workspace has active practices. */
+    private void verifyActivePractices(AgentJob job) {
+        if (job.getWorkspace() == null) {
+            throw new JobPreparationException("Job has no workspace: jobId=" + job.getId());
+        }
+        Long workspaceId = job.getWorkspace().getId();
+        List<Practice> practices = practiceRepository.findByWorkspaceIdAndActiveTrue(workspaceId);
+        if (practices.isEmpty()) {
+            throw new JobPreparationException(
+                "No active practices for workspace: workspaceId=" + workspaceId + ", jobId=" + job.getId()
+            );
+        }
+        log.info(
+            "Verified {} active practices for workspace: workspaceId={}, jobId={}",
+            practices.size(),
+            workspaceId,
+            job.getId()
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Internal helpers
     // -------------------------------------------------------------------------
 
-    private ObjectNode buildPullRequestMetadata(long pullRequestId, JsonNode jobMetadata) {
+    private ObjectNode buildPullRequestMetadata(PullRequest pullRequest, JsonNode jobMetadata) {
         ObjectNode result = objectMapper.createObjectNode();
 
         // Copy routing fields from job metadata (always present — validated in prepareInputFiles)
@@ -593,9 +676,8 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         result.put("commit_sha", requireText(jobMetadata, "commit_sha"));
 
         // Enrich from current DB state (title, body, author, etc.)
-        PullRequest pullRequest = pullRequestRepository.findByIdWithAllForGate(pullRequestId).orElse(null);
         if (pullRequest == null) {
-            log.warn("Pull request not found in database during context preparation: pullRequestId={}", pullRequestId);
+            log.warn("Pull request not found in database during context preparation");
             result.put("enriched", false);
             return result;
         }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/practices/finding/ContributorHistoryProvider.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/practices/finding/ContributorHistoryProvider.java
@@ -1,0 +1,138 @@
+package de.tum.in.www1.hephaestus.practices.finding;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.tum.in.www1.hephaestus.practices.model.Verdict;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Builds aggregated contributor practice history JSON for the review agent context.
+ *
+ * <p>Queries {@link PracticeFindingRepository} for verdict counts per practice and
+ * produces a compact JSON array suitable for injection into the agent sandbox as
+ * {@code .context/contributor_history.json}. NOT_APPLICABLE verdicts are excluded
+ * (they carry no calibration signal for guidance method selection).
+ *
+ * <p>Output is capped at {@value #MAX_PRACTICES} practices, sorted by NEGATIVE count
+ * descending so the most problematic practices are always included when truncation occurs.
+ */
+public class ContributorHistoryProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(ContributorHistoryProvider.class);
+
+    /** Maximum number of practices included in the history JSON. */
+    static final int MAX_PRACTICES = 20;
+
+    private final PracticeFindingRepository practiceFindingRepository;
+    private final ObjectMapper objectMapper;
+
+    public ContributorHistoryProvider(PracticeFindingRepository practiceFindingRepository, ObjectMapper objectMapper) {
+        this.practiceFindingRepository = practiceFindingRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Builds contributor practice history JSON for agent context injection.
+     *
+     * @param contributorId the contributor whose history to aggregate
+     * @param workspaceId   the workspace scope
+     * @return compact JSON bytes, or empty if the contributor has no relevant history
+     */
+    public Optional<byte[]> buildHistoryJson(Long contributorId, Long workspaceId) {
+        List<ContributorPracticeSummary> summaries = practiceFindingRepository.findContributorPracticeSummary(
+            contributorId,
+            workspaceId
+        );
+
+        if (summaries.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Group by practice slug, accumulate verdict counts and track latest detection
+        Map<String, PracticeAggregate> byPractice = new LinkedHashMap<>();
+        for (ContributorPracticeSummary row : summaries) {
+            if (row.getVerdict() == Verdict.NOT_APPLICABLE) {
+                continue; // No calibration signal
+            }
+            byPractice.computeIfAbsent(row.getPracticeSlug(), slug -> new PracticeAggregate()).add(row);
+        }
+
+        if (byPractice.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Sort by NEGATIVE count desc, then slug for deterministic ordering
+        List<Map.Entry<String, PracticeAggregate>> sorted = byPractice
+            .entrySet()
+            .stream()
+            .sorted(
+                Comparator.<Map.Entry<String, PracticeAggregate>>comparingLong(e -> e.getValue().negative)
+                    .reversed()
+                    .thenComparing(Map.Entry::getKey)
+            )
+            .limit(MAX_PRACTICES)
+            .toList();
+
+        ArrayNode array = objectMapper.createArrayNode();
+        for (Map.Entry<String, PracticeAggregate> entry : sorted) {
+            ObjectNode node = objectMapper.createObjectNode();
+            PracticeAggregate agg = entry.getValue();
+            node.put("practice", entry.getKey());
+            node.put("positive", agg.positive);
+            node.put("negative", agg.negative);
+            node.put("needsReview", agg.needsReview);
+            node.put("lastSeen", agg.lastDetectedAt.toString());
+            array.add(node);
+        }
+
+        try {
+            byte[] json = objectMapper.writeValueAsBytes(array);
+            log.debug(
+                "Built contributor history: {} practices, {} bytes, contributorId={}, workspaceId={}",
+                sorted.size(),
+                json.length,
+                contributorId,
+                workspaceId
+            );
+            return Optional.of(json);
+        } catch (JsonProcessingException e) {
+            // Should never happen for ObjectNode serialization
+            log.error("Failed to serialize contributor history JSON", e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Mutable accumulator for per-practice verdict counts during aggregation.
+     */
+    private static final class PracticeAggregate {
+
+        long positive;
+        long negative;
+        long needsReview;
+        Instant lastDetectedAt;
+
+        void add(ContributorPracticeSummary row) {
+            switch (row.getVerdict()) {
+                case POSITIVE -> positive += row.getCount();
+                case NEGATIVE -> negative += row.getCount();
+                case NEEDS_REVIEW -> needsReview += row.getCount();
+                default -> {
+                    /* NOT_APPLICABLE already filtered */
+                }
+            }
+            if (lastDetectedAt == null || row.getLastDetectedAt().isAfter(lastDetectedAt)) {
+                lastDetectedAt = row.getLastDetectedAt();
+            }
+        }
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/practices/finding/ContributorPracticeSummary.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/practices/finding/ContributorPracticeSummary.java
@@ -1,0 +1,22 @@
+package de.tum.in.www1.hephaestus.practices.finding;
+
+import de.tum.in.www1.hephaestus.practices.model.Verdict;
+import java.time.Instant;
+
+/**
+ * Spring Data projection for aggregated practice finding summaries per contributor.
+ *
+ * <p>Each row represents one (practice, verdict) combination with the total count
+ * and the most recent detection timestamp. Used by
+ * {@link PracticeFindingRepository#findContributorPracticeSummary} to build
+ * contributor history context for the review agent.
+ */
+public interface ContributorPracticeSummary {
+    String getPracticeSlug();
+
+    Verdict getVerdict();
+
+    long getCount();
+
+    Instant getLastDetectedAt();
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/practices/finding/PracticeFindingRepository.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/practices/finding/PracticeFindingRepository.java
@@ -191,4 +191,38 @@ public interface PracticeFindingRepository extends JpaRepository<PracticeFinding
         @Param("pullRequestId") Long pullRequestId,
         @Param("workspaceId") Long workspaceId
     );
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Aggregation for agent context (Issue #895)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Returns aggregated verdict counts per practice for a contributor within a workspace.
+     *
+     * <p>Each row is one (practice slug, verdict) combination with the total count and the
+     * most recent detection timestamp. Callers group results by slug to build a per-practice
+     * history summary. The {@code idx_practice_finding_contributor_detected} index on
+     * {@code (contributor_id, detected_at DESC)} narrows the initial scan by contributor.
+     *
+     * @param contributorId the contributor whose history to aggregate
+     * @param workspaceId   the workspace scope (via practice → workspace relationship)
+     * @return aggregated summary rows ordered by slug then verdict, empty if no findings exist
+     */
+    @Query(
+        """
+        SELECT pf.practice.slug AS practiceSlug,
+               pf.verdict AS verdict,
+               COUNT(pf) AS count,
+               MAX(pf.detectedAt) AS lastDetectedAt
+        FROM PracticeFinding pf
+        WHERE pf.contributor.id = :contributorId
+          AND pf.practice.workspace.id = :workspaceId
+        GROUP BY pf.practice.slug, pf.verdict
+        ORDER BY pf.practice.slug, pf.verdict
+        """
+    )
+    List<ContributorPracticeSummary> findContributorPracticeSummary(
+        @Param("contributorId") Long contributorId,
+        @Param("workspaceId") Long workspaceId
+    );
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerRegistryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerRegistryTest.java
@@ -12,6 +12,7 @@ import de.tum.in.www1.hephaestus.gitprovider.git.GitRepositoryManager;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.PullRequestReviewCommentRepository;
 import de.tum.in.www1.hephaestus.practices.PracticeRepository;
+import de.tum.in.www1.hephaestus.practices.finding.ContributorHistoryProvider;
 import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,9 @@ class JobTypeHandlerRegistryTest extends BaseUnitTest {
     private PracticeRepository practiceRepository;
 
     @Mock
+    private ContributorHistoryProvider contributorHistoryProvider;
+
+    @Mock
     private PracticeDetectionDeliveryService deliveryService;
 
     @Mock
@@ -50,6 +54,7 @@ class JobTypeHandlerRegistryTest extends BaseUnitTest {
             pullRequestRepository,
             reviewCommentRepository,
             practiceRepository,
+            contributorHistoryProvider,
             parser,
             deliveryService,
             feedbackService

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
@@ -29,12 +29,14 @@ import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.PullReques
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.PullRequestReviewCommentRepository;
 import de.tum.in.www1.hephaestus.gitprovider.user.User;
 import de.tum.in.www1.hephaestus.practices.PracticeRepository;
+import de.tum.in.www1.hephaestus.practices.finding.ContributorHistoryProvider;
 import de.tum.in.www1.hephaestus.practices.model.CaMethod;
 import de.tum.in.www1.hephaestus.practices.model.Practice;
 import de.tum.in.www1.hephaestus.practices.model.Severity;
 import de.tum.in.www1.hephaestus.practices.model.Verdict;
 import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
 import de.tum.in.www1.hephaestus.workspace.Workspace;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +66,9 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
     private PracticeRepository practiceRepository;
 
     @Mock
+    private ContributorHistoryProvider contributorHistoryProvider;
+
+    @Mock
     private PracticeDetectionDeliveryService deliveryService;
 
     private static final Long WORKSPACE_ID = 99L;
@@ -83,6 +88,7 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             pullRequestRepository,
             reviewCommentRepository,
             practiceRepository,
+            contributorHistoryProvider,
             resultParser,
             deliveryService,
             feedbackService
@@ -439,6 +445,99 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             assertThat(metadataJson.get("state").asText()).isEqualTo("OPEN");
             assertThat(metadataJson.has("author")).isFalse();
         }
+
+        @Test
+        @DisplayName("should include contributor_history.json when provider returns data")
+        void shouldIncludeContributorHistory() throws Exception {
+            PullRequest pullRequest = new PullRequest();
+            pullRequest.setTitle("Fix bug");
+            User author = new User();
+            author.setId(42L);
+            author.setLogin("alice");
+            pullRequest.setAuthor(author);
+
+            stubDefaults();
+            when(pullRequestRepository.findByIdWithAllForGate(456L)).thenReturn(Optional.of(pullRequest));
+
+            byte[] historyJson = "[{\"practice\":\"error-handling\",\"negative\":3}]".getBytes(StandardCharsets.UTF_8);
+            when(contributorHistoryProvider.buildHistoryJson(42L, WORKSPACE_ID)).thenReturn(Optional.of(historyJson));
+
+            Map<String, byte[]> files = handler.prepareInputFiles(jobWithMetadata(sampleJobMetadata()));
+
+            assertThat(files).containsKey(".context/contributor_history.json");
+            assertThat(files.get(".context/contributor_history.json")).isEqualTo(historyJson);
+            verify(contributorHistoryProvider).buildHistoryJson(42L, WORKSPACE_ID);
+        }
+
+        @Test
+        @DisplayName("should not include contributor_history.json when provider returns empty")
+        void shouldOmitContributorHistoryWhenEmpty() throws Exception {
+            PullRequest pullRequest = new PullRequest();
+            pullRequest.setTitle("New PR");
+            User author = new User();
+            author.setId(42L);
+            author.setLogin("alice");
+            pullRequest.setAuthor(author);
+
+            stubDefaults();
+            when(pullRequestRepository.findByIdWithAllForGate(456L)).thenReturn(Optional.of(pullRequest));
+            when(contributorHistoryProvider.buildHistoryJson(42L, WORKSPACE_ID)).thenReturn(Optional.empty());
+
+            Map<String, byte[]> files = handler.prepareInputFiles(jobWithMetadata(sampleJobMetadata()));
+
+            assertThat(files).doesNotContainKey(".context/contributor_history.json");
+            verify(contributorHistoryProvider).buildHistoryJson(42L, WORKSPACE_ID);
+        }
+
+        @Test
+        @DisplayName("should gracefully continue when contributor history provider throws")
+        void shouldContinueWhenHistoryProviderThrows() throws Exception {
+            PullRequest pullRequest = new PullRequest();
+            pullRequest.setTitle("PR with broken history");
+            User author = new User();
+            author.setId(42L);
+            author.setLogin("alice");
+            pullRequest.setAuthor(author);
+
+            stubDefaults();
+            when(pullRequestRepository.findByIdWithAllForGate(456L)).thenReturn(Optional.of(pullRequest));
+            when(contributorHistoryProvider.buildHistoryJson(42L, WORKSPACE_ID)).thenThrow(
+                new RuntimeException("DB connection timeout")
+            );
+
+            Map<String, byte[]> files = handler.prepareInputFiles(jobWithMetadata(sampleJobMetadata()));
+
+            assertThat(files).doesNotContainKey(".context/contributor_history.json");
+            assertThat(files).containsKey(".context/metadata.json");
+        }
+
+        @Test
+        @DisplayName("should not include contributor_history.json when PR has no author")
+        void shouldOmitContributorHistoryWhenNoAuthor() throws Exception {
+            PullRequest pullRequest = new PullRequest();
+            pullRequest.setTitle("Orphan PR");
+            pullRequest.setAuthor(null);
+
+            stubDefaults();
+            when(pullRequestRepository.findByIdWithAllForGate(456L)).thenReturn(Optional.of(pullRequest));
+
+            Map<String, byte[]> files = handler.prepareInputFiles(jobWithMetadata(sampleJobMetadata()));
+
+            assertThat(files).doesNotContainKey(".context/contributor_history.json");
+            verifyNoInteractions(contributorHistoryProvider);
+        }
+
+        @Test
+        @DisplayName("should not include contributor_history.json when PR not found")
+        void shouldOmitContributorHistoryWhenPrNotFound() throws Exception {
+            stubDefaults();
+            // stubDefaults already returns Optional.empty() for the PR
+
+            Map<String, byte[]> files = handler.prepareInputFiles(jobWithMetadata(sampleJobMetadata()));
+
+            assertThat(files).doesNotContainKey(".context/contributor_history.json");
+            verifyNoInteractions(contributorHistoryProvider);
+        }
     }
 
     @Nested
@@ -684,6 +783,20 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             // Severity semantics are disambiguated with a concrete example
             assertThat(prompt).contains("verdict=POSITIVE severity=MAJOR");
             assertThat(prompt).contains("verdict=NEGATIVE severity=MINOR");
+        }
+
+        @Test
+        @DisplayName("should include contributor history reference with CA method guidance")
+        void shouldIncludeContributorHistoryReference() {
+            when(practiceRepository.findByWorkspaceIdAndActiveTrue(WORKSPACE_ID)).thenReturn(samplePractices());
+
+            String prompt = handler.buildPrompt(jobWithMetadata(sampleJobMetadata()));
+
+            assertThat(prompt).contains("contributor_history.json");
+            assertThat(prompt).contains("guidanceMethod");
+            assertThat(prompt).contains("COACHING");
+            assertThat(prompt).contains("SCAFFOLDING");
+            assertThat(prompt).contains("new contributor");
         }
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/practices/finding/ContributorHistoryProviderTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/practices/finding/ContributorHistoryProviderTest.java
@@ -1,0 +1,258 @@
+package de.tum.in.www1.hephaestus.practices.finding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.tum.in.www1.hephaestus.practices.model.Verdict;
+import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@DisplayName("ContributorHistoryProvider")
+class ContributorHistoryProviderTest extends BaseUnitTest {
+
+    private static final Long CONTRIBUTOR_ID = 42L;
+    private static final Long WORKSPACE_ID = 99L;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private PracticeFindingRepository practiceFindingRepository;
+
+    private ContributorHistoryProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new ContributorHistoryProvider(practiceFindingRepository, objectMapper);
+    }
+
+    @Nested
+    @DisplayName("buildHistoryJson")
+    class BuildHistoryJson {
+
+        @Test
+        @DisplayName("returns empty when no findings exist")
+        void returnsEmptyForNoFindings() {
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of()
+            );
+
+            Optional<byte[]> result = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("returns empty when all findings are NOT_APPLICABLE")
+        void returnsEmptyForOnlyNotApplicable() {
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of(summary("pr-description", Verdict.NOT_APPLICABLE, 5, Instant.parse("2026-03-20T10:00:00Z")))
+            );
+
+            Optional<byte[]> result = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("builds correct JSON structure for single practice")
+        void buildsSinglePracticeJson() throws Exception {
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of(
+                    summary("pr-description-quality", Verdict.NEGATIVE, 3, Instant.parse("2026-03-20T14:30:00Z")),
+                    summary("pr-description-quality", Verdict.POSITIVE, 1, Instant.parse("2026-03-18T10:00:00Z"))
+                )
+            );
+
+            byte[] json = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID).orElseThrow();
+            JsonNode root = objectMapper.readTree(json);
+
+            assertThat(root.isArray()).isTrue();
+            assertThat(root).hasSize(1);
+
+            JsonNode entry = root.get(0);
+            assertThat(entry.get("practice").asText()).isEqualTo("pr-description-quality");
+            assertThat(entry.get("positive").asLong()).isEqualTo(1);
+            assertThat(entry.get("negative").asLong()).isEqualTo(3);
+            assertThat(entry.get("needsReview").asLong()).isZero();
+            assertThat(entry.get("lastSeen").asText()).isEqualTo("2026-03-20T14:30:00Z");
+        }
+
+        @Test
+        @DisplayName("aggregates multiple practices with mixed verdicts")
+        void aggregatesMultiplePractices() throws Exception {
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of(
+                    summary("error-handling", Verdict.NEGATIVE, 2, Instant.parse("2026-03-18T10:15:00Z")),
+                    summary("error-handling", Verdict.NEEDS_REVIEW, 1, Instant.parse("2026-03-19T12:00:00Z")),
+                    summary("pr-description-quality", Verdict.POSITIVE, 5, Instant.parse("2026-03-20T14:30:00Z")),
+                    summary("pr-description-quality", Verdict.NEGATIVE, 1, Instant.parse("2026-03-15T08:00:00Z"))
+                )
+            );
+
+            byte[] json = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID).orElseThrow();
+            JsonNode root = objectMapper.readTree(json);
+
+            assertThat(root).hasSize(2);
+
+            // Sorted by NEGATIVE desc: error-handling (2) before pr-description-quality (1)
+            JsonNode first = root.get(0);
+            assertThat(first.get("practice").asText()).isEqualTo("error-handling");
+            assertThat(first.get("negative").asLong()).isEqualTo(2);
+            assertThat(first.get("needsReview").asLong()).isEqualTo(1);
+            assertThat(first.get("lastSeen").asText()).isEqualTo("2026-03-19T12:00:00Z");
+
+            JsonNode second = root.get(1);
+            assertThat(second.get("practice").asText()).isEqualTo("pr-description-quality");
+            assertThat(second.get("positive").asLong()).isEqualTo(5);
+            assertThat(second.get("negative").asLong()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("omits NOT_APPLICABLE verdicts from counts")
+        void omitsNotApplicable() throws Exception {
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of(
+                    summary("test-coverage", Verdict.POSITIVE, 2, Instant.parse("2026-03-20T10:00:00Z")),
+                    summary("test-coverage", Verdict.NOT_APPLICABLE, 8, Instant.parse("2026-03-21T10:00:00Z"))
+                )
+            );
+
+            byte[] json = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID).orElseThrow();
+            JsonNode root = objectMapper.readTree(json);
+
+            assertThat(root).hasSize(1);
+            JsonNode entry = root.get(0);
+            assertThat(entry.get("positive").asLong()).isEqualTo(2);
+            assertThat(entry.get("negative").asLong()).isZero();
+            // lastSeen should only reflect non-NA verdicts
+            assertThat(entry.get("lastSeen").asText()).isEqualTo("2026-03-20T10:00:00Z");
+        }
+
+        @Test
+        @DisplayName("caps output at MAX_PRACTICES sorted by NEGATIVE count")
+        void capsAtMaxPractices() throws Exception {
+            List<ContributorPracticeSummary> summaries = new ArrayList<>();
+            // Create 25 practices (exceeds MAX_PRACTICES=20)
+            for (int i = 0; i < 25; i++) {
+                String slug = String.format("practice-%02d", i);
+                summaries.add(summary(slug, Verdict.NEGATIVE, i, Instant.parse("2026-03-20T10:00:00Z")));
+            }
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                summaries
+            );
+
+            byte[] json = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID).orElseThrow();
+            JsonNode root = objectMapper.readTree(json);
+
+            assertThat(root).hasSize(ContributorHistoryProvider.MAX_PRACTICES);
+
+            // First entry should be the one with most negatives (practice-24)
+            assertThat(root.get(0).get("practice").asText()).isEqualTo("practice-24");
+            assertThat(root.get(0).get("negative").asLong()).isEqualTo(24);
+
+            // Last entry should be practice-05 (index 19 in reversed order: 24,23,...,5)
+            assertThat(root.get(19).get("practice").asText()).isEqualTo("practice-05");
+        }
+
+        @Test
+        @DisplayName("uses alphabetical order as tiebreaker when NEGATIVE counts are equal")
+        void alphabeticalTiebreaker() throws Exception {
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of(
+                    summary("zebra-practice", Verdict.NEGATIVE, 2, Instant.parse("2026-03-20T10:00:00Z")),
+                    summary("alpha-practice", Verdict.NEGATIVE, 2, Instant.parse("2026-03-20T10:00:00Z"))
+                )
+            );
+
+            byte[] json = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID).orElseThrow();
+            JsonNode root = objectMapper.readTree(json);
+
+            assertThat(root.get(0).get("practice").asText()).isEqualTo("alpha-practice");
+            assertThat(root.get(1).get("practice").asText()).isEqualTo("zebra-practice");
+        }
+
+        @Test
+        @DisplayName("lastSeen reflects maximum across all verdicts for a practice")
+        void lastSeenReflectsMaxAcrossVerdicts() throws Exception {
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of(
+                    summary("commit-quality", Verdict.POSITIVE, 1, Instant.parse("2026-03-15T10:00:00Z")),
+                    summary("commit-quality", Verdict.NEGATIVE, 1, Instant.parse("2026-03-20T14:00:00Z"))
+                )
+            );
+
+            byte[] json = provider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID).orElseThrow();
+            JsonNode root = objectMapper.readTree(json);
+
+            assertThat(root.get(0).get("lastSeen").asText()).isEqualTo("2026-03-20T14:00:00Z");
+        }
+
+        @Test
+        @DisplayName("returns empty when ObjectMapper throws JsonProcessingException")
+        void returnsEmptyOnSerializationFailure() throws Exception {
+            ObjectMapper brokenMapper = org.mockito.Mockito.mock(ObjectMapper.class);
+            when(brokenMapper.createArrayNode()).thenReturn(objectMapper.createArrayNode());
+            when(brokenMapper.createObjectNode()).thenReturn(objectMapper.createObjectNode());
+            when(brokenMapper.writeValueAsBytes(any())).thenThrow(
+                new JsonProcessingException("Simulated serialization failure") {}
+            );
+
+            ContributorHistoryProvider brokenProvider = new ContributorHistoryProvider(
+                practiceFindingRepository,
+                brokenMapper
+            );
+
+            when(practiceFindingRepository.findContributorPracticeSummary(CONTRIBUTOR_ID, WORKSPACE_ID)).thenReturn(
+                List.of(summary("test-practice", Verdict.NEGATIVE, 1, Instant.parse("2026-03-20T10:00:00Z")))
+            );
+
+            Optional<byte[]> result = brokenProvider.buildHistoryJson(CONTRIBUTOR_ID, WORKSPACE_ID);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    /**
+     * Creates a mock {@link ContributorPracticeSummary} for testing.
+     */
+    private static ContributorPracticeSummary summary(
+        String practiceSlug,
+        Verdict verdict,
+        long count,
+        Instant lastDetectedAt
+    ) {
+        return new ContributorPracticeSummary() {
+            @Override
+            public String getPracticeSlug() {
+                return practiceSlug;
+            }
+
+            @Override
+            public Verdict getVerdict() {
+                return verdict;
+            }
+
+            @Override
+            public long getCount() {
+                return count;
+            }
+
+            @Override
+            public Instant getLastDetectedAt() {
+                return lastDetectedAt;
+            }
+        };
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/practices/finding/PracticeFindingRepositoryIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/practices/finding/PracticeFindingRepositoryIntegrationTest.java
@@ -14,6 +14,7 @@ import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
 import de.tum.in.www1.hephaestus.practices.PracticeRepository;
 import de.tum.in.www1.hephaestus.practices.model.Practice;
 import de.tum.in.www1.hephaestus.practices.model.PracticeFinding;
+import de.tum.in.www1.hephaestus.practices.model.Verdict;
 import de.tum.in.www1.hephaestus.testconfig.BaseIntegrationTest;
 import de.tum.in.www1.hephaestus.testconfig.TestUserFactory;
 import de.tum.in.www1.hephaestus.testconfig.WorkspaceTestFactory;
@@ -381,6 +382,232 @@ class PracticeFindingRepositoryIntegrationTest extends BaseIntegrationTest {
             List<PracticeFinding> remaining = practiceFindingRepository.findAll();
             assertThat(remaining).hasSize(1);
             assertThat(remaining.get(0).getIdempotencyKey()).isEqualTo("cascade-key-2");
+        }
+    }
+
+    @Nested
+    @DisplayName("findContributorPracticeSummary")
+    class FindContributorPracticeSummaryTests {
+
+        @Test
+        @DisplayName("returns empty list for contributor with no findings")
+        void returnsEmptyForNoFindings() {
+            List<ContributorPracticeSummary> result = practiceFindingRepository.findContributorPracticeSummary(
+                contributor.getId(),
+                workspace.getId()
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("aggregates verdict counts for a single practice")
+        void aggregatesSinglePractice() {
+            // Insert 3 NEGATIVE and 1 POSITIVE for the same practice
+            insertFinding("sum-1", practice, "NEGATIVE", Instant.parse("2026-03-18T10:00:00Z"));
+            insertFinding("sum-2", practice, "NEGATIVE", Instant.parse("2026-03-19T10:00:00Z"));
+            insertFinding("sum-3", practice, "NEGATIVE", Instant.parse("2026-03-20T14:30:00Z"));
+            insertFinding("sum-4", practice, "POSITIVE", Instant.parse("2026-03-17T08:00:00Z"));
+
+            List<ContributorPracticeSummary> result = practiceFindingRepository.findContributorPracticeSummary(
+                contributor.getId(),
+                workspace.getId()
+            );
+
+            assertThat(result).hasSize(2); // One row per (slug, verdict) combination
+
+            ContributorPracticeSummary negative = result
+                .stream()
+                .filter(s -> s.getVerdict() == Verdict.NEGATIVE)
+                .findFirst()
+                .orElseThrow();
+            assertThat(negative.getPracticeSlug()).isEqualTo("test-practice");
+            assertThat(negative.getCount()).isEqualTo(3);
+            assertThat(negative.getLastDetectedAt()).isEqualTo(Instant.parse("2026-03-20T14:30:00Z"));
+
+            ContributorPracticeSummary positive = result
+                .stream()
+                .filter(s -> s.getVerdict() == Verdict.POSITIVE)
+                .findFirst()
+                .orElseThrow();
+            assertThat(positive.getCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("groups by practice slug across multiple practices")
+        void groupsByPracticeSlug() {
+            Practice secondPractice = new Practice();
+            secondPractice.setWorkspace(workspace);
+            secondPractice.setSlug("error-handling");
+            secondPractice.setName("Error Handling");
+            secondPractice.setCategory("test");
+            secondPractice.setDescription("Handle errors");
+            secondPractice.setTriggerEvents(OBJECT_MAPPER.valueToTree(List.of("PullRequestCreated")));
+            secondPractice = practiceRepository.save(secondPractice);
+
+            insertFinding("multi-1", practice, "POSITIVE", Instant.parse("2026-03-20T10:00:00Z"));
+            insertFinding("multi-2", secondPractice, "NEGATIVE", Instant.parse("2026-03-19T10:00:00Z"));
+
+            List<ContributorPracticeSummary> result = practiceFindingRepository.findContributorPracticeSummary(
+                contributor.getId(),
+                workspace.getId()
+            );
+
+            assertThat(result).hasSize(2);
+            assertThat(result)
+                .extracting(ContributorPracticeSummary::getPracticeSlug)
+                .containsExactlyInAnyOrder("test-practice", "error-handling");
+        }
+
+        @Test
+        @DisplayName("workspace isolation: excludes findings from other workspaces")
+        void workspaceIsolation() {
+            Workspace otherWorkspace = workspaceRepository.save(WorkspaceTestFactory.activeWorkspace("other-ws"));
+            Practice otherPractice = new Practice();
+            otherPractice.setWorkspace(otherWorkspace);
+            otherPractice.setSlug("test-practice"); // Same slug, different workspace
+            otherPractice.setName("Test Practice");
+            otherPractice.setCategory("test");
+            otherPractice.setDescription("Other workspace practice");
+            otherPractice.setTriggerEvents(OBJECT_MAPPER.valueToTree(List.of("PullRequestCreated")));
+            otherPractice = practiceRepository.save(otherPractice);
+
+            AgentJob otherJob = new AgentJob();
+            otherJob.setWorkspace(otherWorkspace);
+            otherJob.setJobType(AgentJobType.PULL_REQUEST_REVIEW);
+            otherJob.setConfigSnapshot(OBJECT_MAPPER.valueToTree(Map.of("model", "test")));
+            otherJob = agentJobRepository.save(otherJob);
+
+            // Finding in target workspace
+            insertFinding("iso-1", practice, "NEGATIVE", Instant.parse("2026-03-20T10:00:00Z"));
+            // Finding in other workspace (same contributor)
+            practiceFindingRepository.insertIfAbsent(
+                UUID.randomUUID(),
+                "iso-2",
+                otherJob.getId(),
+                otherPractice.getId(),
+                "pull_request",
+                2L,
+                contributor.getId(),
+                "Other WS finding",
+                "NEGATIVE",
+                "MAJOR",
+                0.8f,
+                null,
+                null,
+                null,
+                null,
+                Instant.parse("2026-03-20T10:00:00Z")
+            );
+
+            List<ContributorPracticeSummary> result = practiceFindingRepository.findContributorPracticeSummary(
+                contributor.getId(),
+                workspace.getId()
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getPracticeSlug()).isEqualTo("test-practice");
+            assertThat(result.get(0).getCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("returns correct MAX(detectedAt) as lastDetectedAt")
+        void correctLastDetectedAt() {
+            Instant earliest = Instant.parse("2026-03-15T08:00:00Z");
+            Instant latest = Instant.parse("2026-03-20T14:30:00Z");
+            Instant middle = Instant.parse("2026-03-18T12:00:00Z");
+
+            insertFinding("time-1", practice, "NEGATIVE", earliest);
+            insertFinding("time-2", practice, "NEGATIVE", latest);
+            insertFinding("time-3", practice, "NEGATIVE", middle);
+
+            List<ContributorPracticeSummary> result = practiceFindingRepository.findContributorPracticeSummary(
+                contributor.getId(),
+                workspace.getId()
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getLastDetectedAt()).isEqualTo(latest);
+        }
+
+        @Test
+        @DisplayName("contributor isolation: excludes findings from other contributors")
+        void contributorIsolation() {
+            GitProvider provider = gitProviderRepository
+                .findByTypeAndServerUrl(GitProviderType.GITHUB, "https://github.com")
+                .orElseThrow();
+            User otherContributor = TestUserFactory.createUser(200L, "other-contributor", provider);
+            otherContributor = userRepository.save(otherContributor);
+
+            // Finding for target contributor
+            insertFinding("contrib-iso-1", practice, "NEGATIVE", Instant.parse("2026-03-20T10:00:00Z"));
+            // Finding for other contributor (same practice, same workspace)
+            practiceFindingRepository.insertIfAbsent(
+                UUID.randomUUID(),
+                "contrib-iso-2",
+                agentJob.getId(),
+                practice.getId(),
+                "pull_request",
+                2L,
+                otherContributor.getId(),
+                "Other contributor finding",
+                "NEGATIVE",
+                "MAJOR",
+                0.8f,
+                null,
+                null,
+                null,
+                null,
+                Instant.parse("2026-03-20T10:00:00Z")
+            );
+
+            List<ContributorPracticeSummary> result = practiceFindingRepository.findContributorPracticeSummary(
+                contributor.getId(),
+                workspace.getId()
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("includes NOT_APPLICABLE verdict rows in query results")
+        void includesNotApplicableVerdict() {
+            insertFinding("na-1", practice, "NOT_APPLICABLE", Instant.parse("2026-03-20T10:00:00Z"));
+            insertFinding("na-2", practice, "NEGATIVE", Instant.parse("2026-03-19T10:00:00Z"));
+
+            List<ContributorPracticeSummary> result = practiceFindingRepository.findContributorPracticeSummary(
+                contributor.getId(),
+                workspace.getId()
+            );
+
+            // Query returns all verdicts — filtering is the caller's responsibility
+            assertThat(result).hasSize(2);
+            assertThat(result)
+                .extracting(ContributorPracticeSummary::getVerdict)
+                .containsExactlyInAnyOrder(Verdict.NOT_APPLICABLE, Verdict.NEGATIVE);
+        }
+
+        /** Helper to insert a finding with minimal boilerplate. */
+        private void insertFinding(String idempotencyKey, Practice targetPractice, String verdict, Instant detectedAt) {
+            practiceFindingRepository.insertIfAbsent(
+                UUID.randomUUID(),
+                idempotencyKey,
+                agentJob.getId(),
+                targetPractice.getId(),
+                "pull_request",
+                1L,
+                contributor.getId(),
+                "Test finding",
+                verdict,
+                "INFO",
+                0.9f,
+                null,
+                null,
+                null,
+                null,
+                detectedAt
+            );
         }
     }
 }


### PR DESCRIPTION
## Description

Closes #895

The practice-aware review agent receives PR metadata, diffs, comments, and practice definitions — but **zero contributor history**. Without it, the Cognitive Apprenticeship (CA) progression (MODELING → COACHING → SCAFFOLDING → ARTICULATION) is fiction: `guidanceMethod` is guessed in isolation every time.

This PR injects an **aggregated summary** (not raw findings) of each contributor's practice verdict history into the agent sandbox as `.context/contributor_history.json`, giving the agent the signal it needs to calibrate guidance.

### What changed

**New files (2 production, 1 test):**
- `ContributorPracticeSummary.java` — Spring Data projection interface for the JPQL aggregate query. Returns `(practiceSlug, verdict, count, lastDetectedAt)` per group.
- `ContributorHistoryProvider.java` — Stateless transformer that queries the repository, filters out `NOT_APPLICABLE` verdicts, aggregates by practice, sorts by NEGATIVE count desc, caps at 20 practices, and serializes to compact JSON `byte[]`. Returns `Optional.empty()` on no data or serialization failure (graceful degradation).
- `ContributorHistoryProviderTest.java` — 9 unit tests covering: empty findings, all-NOT_APPLICABLE, single/multi practice aggregation, NOT_APPLICABLE exclusion, 20-practice cap with sort order, alphabetical tiebreaker, lastSeen max across verdicts, and JsonProcessingException catch path.

**Modified files (6):**
- `PracticeFindingRepository.java` — Added `findContributorPracticeSummary()` JPQL query with `GROUP BY slug, verdict` and `ORDER BY slug, verdict`. Uses existing `idx_practice_finding_contributor_detected` index.
- `PullRequestReviewHandler.java` — Loads PR once in `prepareInputFiles()` and threads to both `storeMetadataAndComments()` and new `storeContributorHistory()`. History injection is wrapped in try-catch for graceful degradation (DB failure doesn't crash the job). Prompt updated with CA method calibration instructions.
- `JobTypeHandlerConfiguration.java` — Added `PracticeFindingRepository` as constructor field, new `contributorHistoryProvider()` @Bean (package-private), wired into handler via CGLIB proxy call to stay within the 6-parameter arch test limit.
- `PullRequestReviewHandlerTest.java` — 4 new tests: history present, history empty, no author skip, provider exception graceful degradation. Added `verify()` calls on existing tests.
- `PracticeFindingRepositoryIntegrationTest.java` — 7 new integration tests: empty results, single/multi practice aggregation, workspace isolation, correct MAX(detectedAt), contributor isolation, NOT_APPLICABLE verdict inclusion.
- `JobTypeHandlerRegistryTest.java` — Updated constructor call for new 9th parameter.

### Design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Aggregated summary vs raw findings | Summary | Avoids token explosion (200 findings = 100K+ tokens). Bounded JSON ≤ 20 practices. |
| Flat JSON array vs nested map | Flat array `[{practice, positive, negative, needsReview, lastSeen}]` | LLMs parse flat arrays more reliably than nested maps. |
| Practice cap | 20 (sorted by NEGATIVE desc) | Hard bound on context size. Prioritizes problematic practices. |
| NOT_APPLICABLE filtering | Excluded from output | Carries no CA calibration signal. |
| Graceful degradation | try-catch in handler, Optional.empty in provider | History is supplementary context — failure must not crash the review job. |
| No Liquibase migration | Skipped | Existing `idx_practice_finding_contributor_detected` index sufficient for the GROUP BY query. |
| CGLIB proxy call for wiring | Yes, with comment | Necessary to stay within @Bean 6-param arch test limit. |

### JSON output format

```json
[
  {"practice":"pr-description-quality","positive":1,"negative":3,"needsReview":0,"lastSeen":"2026-03-20T14:30:00Z"},
  {"practice":"commit-message-quality","positive":2,"negative":0,"needsReview":0,"lastSeen":"2026-03-18T10:15:00Z"}
]
```

### What this does NOT include

- No raw finding injection (token bomb risk)
- No feedback data in history (#898 — excluded to avoid contaminating AI accuracy measurement)
- No Liquibase migration (existing index is sufficient)
- No time-windowed queries (all-time summary is fine — GROUP BY is cheap on indexed columns)

## How to Test

1. **Unit tests** (2042 pass): `cd server/application-server && ./mvnw test -Dsurefire.includedGroups="unit" -Dmaven.test.skip=false -T 2C --batch-mode -q`
2. **Architecture tests** (114 pass): `cd server/application-server && ./mvnw test -Dsurefire.includedGroups="architecture" -Dmaven.test.skip=false -T 2C --batch-mode -q`
3. **Integration tests**: `cd server/application-server && ./mvnw test -Dsurefire.includedGroups="integration" -Dmaven.test.skip=false` (needs PostgreSQL)
4. Verify `contributor_history.json` appears in agent sandbox `.context/` directory during a real PR review
5. Verify agent output shows varied `guidanceMethod` for repeat offenders vs first-timers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pull request reviews now incorporate contributor history context, considering a contributor's past findings and performance patterns to provide more informed feedback.
  
* **Tests**
  * Added comprehensive test coverage for new contributor history tracking and integration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->