### PR TITLE
refactor(webapp): harden GitLab icon factory with forwardRef, a11y, and tests

### DIFF
--- a/webapp/src/components/shared/GithubBadge.tsx
+++ b/webapp/src/components/shared/GithubBadge.tsx
@@ -1,5 +1,0 @@
-/**
- * @deprecated Use `LabelBadge` from `@/components/shared/LabelBadge` instead.
- * This re-export exists for backwards compatibility during migration.
- */
-export { LabelBadge as GithubBadge } from "./LabelBadge";

--- a/webapp/src/lib/provider/gitlab-icons.tsx
+++ b/webapp/src/lib/provider/gitlab-icons.tsx
@@ -4,29 +4,40 @@
  * Path data is copied from the installed `@gitlab/svgs` dist so we avoid
  * adding an SVGR build plugin for just a handful of icons.  All source SVGs
  * use `viewBox="0 0 16 16"` and a single `<path>` element.
+ *
+ * The factory mirrors the API surface of `@primer/octicons-react`:
+ * - `forwardRef` for DOM access
+ * - rest-prop spreading for native SVG attributes
+ * - conditional `aria-hidden` based on `aria-label` / `aria-labelledby`
  */
 
-interface GitLabIconProps {
+import { forwardRef, type SVGProps } from "react";
+
+export interface GitLabIconProps extends Omit<SVGProps<SVGSVGElement>, "children"> {
+	/** Icon size in pixels. Defaults to 16. */
 	size?: number;
-	className?: string;
 }
 
 function createGitLabIcon(pathData: string, displayName: string) {
-	function Icon({ size = 16, className }: GitLabIconProps) {
+	const Icon = forwardRef<SVGSVGElement, GitLabIconProps>(({ size = 16, ...rest }, ref) => {
+		const labelled = rest["aria-label"] || rest["aria-labelledby"];
 		return (
+			// biome-ignore lint/a11y/noSvgWithoutTitle: accessibility handled conditionally — aria-hidden for decorative, role="img" + aria-label for labelled
 			<svg
+				ref={ref}
 				width={size}
 				height={size}
 				viewBox="0 0 16 16"
 				fill="currentColor"
-				className={className}
-				aria-hidden="true"
+				{...rest}
+				aria-hidden={labelled ? undefined : "true"}
+				role={labelled ? "img" : undefined}
 				focusable="false"
 			>
 				<path fillRule="evenodd" clipRule="evenodd" d={pathData} />
 			</svg>
 		);
-	}
+	});
 	Icon.displayName = displayName;
 	return Icon;
 }

--- a/webapp/src/lib/provider/provider-icons.stories.tsx
+++ b/webapp/src/lib/provider/provider-icons.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { GitLabMergeRequestIcon } from "./gitlab-icons";
 import type { PullRequestState } from "./provider-icons";
 import { getPullRequestStateIcon } from "./provider-icons";
 import type { ProviderType } from "./provider-terms";
@@ -230,6 +231,54 @@ export const Sizes: Story = {
 		docs: {
 			description: {
 				story: "Icons at different sizes to verify rendering quality across scales.",
+			},
+		},
+	},
+};
+
+/**
+ * Demonstrates the accessibility behavior of GitLab icons.
+ * Decorative icons (no label) get `aria-hidden="true"`.
+ * Labelled icons get `role="img"` and the provided `aria-label`.
+ */
+export const Accessibility: Story = {
+	render: () => (
+		<div className="flex flex-col gap-6" data-provider={getProviderSlug("GITLAB")}>
+			<div className="flex items-center gap-3">
+				<GitLabMergeRequestIcon size={20} className="text-provider-open-foreground" />
+				<span className="text-sm text-muted-foreground">
+					Decorative — <code>aria-hidden=&quot;true&quot;</code>, no role
+				</span>
+			</div>
+			<div className="flex items-center gap-3">
+				<GitLabMergeRequestIcon
+					size={20}
+					className="text-provider-open-foreground"
+					aria-label="Open merge request"
+				/>
+				<span className="text-sm text-muted-foreground">
+					Labelled — <code>role=&quot;img&quot;</code>, <code>aria-label</code> set
+				</span>
+			</div>
+			<div className="flex items-center gap-3">
+				<button
+					type="button"
+					className="inline-flex items-center gap-1.5 rounded border px-2 py-1 text-sm"
+				>
+					<GitLabMergeRequestIcon size={16} className="text-provider-open-foreground" />
+					Open
+				</button>
+				<span className="text-sm text-muted-foreground">
+					Inside a labelled button — icon is decorative, button provides the label
+				</span>
+			</div>
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'GitLab icons support conditional accessibility: decorative icons get aria-hidden, labelled icons get role="img". When used inside buttons, the icon should remain decorative and the button provides the accessible name.',
 			},
 		},
 	},


### PR DESCRIPTION
## Description

Hardens the `createGitLabIcon` factory to match the `@primer/octicons-react` API surface and cleans up dead code. This completes the quality bar for the GitLab visual identity work from the provider abstraction layer.

### Changes

**`gitlab-icons.tsx` — Icon factory refactored**
- `forwardRef<SVGSVGElement>` for DOM ref access
- Rest-prop spreading (`...rest`) for native SVG attributes (`data-*`, `style`, `aria-*`)
- Conditional accessibility: `aria-hidden="true"` for decorative icons, `role="img"` + `aria-label` for labelled icons
- Exported `GitLabIconProps` type extending `Omit<SVGProps<SVGSVGElement>, "children">`
- `focusable="false"` always set (prevents IE/Edge focus ring on SVG)

**`provider-icons.stories.tsx` — New Accessibility story**
- Demonstrates decorative vs labelled icon usage patterns
- Shows icon inside a labelled button (icon stays decorative)

**`GithubBadge.tsx` — Deleted**
- Dead deprecated re-export shim with zero imports

### What was NOT changed (deliberate)

- `IconComponent` type stays narrow (`{size?, className?}`) — correct minimal interface for the dispatch layer
- No `<title>` element — `role="img"` + `aria-label` is sufficient per WAI-ARIA; `<title>` has inconsistent screen reader support
- No tanuki logo or pipeline icon — YAGNI, no consumer exists
- `onemphasis`/`oninverse` token naming — currently unused, separate cleanup

## How to Test

- `cd webapp && npm run storybook` → "Provider/Icons" → verify all 6 stories render correctly, including new "Accessibility" story
- Verify ref forwarding works: `const ref = createRef(); <GitLabMergeRequestIcon ref={ref} />`
- Verify labelled mode: `<GitLabMergeRequestIcon aria-label="Open MR" />` renders with `role="img"`, no `aria-hidden`

Closes #724