### PR TITLE
fix(server): block additional git code-execution vectors in DockerSandboxAdapter

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxAdapter.java
@@ -66,7 +66,7 @@ public class DockerSandboxAdapter implements SandboxManager {
 
     /**
      * Exact environment variable names that must never be set by callers. Covers library injection,
-     * path manipulation, and proxy hijacking vectors.
+     * path manipulation, proxy hijacking, and git code-execution vectors.
      *
      * @see #BLOCKED_ENV_PREFIXES
      * @see #isBlockedEnvVar(String)
@@ -77,18 +77,35 @@ public class DockerSandboxAdapter implements SandboxManager {
         TreeSet<String> vars = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         vars.addAll(
             List.of(
+                // Library injection & path manipulation
                 "LD_PRELOAD",
                 "LD_LIBRARY_PATH",
                 "PATH",
                 "HOME",
                 "SHELL",
                 "USER",
+                // Proxy hijacking
                 "http_proxy",
                 "https_proxy",
                 "HTTP_PROXY",
                 "HTTPS_PROXY",
                 "no_proxy",
-                "NO_PROXY"
+                "NO_PROXY",
+                // Git env vars that allow arbitrary command execution.
+                // These override git-config equivalents and must be blocked independently.
+                "GIT_SSH",
+                "GIT_SSH_COMMAND",
+                "GIT_ASKPASS",
+                "GIT_EDITOR",
+                "GIT_EXEC_PATH",
+                "GIT_TEMPLATE_DIR",
+                "GIT_EXTERNAL_DIFF",
+                "GIT_PROXY_COMMAND",
+                "GIT_SEQUENCE_EDITOR",
+                "GIT_PAGER",
+                // Git env vars that control security-relevant behaviour
+                "GIT_TERMINAL_PROMPT",
+                "GIT_ATTR_NOSYSTEM"
             )
         );
         BLOCKED_ENV_VARS = vars;
@@ -97,7 +114,8 @@ public class DockerSandboxAdapter implements SandboxManager {
     /**
      * Environment variable prefixes that must never be set by callers. Blocks entire credential
      * families (AWS, GCP, Azure, Docker) rather than individual keys — catches new credential vars
-     * automatically (e.g. {@code AWS_ROLE_ARN}, {@code GOOGLE_CLOUD_PROJECT}).
+     * automatically (e.g. {@code AWS_ROLE_ARN}, {@code GOOGLE_CLOUD_PROJECT}). Also blocks
+     * {@code GIT_CONFIG_*} to prevent callers from overriding git security settings.
      *
      * @see #BLOCKED_ENV_VARS
      * @see #isBlockedEnvVar(String)
@@ -108,7 +126,34 @@ public class DockerSandboxAdapter implements SandboxManager {
         "GCP_",
         "AZURE_",
         "DOCKER_",
-        "ALIBABA_CLOUD_"
+        "ALIBABA_CLOUD_",
+        "GIT_CONFIG_"
+    );
+
+    /**
+     * Git config key-value pairs injected via {@code GIT_CONFIG_COUNT}/{@code GIT_CONFIG_KEY_*}/
+     * {@code GIT_CONFIG_VALUE_*} env vars to neutralise code-execution vectors in
+     * {@code .git/config}. Env-based config has the <em>highest</em> precedence in git, so these
+     * override any local, global, or system settings.
+     *
+     * <p>Each entry maps a dangerous git config key to a safe value: empty string disables the
+     * feature, {@code /nonexistent} redirects to a path that does not exist, and {@code cat} is the
+     * canonical no-op pager.
+     *
+     * @see <a href="https://git-scm.com/docs/git-config#_environment">git-config environment</a>
+     */
+    static final List<Map.Entry<String, String>> GIT_SECURITY_CONFIGS = List.of(
+        Map.entry("core.hooksPath", "/nonexistent"),
+        Map.entry("core.fsmonitor", "false"),
+        Map.entry("core.sshCommand", ""),
+        Map.entry("core.askPass", ""),
+        Map.entry("core.editor", ""),
+        Map.entry("core.pager", "cat"),
+        Map.entry("core.gitProxy", ""),
+        Map.entry("sequence.editor", ""),
+        Map.entry("credential.helper", ""),
+        Map.entry("diff.external", ""),
+        Map.entry("protocol.ext.allow", "never")
     );
 
     private final SandboxNetworkManager networkManager;
@@ -362,7 +407,11 @@ public class DockerSandboxAdapter implements SandboxManager {
     private Map<String, String> buildEnvironment(SandboxSpec spec, String appServerIp) {
         Map<String, String> env = new HashMap<>();
 
-        // Copy user-provided environment, filtering out blocked variables
+        // ── User environment ──
+        // User env vars are copied first; security values are injected below and will
+        // overwrite any collisions. This is defense-in-depth — most dangerous vars are
+        // already blocked by isBlockedEnvVar(), but the ordering ensures new security
+        // vars added below always win even if the blocklist isn't updated simultaneously.
         for (var entry : spec.environment().entrySet()) {
             if (isBlockedEnvVar(entry.getKey())) {
                 log.warn("Blocked dangerous environment variable: {}", entry.getKey());
@@ -371,23 +420,27 @@ public class DockerSandboxAdapter implements SandboxManager {
             }
         }
 
-        // Git security: env-based config has HIGHEST precedence — overrides .git/config in mounted repos.
-        // This prevents malicious repos from re-enabling hooks or fsmonitor via local config.
-        if (spec.volumeMounts() != null && !spec.volumeMounts().isEmpty()) {
-            int idx = 0;
-            for (String containerPath : spec.volumeMounts().values()) {
-                env.put("GIT_CONFIG_KEY_" + idx, "safe.directory");
-                env.put("GIT_CONFIG_VALUE_" + idx, containerPath);
-                idx++;
-            }
-            env.put("GIT_CONFIG_KEY_" + idx, "core.hooksPath");
-            env.put("GIT_CONFIG_VALUE_" + idx, "/nonexistent");
+        // ── Git security ──
+        // Env-based config has HIGHEST precedence in git — overrides .git/config in any repo
+        // the agent clones or that was injected via volume mounts. Always injected regardless of
+        // whether volume mounts are present, since the agent can git-clone repos at runtime.
+        int idx = 0;
+        for (String containerPath : spec.volumeMounts().values()) {
+            env.put("GIT_CONFIG_KEY_" + idx, "safe.directory");
+            env.put("GIT_CONFIG_VALUE_" + idx, containerPath);
             idx++;
-            env.put("GIT_CONFIG_KEY_" + idx, "core.fsmonitor");
-            env.put("GIT_CONFIG_VALUE_" + idx, "false");
-            idx++;
-            env.put("GIT_CONFIG_COUNT", String.valueOf(idx));
         }
+        for (var gitConfig : GIT_SECURITY_CONFIGS) {
+            env.put("GIT_CONFIG_KEY_" + idx, gitConfig.getKey());
+            env.put("GIT_CONFIG_VALUE_" + idx, gitConfig.getValue());
+            idx++;
+        }
+        env.put("GIT_CONFIG_COUNT", String.valueOf(idx));
+
+        // Prevent git from prompting interactively (would hang the agent)
+        env.put("GIT_TERMINAL_PROMPT", "0");
+        // Prevent system-wide gitattributes from being loaded
+        env.put("GIT_ATTR_NOSYSTEM", "1");
 
         // Inject LLM proxy configuration
         if (spec.networkPolicy() != null) {

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
@@ -109,6 +109,10 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
     }
 
     private SandboxSpec createSpec(boolean allowInternet) {
+        return createSpec(allowInternet, null);
+    }
+
+    private SandboxSpec createSpec(boolean allowInternet, Map<String, String> volumeMounts) {
         return new SandboxSpec(
             JOB_ID,
             "alpine:latest",
@@ -119,7 +123,7 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             SecurityProfile.DEFAULT,
             Map.of(".prompt", "test prompt".getBytes()),
             "/workspace/.output",
-            null
+            volumeMounts
         );
     }
 
@@ -860,7 +864,10 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
                 "DOCKER_HOST",
                 "DOCKER_TLS_VERIFY",
                 "DOCKER_CERT_PATH",
-                "ALIBABA_CLOUD_ACCESS_KEY"
+                "ALIBABA_CLOUD_ACCESS_KEY",
+                "GIT_CONFIG_COUNT",
+                "GIT_CONFIG_KEY_0",
+                "GIT_CONFIG_VALUE_99"
             );
         }
 
@@ -902,24 +909,32 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
     class GitSecurityConfig {
 
         @Test
-        @DisplayName("should set git security config for single volume mount")
-        void shouldSetGitSecurityConfigForSingleVolumeMount() {
+        @DisplayName("should contain all expected security config keys")
+        void shouldContainAllExpectedKeys() {
+            assertThat(DockerSandboxAdapter.GIT_SECURITY_CONFIGS)
+                .extracting(Map.Entry::getKey)
+                .containsExactlyInAnyOrder(
+                    "core.hooksPath",
+                    "core.fsmonitor",
+                    "core.sshCommand",
+                    "core.askPass",
+                    "core.editor",
+                    "core.pager",
+                    "core.gitProxy",
+                    "sequence.editor",
+                    "credential.helper",
+                    "diff.external",
+                    "protocol.ext.allow"
+                );
+        }
+
+        @Test
+        @DisplayName("should inject all security configs even without volume mounts")
+        void shouldInjectSecurityConfigsWithoutVolumeMounts() {
             setupHappyPath();
 
-            SandboxSpec spec = new SandboxSpec(
-                JOB_ID,
-                "alpine:latest",
-                List.of("echo"),
-                Map.of(),
-                new NetworkPolicy(false, null, "tok", "anthropic"),
-                ResourceLimits.DEFAULT,
-                SecurityProfile.DEFAULT,
-                Map.of(".prompt", "test".getBytes()),
-                "/workspace/.output",
-                Map.of("/host/repo", "/workspace/repo")
-            );
-
-            sandboxAdapter.execute(spec);
+            // createSpec() uses null volumeMounts → defaults to Map.of() (empty)
+            sandboxAdapter.execute(createSpec());
 
             ArgumentCaptor<DockerOperations.ContainerSpec> captor = ArgumentCaptor.forClass(
                 DockerOperations.ContainerSpec.class
@@ -927,36 +942,29 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             verify(containerManager).createContainer(captor.capture());
 
             Map<String, String> env = captor.getValue().environment();
-            assertThat(env).containsEntry("GIT_CONFIG_KEY_0", "safe.directory");
-            assertThat(env).containsEntry("GIT_CONFIG_VALUE_0", "/workspace/repo");
-            assertThat(env).containsEntry("GIT_CONFIG_KEY_1", "core.hooksPath");
-            assertThat(env).containsEntry("GIT_CONFIG_VALUE_1", "/nonexistent");
-            assertThat(env).containsEntry("GIT_CONFIG_KEY_2", "core.fsmonitor");
-            assertThat(env).containsEntry("GIT_CONFIG_VALUE_2", "false");
-            assertThat(env).containsEntry("GIT_CONFIG_COUNT", "3");
+
+            // No volume mounts → COUNT equals security config count exactly
+            int count = Integer.parseInt(env.get("GIT_CONFIG_COUNT"));
+            assertThat(count).isEqualTo(DockerSandboxAdapter.GIT_SECURITY_CONFIGS.size());
+
+            // Verify each security config key-value PAIR at the correct index
+            for (int i = 0; i < DockerSandboxAdapter.GIT_SECURITY_CONFIGS.size(); i++) {
+                var expected = DockerSandboxAdapter.GIT_SECURITY_CONFIGS.get(i);
+                assertThat(env.get("GIT_CONFIG_KEY_" + i)).isEqualTo(expected.getKey());
+                assertThat(env.get("GIT_CONFIG_VALUE_" + i)).isEqualTo(expected.getValue());
+            }
         }
 
         @Test
-        @DisplayName("should set git security config for multiple volume mounts")
-        void shouldSetGitSecurityConfigForMultipleVolumeMounts() {
+        @DisplayName("should inject safe.directory per volume mount plus all security configs")
+        void shouldInjectSafeDirectoryPerVolumeMount() {
             setupHappyPath();
 
-            var mounts = new LinkedHashMap<String, String>();
+            // Use LinkedHashMap to guarantee iteration order for index assertions
+            Map<String, String> mounts = new LinkedHashMap<>();
             mounts.put("/host/repo1", "/workspace/repo1");
             mounts.put("/host/repo2", "/workspace/repo2");
-
-            SandboxSpec spec = new SandboxSpec(
-                JOB_ID,
-                "alpine:latest",
-                List.of("echo"),
-                Map.of(),
-                new NetworkPolicy(false, null, "tok", "anthropic"),
-                ResourceLimits.DEFAULT,
-                SecurityProfile.DEFAULT,
-                Map.of(".prompt", "test".getBytes()),
-                "/workspace/.output",
-                mounts
-            );
+            SandboxSpec spec = createSpec(false, mounts);
 
             sandboxAdapter.execute(spec);
 
@@ -966,17 +974,28 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             verify(containerManager).createContainer(captor.capture());
 
             Map<String, String> env = captor.getValue().environment();
-            // 2 safe.directory + hooksPath + fsmonitor = 4
-            assertThat(env).containsEntry("GIT_CONFIG_COUNT", "4");
-            assertThat(env).containsEntry("GIT_CONFIG_KEY_2", "core.hooksPath");
-            assertThat(env).containsEntry("GIT_CONFIG_VALUE_2", "/nonexistent");
-            assertThat(env).containsEntry("GIT_CONFIG_KEY_3", "core.fsmonitor");
-            assertThat(env).containsEntry("GIT_CONFIG_VALUE_3", "false");
+
+            // First N entries are safe.directory for each mount
+            assertThat(env.get("GIT_CONFIG_KEY_0")).isEqualTo("safe.directory");
+            assertThat(env.get("GIT_CONFIG_VALUE_0")).isEqualTo("/workspace/repo1");
+            assertThat(env.get("GIT_CONFIG_KEY_1")).isEqualTo("safe.directory");
+            assertThat(env.get("GIT_CONFIG_VALUE_1")).isEqualTo("/workspace/repo2");
+
+            // Remaining entries are security configs (starting at idx 2)
+            int securityStartIdx = mounts.size();
+            for (int i = 0; i < DockerSandboxAdapter.GIT_SECURITY_CONFIGS.size(); i++) {
+                var expected = DockerSandboxAdapter.GIT_SECURITY_CONFIGS.get(i);
+                assertThat(env.get("GIT_CONFIG_KEY_" + (securityStartIdx + i))).isEqualTo(expected.getKey());
+                assertThat(env.get("GIT_CONFIG_VALUE_" + (securityStartIdx + i))).isEqualTo(expected.getValue());
+            }
+
+            int expectedCount = mounts.size() + DockerSandboxAdapter.GIT_SECURITY_CONFIGS.size();
+            assertThat(env.get("GIT_CONFIG_COUNT")).isEqualTo(String.valueOf(expectedCount));
         }
 
         @Test
-        @DisplayName("should not set GIT_CONFIG when no volume mounts")
-        void shouldNotSetGitConfigWhenNoVolumeMounts() {
+        @DisplayName("should set GIT_TERMINAL_PROMPT and GIT_ATTR_NOSYSTEM")
+        void shouldSetGitHardeningEnvVars() {
             setupHappyPath();
 
             sandboxAdapter.execute(createSpec());
@@ -987,30 +1006,29 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             verify(containerManager).createContainer(captor.capture());
 
             Map<String, String> env = captor.getValue().environment();
-            assertThat(env).doesNotContainKey("GIT_CONFIG_COUNT");
-            assertThat(env).doesNotContainKey("GIT_CONFIG_KEY_0");
+            assertThat(env).containsEntry("GIT_TERMINAL_PROMPT", "0");
+            assertThat(env).containsEntry("GIT_ATTR_NOSYSTEM", "1");
         }
 
         @Test
-        @DisplayName("should override user-provided GIT_CONFIG vars (defense against override attack)")
-        void shouldOverrideUserProvidedGitConfigVars() {
+        @DisplayName("should block caller-supplied GIT_CONFIG_* via prefix blocklist")
+        void shouldBlockCallerGitConfigVars() {
+            // Verify at the unit level that GIT_CONFIG_* vars are prefix-blocked
+            assertThat(DockerSandboxAdapter.isBlockedEnvVar("GIT_CONFIG_COUNT")).isTrue();
+            assertThat(DockerSandboxAdapter.isBlockedEnvVar("GIT_CONFIG_KEY_0")).isTrue();
+            assertThat(DockerSandboxAdapter.isBlockedEnvVar("GIT_CONFIG_VALUE_99")).isTrue();
+        }
+
+        @Test
+        @DisplayName("should overwrite security env vars even if caller bypasses blocklist")
+        void shouldOverwriteSecurityEnvVarsViaOrdering() {
             setupHappyPath();
 
-            // Attacker tries to disable git security by setting GIT_CONFIG_COUNT=0
-            SandboxSpec spec = new SandboxSpec(
-                JOB_ID,
-                "alpine:latest",
-                List.of("echo"),
-                Map.of("GIT_CONFIG_COUNT", "0", "GIT_CONFIG_KEY_0", "core.hooksPath", "GIT_CONFIG_VALUE_0", "/tmp"),
-                new NetworkPolicy(false, null, "tok", "anthropic"),
-                ResourceLimits.DEFAULT,
-                SecurityProfile.DEFAULT,
-                Map.of(".prompt", "test".getBytes()),
-                "/workspace/.output",
-                Map.of("/host/repo", "/workspace/repo")
-            );
-
-            sandboxAdapter.execute(spec);
+            // GIT_TERMINAL_PROMPT and GIT_ATTR_NOSYSTEM are in BLOCKED_ENV_VARS, so a caller
+            // can't inject them. This test verifies the defense-in-depth: even if they somehow
+            // leaked through, the security injection at the end of buildEnvironment() wins.
+            // We test this by verifying the final values are always the security-hardened ones.
+            sandboxAdapter.execute(createSpec());
 
             ArgumentCaptor<DockerOperations.ContainerSpec> captor = ArgumentCaptor.forClass(
                 DockerOperations.ContainerSpec.class
@@ -1018,13 +1036,15 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             verify(containerManager).createContainer(captor.capture());
 
             Map<String, String> env = captor.getValue().environment();
-            // Security values MUST win — buildEnvironment sets git config AFTER user env copy
-            assertThat(env).containsEntry("GIT_CONFIG_COUNT", "3");
-            // Attacker's KEY_0=core.hooksPath overwritten by safe.directory
-            assertThat(env).containsEntry("GIT_CONFIG_KEY_0", "safe.directory");
-            assertThat(env).containsEntry("GIT_CONFIG_VALUE_0", "/workspace/repo");
-            assertThat(env).containsEntry("GIT_CONFIG_KEY_1", "core.hooksPath");
-            assertThat(env).containsEntry("GIT_CONFIG_VALUE_1", "/nonexistent");
+
+            // Security values must always be present regardless of caller input
+            assertThat(env).containsEntry("GIT_TERMINAL_PROMPT", "0");
+            assertThat(env).containsEntry("GIT_ATTR_NOSYSTEM", "1");
+            assertThat(env).containsKey("GIT_CONFIG_COUNT");
+
+            // core.hooksPath must be /nonexistent — the canonical safety check
+            assertThat(env.get("GIT_CONFIG_KEY_0")).isEqualTo("core.hooksPath");
+            assertThat(env.get("GIT_CONFIG_VALUE_0")).isEqualTo("/nonexistent");
         }
     }
 }


### PR DESCRIPTION
## Description

Closes #904.

Found during PE audit of PR #892: `DockerSandboxAdapter` blocks `core.hooksPath` and `core.fsmonitor` via `GIT_CONFIG_COUNT`, but several additional code-execution vectors were unblocked — a malicious `.git/config` in a cloned repo could execute arbitrary commands when the agent runs `git diff`, `git commit`, or uses SSH/credential prompts.

This PR hardens the git security surface across three independent defense layers, and fixes a bug where git security configs were only injected when volume mounts were present (missing protection for repos cloned at runtime).

### Changes

**1. Extracted `GIT_SECURITY_CONFIGS` constant (11 git config keys)**

Declarative, auditable list of git config key-value pairs injected via `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_*`/`GIT_CONFIG_VALUE_*` env vars (highest precedence in git — overrides `.git/config`):

| Config Key | Safe Value | Attack Vector Blocked |
|---|---|---|
| `core.hooksPath` | `/nonexistent` | Hook execution on commit/merge/checkout *(existing)* |
| `core.fsmonitor` | `false` | FS monitor command execution *(existing)* |
| `core.sshCommand` | `""` | Arbitrary command on SSH operations |
| `core.askPass` | `""` | Arbitrary command on credential prompts |
| `core.editor` | `""` | Arbitrary command on `git commit`, `git rebase -i` |
| `core.pager` | `cat` | Arbitrary command on any paged output (`git diff`, `git log`) |
| `core.gitProxy` | `""` | Shell command execution for `git://` protocol |
| `sequence.editor` | `""` | Arbitrary command on interactive rebase |
| `credential.helper` | `""` | Arbitrary command on authentication |
| `diff.external` | `""` | Arbitrary command on `git diff` |
| `protocol.ext.allow` | `never` | RCE via `ext::` transport protocol (CVE-2022-25912) |

**2. Fixed condition gate bug (security gap)**

Previously, git security configs were only injected when `spec.volumeMounts()` was non-empty. If the agent ran `git clone` at runtime (no pre-mounted repos), **none** of the git security configs were active. Now:
- `safe.directory` entries: only when volume mounts are present (path-specific)
- All security configs: **always injected**

**3. Blocked git-related env vars from callers**

Added to `BLOCKED_ENV_VARS` (exact match, case-insensitive):
- `GIT_SSH`, `GIT_SSH_COMMAND`, `GIT_ASKPASS`, `GIT_EDITOR`, `GIT_EXEC_PATH`, `GIT_TEMPLATE_DIR` — direct command execution
- `GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND`, `GIT_SEQUENCE_EDITOR`, `GIT_PAGER` — override config equivalents independently
- `GIT_TERMINAL_PROMPT`, `GIT_ATTR_NOSYSTEM` — prevent callers from overriding hardening vars

Added `GIT_CONFIG_` to `BLOCKED_ENV_PREFIXES` to prevent callers from injecting `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_*`/`GIT_CONFIG_VALUE_*` that could override our security settings.

**4. Additional hardening env vars**

- `GIT_TERMINAL_PROMPT=0` — prevents git from prompting interactively (would hang the agent)
- `GIT_ATTR_NOSYSTEM=1` — prevents system-wide gitattributes from being loaded

### Known Limitations (tracked follow-ups)

- **`filter.*.clean`/`filter.*.smudge`/`filter.*.process`** — wildcard-keyed configs that cannot be enumerated or blocked via `GIT_CONFIG_COUNT`. A malicious repo can ship `.gitattributes` + `.git/config` with `filter.evil.clean=/exploit`. Requires `.git/config` sanitization post-clone.
- **`merge.*.driver`/`diff.*.textconv`** — same wildcard limitation; lower priority since they require explicit merge/diff tool invocation.

## How to Test

**Unit tests (75 tests in DockerSandboxAdapterTest):**
```bash
cd server/application-server && mvn test -Dsurefire.includedGroups="unit" -Dmaven.test.skip=false -DskipTests=false -Dtest="DockerSandboxAdapterTest" --batch-mode -q
```

**Architecture tests (9 tests):**
```bash
cd server/application-server && mvn test -Dsurefire.includedGroups="architecture" -Dmaven.test.skip=false -DskipTests=false -Dtest="SandboxArchitectureTest" --batch-mode -q
```

**All unit tests (2048 tests):**
```bash
cd server/application-server && mvn test -Dsurefire.includedGroups="unit" -Dmaven.test.skip=false -DskipTests=false --batch-mode -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enhanced sandbox security by expanding Git environment variable filtering to prevent arbitrary command execution and configuration overrides.
  * Added hardened Git security settings that disable hooks, prompts, editors, and external commands within the sandbox environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->