### PR TITLE
fix(server): add size limit to directory injection in SandboxWorkspaceManager

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/SandboxProperties.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/SandboxProperties.java
@@ -41,6 +41,8 @@ import org.springframework.validation.annotation.Validated;
  * @param llmProxyPort port on which the LLM proxy listens (inside the app-server container)
  * @param appServerContainerId Docker container ID of the app-server (null=auto-detect from
  *     HOSTNAME)
+ * @param maxDirectoryBytes maximum total bytes for directory injection via tar (default 1 GB)
+ * @param maxDirectoryEntries maximum entry count for directory injection (default 500,000)
  * @param defaultResourceLimits default resource constraints for containers
  */
 @Validated
@@ -56,6 +58,8 @@ public record SandboxProperties(
     @Nullable String containerRuntime,
     @DefaultValue("8080") @Min(1) int llmProxyPort,
     @Nullable String appServerContainerId,
+    @DefaultValue("1073741824") @Min(1) long maxDirectoryBytes, // 1 GB
+    @DefaultValue("500000") @Min(1) int maxDirectoryEntries,
     @Valid DefaultResourceLimits defaultResourceLimits
 ) {
     public SandboxProperties {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
@@ -96,8 +96,14 @@ public class DockerSandboxConfiguration {
     }
 
     @Bean
-    public SandboxWorkspaceManager sandboxWorkspaceManager(DockerClientOperations ops) {
-        return new SandboxWorkspaceManager(ops);
+    public SandboxWorkspaceManager sandboxWorkspaceManager(DockerClientOperations ops, SandboxProperties properties) {
+        return new SandboxWorkspaceManager(
+            ops,
+            SandboxWorkspaceManager.MAX_OUTPUT_BYTES,
+            SandboxWorkspaceManager.MAX_SINGLE_FILE_BYTES,
+            properties.maxDirectoryBytes(),
+            properties.maxDirectoryEntries()
+        );
     }
 
     /**

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxWorkspaceManager.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxWorkspaceManager.java
@@ -1,14 +1,18 @@
 package de.tum.in.www1.hephaestus.agent.sandbox.docker;
 
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.SandboxException;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -34,19 +38,38 @@ public class SandboxWorkspaceManager {
     /** Maximum total size of injected input files (50 MB). */
     static final long MAX_INPUT_BYTES = 50L * 1024 * 1024;
 
+    /** Maximum total size of a directory injected via tar (1 GB). */
+    static final long MAX_DIRECTORY_BYTES = 1024L * 1024 * 1024;
+
+    /** Maximum number of entries (files + directories) in a directory injection. */
+    static final int MAX_DIRECTORY_ENTRIES = 500_000;
+
+    /** Maximum directory tree depth for walk operations. */
+    static final int MAX_WALK_DEPTH = 50;
+
     private final DockerFileOperations fileOps;
     private final long maxOutputBytes;
     private final long maxSingleFileBytes;
+    private final long maxDirectoryBytes;
+    private final int maxDirectoryEntries;
 
     public SandboxWorkspaceManager(DockerFileOperations fileOps) {
-        this(fileOps, MAX_OUTPUT_BYTES, MAX_SINGLE_FILE_BYTES);
+        this(fileOps, MAX_OUTPUT_BYTES, MAX_SINGLE_FILE_BYTES, MAX_DIRECTORY_BYTES, MAX_DIRECTORY_ENTRIES);
     }
 
-    /** Package-private constructor for testing with smaller limits. */
-    SandboxWorkspaceManager(DockerFileOperations fileOps, long maxOutputBytes, long maxSingleFileBytes) {
+    /** Package-private constructor for testing with custom limits. */
+    SandboxWorkspaceManager(
+        DockerFileOperations fileOps,
+        long maxOutputBytes,
+        long maxSingleFileBytes,
+        long maxDirectoryBytes,
+        int maxDirectoryEntries
+    ) {
         this.fileOps = fileOps;
         this.maxOutputBytes = maxOutputBytes;
         this.maxSingleFileBytes = maxSingleFileBytes;
+        this.maxDirectoryBytes = maxDirectoryBytes;
+        this.maxDirectoryEntries = maxDirectoryEntries;
     }
 
     /**
@@ -93,29 +116,78 @@ public class SandboxWorkspaceManager {
     }
 
     /**
-     * Walk a host directory, create a tar archive, and copy it into the container.
-     * The tar entries are prefixed with the final path component so that extracting at
-     * the parent of containerPath produces the correct layout.
+     * Walk a host directory, create a tar archive on a temp file, and stream it into the container.
+     *
+     * <p>Uses a temporary file instead of {@link ByteArrayOutputStream} to avoid loading the entire
+     * archive into JVM heap. Memory usage is O(buffer_size) regardless of directory size, since each
+     * file is streamed through a fixed buffer. The docker-java transport streams the tar lazily via
+     * chunked transfer encoding — no additional buffering occurs downstream.
+     *
+     * <p>The tar entries are prefixed with the final path component so that extracting at the parent
+     * of containerPath produces the correct layout.
      */
     private void injectDirectoryViaTar(String containerId, String hostPath, String containerPath) {
         Path hostDir = Path.of(hostPath);
-        // Container path parent is where we extract; the tar has the dir name as prefix
         Path containerParent = Path.of(containerPath).getParent();
         String dirName = Path.of(containerPath).getFileName().toString();
         if (containerParent == null) {
             containerParent = Path.of("/");
         }
 
+        Path tempTar = null;
+        try {
+            tempTar = Files.createTempFile("hephaestus-inject-", ".tar");
+
+            // Phase 1: Walk directory and write tar to temp file.
+            // Memory: O(COPY_BUFFER_SIZE) — each file is streamed, never loaded whole.
+            writeTarToFile(tempTar, hostDir, dirName, hostPath);
+
+            // Phase 2: Stream tar from disk to Docker daemon.
+            // docker-java wraps this in InputStreamEntity (chunked transfer) — no heap copy.
+            try (InputStream tarStream = new BufferedInputStream(Files.newInputStream(tempTar))) {
+                fileOps.copyArchiveToContainer(containerId, containerParent.toString(), tarStream);
+            }
+        } catch (IOException e) {
+            throw new SandboxException("Failed to inject directory " + hostPath + " into container " + containerId, e);
+        } finally {
+            if (tempTar != null) {
+                try {
+                    Files.deleteIfExists(tempTar);
+                } catch (IOException e) {
+                    log.warn("Failed to delete temp tar file {}: {}", tempTar, e.getMessage());
+                }
+            }
+        }
+    }
+
+    /** Buffer size for streaming file contents into the tar archive (64 KB). */
+    private static final int COPY_BUFFER_SIZE = 64 * 1024;
+
+    /**
+     * Write a tar archive of the given directory to a file on disk. Files are streamed through a
+     * fixed-size buffer rather than loaded entirely into memory.
+     */
+    private void writeTarToFile(Path tarFile, Path hostDir, String dirName, String hostPath) throws IOException {
+        long[] totalBytes = { 0 };
+        int[] entryCount = { 0 };
+
         try (
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            TarArchiveOutputStream tar = new TarArchiveOutputStream(baos)
+            OutputStream fileOut = new BufferedOutputStream(Files.newOutputStream(tarFile), COPY_BUFFER_SIZE);
+            TarArchiveOutputStream tar = new TarArchiveOutputStream(fileOut);
+            Stream<Path> paths = Files.walk(hostDir, MAX_WALK_DEPTH)
         ) {
             tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
             tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
 
-            // Walk the directory tree and add each file/directory
-            Files.walk(hostDir).forEach(path -> {
+            paths.forEach(path -> {
                 try {
+                    entryCount[0]++;
+                    if (entryCount[0] > maxDirectoryEntries) {
+                        throw new SandboxException(
+                            "Directory injection exceeds entry count limit (" + maxDirectoryEntries + "): " + hostPath
+                        );
+                    }
+
                     String relativePath = hostDir.relativize(path).toString();
                     String entryName = relativePath.isEmpty() ? dirName : dirName + "/" + relativePath;
 
@@ -125,27 +197,33 @@ public class SandboxWorkspaceManager {
                         tar.putArchiveEntry(dirEntry);
                         tar.closeArchiveEntry();
                     } else if (Files.isRegularFile(path)) {
-                        byte[] content = Files.readAllBytes(path);
+                        long fileSize = Files.size(path);
+                        totalBytes[0] += fileSize;
+                        if (totalBytes[0] > maxDirectoryBytes) {
+                            throw new SandboxException(
+                                "Directory injection exceeds size limit (" + maxDirectoryBytes + " bytes): " + hostPath
+                            );
+                        }
+
                         TarArchiveEntry fileEntry = new TarArchiveEntry(entryName);
-                        fileEntry.setSize(content.length);
+                        fileEntry.setSize(fileSize);
                         fileEntry.setModTime(Files.getLastModifiedTime(path).toMillis());
                         tar.putArchiveEntry(fileEntry);
-                        tar.write(content);
+
+                        // Stream file through fixed buffer — not Files.readAllBytes()
+                        try (InputStream fileIn = Files.newInputStream(path)) {
+                            fileIn.transferTo(tar);
+                        }
                         tar.closeArchiveEntry();
                     }
-                    // Skip symlinks for security (already validated above)
+                    // Symlinks are silently skipped: Files.walk() does not follow them by default,
+                    // and Files.isRegularFile/isDirectory return false for unresolved symlinks.
                 } catch (IOException e) {
                     throw new SandboxException("Failed to add file to tar: " + path, e);
                 }
             });
 
             tar.finish();
-
-            try (InputStream tarStream = new ByteArrayInputStream(baos.toByteArray())) {
-                fileOps.copyArchiveToContainer(containerId, containerParent.toString(), tarStream);
-            }
-        } catch (IOException e) {
-            throw new SandboxException("Failed to inject directory " + hostPath + " into container " + containerId, e);
         }
     }
 

--- a/server/application-server/src/main/resources/application.yml
+++ b/server/application-server/src/main/resources/application.yml
@@ -424,6 +424,8 @@ hephaestus:
         # OCI runtime: null=runc (default), "runsc"=gVisor (recommended for production)
         container-runtime: ${SANDBOX_CONTAINER_RUNTIME:}
         llm-proxy-port: ${SANDBOX_LLM_PROXY_PORT:8080}
+        max-directory-bytes: ${SANDBOX_MAX_DIRECTORY_BYTES:1073741824}  # 1 GB
+        max-directory-entries: ${SANDBOX_MAX_DIRECTORY_ENTRIES:500000}
         default-resource-limits:
             memory-bytes: ${SANDBOX_MEMORY_BYTES:4294967296}  # 4 GB (includes tmpfs)
             cpus: ${SANDBOX_CPUS:2.0}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/ContainerSecurityPolicyTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/ContainerSecurityPolicyTest.java
@@ -34,6 +34,8 @@ class ContainerSecurityPolicyTest extends BaseUnitTest {
             null,
             8080,
             null,
+            209_715_200L,
+            500_000,
             null
         );
         securityPolicy = new ContainerSecurityPolicy(properties, null);
@@ -205,6 +207,8 @@ class ContainerSecurityPolicyTest extends BaseUnitTest {
                 "runsc",
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             ContainerSecurityPolicy policyWithRuntime = new ContainerSecurityPolicy(propsWithRuntime, null);
@@ -265,6 +269,8 @@ class ContainerSecurityPolicyTest extends BaseUnitTest {
                     null,
                     8080,
                     null,
+                    209_715_200L,
+                    500_000,
                     null
                 ),
                 "{\"defaultAction\":\"SCMP_ACT_ERRNO\"}"
@@ -497,6 +503,8 @@ class ContainerSecurityPolicyTest extends BaseUnitTest {
                 "runsc",
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             ContainerSecurityPolicy policyWithRuntime = new ContainerSecurityPolicy(propsWithRuntime, null);

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerHealthIndicatorTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerHealthIndicatorTest.java
@@ -34,6 +34,8 @@ class DockerHealthIndicatorTest extends BaseUnitTest {
             null,
             8080,
             null,
+            209_715_200L,
+            500_000,
             null
         );
         indicator = new DockerHealthIndicator(containerManager, properties);

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxAdapterTest.java
@@ -91,6 +91,8 @@ class DockerSandboxAdapterTest extends BaseUnitTest {
             null,
             8080,
             null,
+            209_715_200L,
+            500_000,
             null
         );
         meterRegistry = new SimpleMeterRegistry();

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxLiveTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/DockerSandboxLiveTest.java
@@ -69,6 +69,8 @@ class DockerSandboxLiveTest {
             null,
             8080,
             null,
+            209_715_200L,
+            500_000,
             null
         );
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxContainerManagerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxContainerManagerTest.java
@@ -47,6 +47,8 @@ class SandboxContainerManagerTest extends BaseUnitTest {
             null,
             8080,
             null,
+            209_715_200L,
+            500_000,
             null
         );
         executor = Executors.newSingleThreadExecutor();

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxNetworkManagerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxNetworkManagerTest.java
@@ -42,6 +42,8 @@ class SandboxNetworkManagerTest extends BaseUnitTest {
             null,
             8080,
             "app-server-id",
+            209_715_200L,
+            500_000,
             null
         );
         manager = new SandboxNetworkManager(networkOps, properties);
@@ -102,6 +104,8 @@ class SandboxNetworkManagerTest extends BaseUnitTest {
                 null,
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             SandboxNetworkManager mgr = new SandboxNetworkManager(networkOps, propsNoId, () -> "hostname-container-id");
@@ -128,6 +132,8 @@ class SandboxNetworkManagerTest extends BaseUnitTest {
                 null,
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             SandboxNetworkManager mgr = new SandboxNetworkManager(networkOps, propsNoId, () -> null);
@@ -151,6 +157,8 @@ class SandboxNetworkManagerTest extends BaseUnitTest {
                 null,
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             SandboxNetworkManager mgr = new SandboxNetworkManager(networkOps, propsNoId, () -> "  ");
@@ -175,6 +183,8 @@ class SandboxNetworkManagerTest extends BaseUnitTest {
                 null,
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             SandboxNetworkManager mgr = new SandboxNetworkManager(networkOps, propsNoId, () -> {
@@ -217,6 +227,8 @@ class SandboxNetworkManagerTest extends BaseUnitTest {
                 null,
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             SandboxNetworkManager mgr = new SandboxNetworkManager(networkOps, propsNoId, () -> null);

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxReconcilerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxReconcilerTest.java
@@ -51,6 +51,8 @@ class SandboxReconcilerTest extends BaseUnitTest {
             null,
             8080,
             null,
+            209_715_200L,
+            500_000,
             null
         );
         meterRegistry = new SimpleMeterRegistry();
@@ -75,6 +77,8 @@ class SandboxReconcilerTest extends BaseUnitTest {
                 null,
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             var disabledReconciler = new SandboxReconciler(
@@ -104,6 +108,8 @@ class SandboxReconcilerTest extends BaseUnitTest {
                 null,
                 8080,
                 null,
+                209_715_200L,
+                500_000,
                 null
             );
             var disabledReconciler = new SandboxReconciler(

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxWorkspaceManagerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/SandboxWorkspaceManagerTest.java
@@ -141,7 +141,9 @@ class SandboxWorkspaceManagerTest extends BaseUnitTest {
             var limitedManager = new SandboxWorkspaceManager(
                 fileOps,
                 1024,
-                SandboxWorkspaceManager.MAX_SINGLE_FILE_BYTES
+                SandboxWorkspaceManager.MAX_SINGLE_FILE_BYTES,
+                SandboxWorkspaceManager.MAX_DIRECTORY_BYTES,
+                SandboxWorkspaceManager.MAX_DIRECTORY_ENTRIES
             );
 
             byte[] largeContent = new byte[800]; // 800 bytes
@@ -213,7 +215,13 @@ class SandboxWorkspaceManagerTest extends BaseUnitTest {
         @DisplayName("should skip single files exceeding per-file size limit")
         void shouldSkipOversizedSingleFile() throws Exception {
             // Use a manager with a 10-byte per-file limit to avoid allocating megabytes in tests
-            var limitedManager = new SandboxWorkspaceManager(fileOps, 10_000, 10);
+            var limitedManager = new SandboxWorkspaceManager(
+                fileOps,
+                10_000,
+                10,
+                SandboxWorkspaceManager.MAX_DIRECTORY_BYTES,
+                SandboxWorkspaceManager.MAX_DIRECTORY_ENTRIES
+            );
 
             byte[] smallContent = "small".getBytes(); // 5 bytes — under limit
             byte[] oversizedContent = "this is way too big".getBytes(); // 19 bytes — over 10-byte limit
@@ -254,10 +262,121 @@ class SandboxWorkspaceManagerTest extends BaseUnitTest {
         @TempDir
         Path tempDir;
 
+        // ---- Size limit tests (from this PR) ----
+
+        @Test
+        @DisplayName("should reject directory exceeding size limit")
+        void shouldRejectDirectoryExceedingSizeLimit() throws Exception {
+            // Use a tiny limit (1 KB) to avoid allocating megabytes in CI
+            var limitedManager = new SandboxWorkspaceManager(
+                fileOps,
+                50L * 1024 * 1024,
+                10L * 1024 * 1024,
+                1024,
+                SandboxWorkspaceManager.MAX_DIRECTORY_ENTRIES
+            );
+
+            // Create two files totaling > 1024 bytes
+            Files.write(tempDir.resolve("file1.txt"), new byte[600]);
+            Files.write(tempDir.resolve("file2.txt"), new byte[600]);
+
+            assertThatThrownBy(() ->
+                limitedManager.injectDirectories(
+                    CONTAINER_ID,
+                    Map.of(tempDir.toAbsolutePath().toString(), "/workspace/repo")
+                )
+            )
+                .isInstanceOf(SandboxException.class)
+                .hasMessageContaining("size limit");
+        }
+
+        @Test
+        @DisplayName("should accept directory at exact size limit (inclusive)")
+        void shouldAcceptDirectoryAtExactSizeLimit() throws Exception {
+            // Exactly 100 bytes of content — limit is 100
+            var limitedManager = new SandboxWorkspaceManager(
+                fileOps,
+                50L * 1024 * 1024,
+                10L * 1024 * 1024,
+                100,
+                SandboxWorkspaceManager.MAX_DIRECTORY_ENTRIES
+            );
+
+            Files.write(tempDir.resolve("exact.txt"), new byte[100]);
+
+            limitedManager.injectDirectories(
+                CONTAINER_ID,
+                Map.of(tempDir.toAbsolutePath().toString(), "/workspace/repo")
+            );
+
+            verify(fileOps).copyArchiveToContainer(eq(CONTAINER_ID), eq("/workspace"), any(InputStream.class));
+        }
+
+        @Test
+        @DisplayName("should accept directory within size limit")
+        void shouldAcceptDirectoryWithinSizeLimit() throws Exception {
+            var limitedManager = new SandboxWorkspaceManager(
+                fileOps,
+                50L * 1024 * 1024,
+                10L * 1024 * 1024,
+                4096,
+                SandboxWorkspaceManager.MAX_DIRECTORY_ENTRIES
+            );
+
+            Files.write(tempDir.resolve("small.txt"), "hello".getBytes());
+
+            limitedManager.injectDirectories(
+                CONTAINER_ID,
+                Map.of(tempDir.toAbsolutePath().toString(), "/workspace/repo")
+            );
+
+            verify(fileOps).copyArchiveToContainer(eq(CONTAINER_ID), eq("/workspace"), any(InputStream.class));
+        }
+
+        @Test
+        @DisplayName("should inject nested subdirectories correctly")
+        void shouldInjectNestedSubdirectories() throws Exception {
+            var limitedManager = new SandboxWorkspaceManager(
+                fileOps,
+                50L * 1024 * 1024,
+                10L * 1024 * 1024,
+                4096,
+                SandboxWorkspaceManager.MAX_DIRECTORY_ENTRIES
+            );
+
+            // Create a nested directory structure: sub/nested.txt
+            Path subDir = Files.createDirectory(tempDir.resolve("sub"));
+            Files.write(subDir.resolve("nested.txt"), "nested content".getBytes());
+            Files.write(tempDir.resolve("root.txt"), "root content".getBytes());
+
+            limitedManager.injectDirectories(
+                CONTAINER_ID,
+                Map.of(tempDir.toAbsolutePath().toString(), "/workspace/repo")
+            );
+
+            verify(fileOps).copyArchiveToContainer(eq(CONTAINER_ID), eq("/workspace"), any(InputStream.class));
+        }
+
+        @Test
+        @DisplayName("should have reasonable entry count limit constant")
+        void shouldHaveReasonableEntryCountLimit() {
+            assertThat(SandboxWorkspaceManager.MAX_DIRECTORY_ENTRIES).isEqualTo(500_000);
+        }
+
+        // ---- Validation tests (from main) ----
+
         @Test
         @DisplayName("should skip injection when directory mounts is null")
         void shouldSkipWhenDirectoryMountsNull() {
             manager.injectDirectories(CONTAINER_ID, null);
+
+            verify(fileOps, never()).copyArchiveToContainer(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("should skip injection when mounts map is empty")
+        void shouldSkipWhenMountsMapIsEmpty() {
+            manager.injectDirectories(CONTAINER_ID, Map.of());
 
             verify(fileOps, never()).copyArchiveToContainer(any(), any(), any());
         }


### PR DESCRIPTION
## Summary

`SandboxWorkspaceManager.injectDirectoryViaTar()` buffered entire tar archives in JVM heap via `ByteArrayOutputStream`. Large repos caused `OutOfMemoryError`.

**Fix**: Stream tar to a temp file, then stream from disk to Docker daemon. Peak memory drops from O(archive_size) to O(64 KB).

- Temp file streaming for directory injection (no heap buffering)
- Per-file streaming via `InputStream.transferTo()` (no `Files.readAllBytes()`)
- `Files.walk()` stream leak fix (try-with-resources)
- Configurable limits: 1 GB directory bytes, 500k entries, 50 walk depth

Fixes #903

## Test plan

- [ ] `./mvnw test -Dsurefire.includedGroups="unit" -Dtest="SandboxWorkspaceManagerTest"` (30 tests)
- [ ] `./mvnw test -Dsurefire.includedGroups="architecture"` (114 tests)
- [ ] Size limit exceeded → `SandboxException`
- [ ] Normal repos inject successfully
- [ ] Limits configurable via `hephaestus.sandbox.max-directory-bytes` / `max-directory-entries`