### PR TITLE
refactor(db): standardize organization login constraint to case-insensitive

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/organization/Organization.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/organization/Organization.java
@@ -23,11 +23,11 @@ import org.springframework.lang.NonNull;
 @Setter
 @NoArgsConstructor
 @ToString(callSuper = true)
+// Case-insensitive unique constraint on LOWER(login) is managed by Liquibase (functional index — not expressible in JPA).
 @Table(
     name = "organization",
     uniqueConstraints = {
         @UniqueConstraint(name = "uq_organization_provider_native_id", columnNames = { "provider_id", "native_id" }),
-        @UniqueConstraint(name = "uq_organization_provider_login", columnNames = { "provider_id", "login" }),
     }
 )
 public class Organization extends BaseGitServiceEntity {

--- a/server/application-server/src/main/resources/db/changelog/1774558928650_changelog.xml
+++ b/server/application-server/src/main/resources/db/changelog/1774558928650_changelog.xml
@@ -1,0 +1,160 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Standardize organization login uniqueness to case-insensitive (matches User table pattern).
+
+        The User table already uses LOWER(login) in its unique index (uk_user_provider_login,
+        created in 1772284124265). The Organization table still uses a case-sensitive constraint.
+        Under concurrent webhook load, two threads could insert the same org with different casings
+        ("MyOrg" / "myorg") and the case-sensitive constraint would allow both.
+
+        This migration:
+          1. Reassigns FK references from duplicate orgs to the canonical (lowest-id) row
+          2. Deletes duplicate organization rows that differ only in login casing
+          3. Replaces the case-sensitive unique constraint with a functional index on LOWER(login)
+
+        FK references to organization.id exist in:
+          - repository.organization_id       (fk_repository_organization)
+          - workspace.organization_id        (fk_workspace_organization)
+          - issue_type.organization_id       (fk_issue_type_organization)
+          - organization_membership          (composite PK: organization_id, user_id)
+    -->
+
+    <!-- Step 1: Reassign FK references and delete case-variant duplicate organizations -->
+    <changeSet id="1774558928650-1" author="issue-404">
+        <comment>Deduplicate organization rows that differ only in login casing.
+            Reassigns all FK references (repository, workspace, issue_type, organization_membership)
+            from duplicate rows to the canonical row (lowest id per provider_id + LOWER(login) group),
+            then deletes the duplicates. This is irreversible — deleted rows cannot be restored.</comment>
+        <sql>
+            -- Identify canonical (surviving) row per case-insensitive group
+            WITH canonical AS (
+                SELECT MIN(id) AS keep_id, provider_id, LOWER(login) AS login_lower
+                FROM organization
+                GROUP BY provider_id, LOWER(login)
+            ),
+            dupes AS (
+                SELECT o.id AS dupe_id, c.keep_id
+                FROM organization o
+                JOIN canonical c ON o.provider_id = c.provider_id
+                    AND LOWER(o.login) = c.login_lower
+                    AND o.id != c.keep_id
+            )
+            -- Reassign repository FK references
+            UPDATE repository SET organization_id = d.keep_id
+            FROM dupes d WHERE repository.organization_id = d.dupe_id;
+        </sql>
+        <sql>
+            WITH canonical AS (
+                SELECT MIN(id) AS keep_id, provider_id, LOWER(login) AS login_lower
+                FROM organization
+                GROUP BY provider_id, LOWER(login)
+            ),
+            dupes AS (
+                SELECT o.id AS dupe_id, c.keep_id
+                FROM organization o
+                JOIN canonical c ON o.provider_id = c.provider_id
+                    AND LOWER(o.login) = c.login_lower
+                    AND o.id != c.keep_id
+            )
+            -- Reassign workspace FK references
+            UPDATE workspace SET organization_id = d.keep_id
+            FROM dupes d WHERE workspace.organization_id = d.dupe_id;
+        </sql>
+        <sql>
+            WITH canonical AS (
+                SELECT MIN(id) AS keep_id, provider_id, LOWER(login) AS login_lower
+                FROM organization
+                GROUP BY provider_id, LOWER(login)
+            ),
+            dupes AS (
+                SELECT o.id AS dupe_id, c.keep_id
+                FROM organization o
+                JOIN canonical c ON o.provider_id = c.provider_id
+                    AND LOWER(o.login) = c.login_lower
+                    AND o.id != c.keep_id
+            )
+            -- Reassign issue_type FK references
+            UPDATE issue_type SET organization_id = d.keep_id
+            FROM dupes d WHERE issue_type.organization_id = d.dupe_id;
+        </sql>
+        <sql>
+            -- Reassign organization_membership rows from duplicate orgs to canonical orgs.
+            -- INSERT...ON CONFLICT handles cases where the canonical org already has a membership
+            -- for the same user (keep the existing one, skip the duplicate's membership).
+            WITH canonical AS (
+                SELECT MIN(id) AS keep_id, provider_id, LOWER(login) AS login_lower
+                FROM organization
+                GROUP BY provider_id, LOWER(login)
+            ),
+            dupes AS (
+                SELECT o.id AS dupe_id, c.keep_id
+                FROM organization o
+                JOIN canonical c ON o.provider_id = c.provider_id
+                    AND LOWER(o.login) = c.login_lower
+                    AND o.id != c.keep_id
+            )
+            INSERT INTO organization_membership (organization_id, user_id, role)
+            SELECT d.keep_id, om.user_id, om.role
+            FROM organization_membership om
+            JOIN dupes d ON om.organization_id = d.dupe_id
+            ON CONFLICT (organization_id, user_id) DO NOTHING;
+        </sql>
+        <sql>
+            -- Delete membership rows that still reference duplicate orgs (already reassigned above)
+            WITH canonical AS (
+                SELECT MIN(id) AS keep_id, provider_id, LOWER(login) AS login_lower
+                FROM organization
+                GROUP BY provider_id, LOWER(login)
+            ),
+            dupes AS (
+                SELECT o.id AS dupe_id, c.keep_id
+                FROM organization o
+                JOIN canonical c ON o.provider_id = c.provider_id
+                    AND LOWER(o.login) = c.login_lower
+                    AND o.id != c.keep_id
+            )
+            DELETE FROM organization_membership
+            WHERE organization_id IN (SELECT dupe_id FROM dupes);
+        </sql>
+        <sql>
+            -- Now delete the duplicate organization rows (all FK references already reassigned)
+            DELETE FROM organization
+            WHERE id NOT IN (
+                SELECT MIN(id) FROM organization GROUP BY provider_id, LOWER(login)
+            );
+        </sql>
+        <rollback>
+            <!-- Data deletion is irreversible. This changeset cannot be rolled back.
+                 Restore from backup if needed. -->
+        </rollback>
+    </changeSet>
+
+    <!-- Step 2: Replace case-sensitive constraint with case-insensitive functional index.
+         No preCondition needed: the old constraint and new index share the same name
+         (uq_organization_provider_login), making indexExists indistinguishable between the two.
+         The DROP CONSTRAINT IF EXISTS + DROP INDEX IF EXISTS guards handle both cases safely. -->
+    <changeSet id="1774558928650-2" author="issue-404">
+        <comment>Replace case-sensitive uq_organization_provider_login with case-insensitive
+            functional index, matching the User table pattern (uk_user_provider_login).</comment>
+        <sql>
+            ALTER TABLE organization DROP CONSTRAINT IF EXISTS uq_organization_provider_login;
+            DROP INDEX IF EXISTS uq_organization_provider_login;
+        </sql>
+        <sql>
+            CREATE UNIQUE INDEX uq_organization_provider_login ON organization (provider_id, LOWER(login));
+        </sql>
+        <rollback>
+            <sql>DROP INDEX IF EXISTS uq_organization_provider_login;</sql>
+            <sql>
+                ALTER TABLE organization
+                ADD CONSTRAINT uq_organization_provider_login UNIQUE (provider_id, login);
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/application-server/src/main/resources/db/master.xml
+++ b/server/application-server/src/main/resources/db/master.xml
@@ -63,4 +63,5 @@
     <include file="./changelog/1774472313956_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1774600000000_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1774528639746_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1774558928650_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/organization/OrganizationServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/organization/OrganizationServiceTest.java
@@ -1,0 +1,138 @@
+package de.tum.in.www1.hephaestus.gitprovider.organization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.in.www1.hephaestus.gitprovider.common.GitProvider;
+import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderRepository;
+import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+@DisplayName("OrganizationService")
+class OrganizationServiceTest extends BaseUnitTest {
+
+    private static final Long PROVIDER_ID = 1L;
+    private static final long NATIVE_ID = 42L;
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private GitProviderRepository gitProviderRepository;
+
+    private OrganizationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new OrganizationService(organizationRepository, gitProviderRepository);
+
+        lenient().when(gitProviderRepository.getReferenceById(PROVIDER_ID)).thenReturn(new GitProvider());
+        lenient()
+            .when(organizationRepository.saveAndFlush(any(Organization.class)))
+            .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("upsertIdentity")
+    class UpsertIdentity {
+
+        @Test
+        @DisplayName("creates new organization when none exists for nativeId")
+        void newOrg_createsAndSetsLogin() {
+            when(organizationRepository.findByNativeIdAndProviderId(NATIVE_ID, PROVIDER_ID)).thenReturn(
+                Optional.empty()
+            );
+
+            Organization result = service.upsertIdentity(NATIVE_ID, "MyOrg", PROVIDER_ID);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getLogin()).isEqualTo("MyOrg");
+            assertThat(result.getNativeId()).isEqualTo(NATIVE_ID);
+            verify(organizationRepository).saveAndFlush(any(Organization.class));
+        }
+
+        @Test
+        @DisplayName("case-only rename from provider IS persisted (dirty-check is case-sensitive)")
+        void caseOnlyRename_isPersisted() {
+            Organization existing = createExistingOrg("myorg");
+            when(organizationRepository.findByNativeIdAndProviderId(NATIVE_ID, PROVIDER_ID)).thenReturn(
+                Optional.of(existing)
+            );
+
+            Organization result = service.upsertIdentity(NATIVE_ID, "MyOrg", PROVIDER_ID);
+
+            // The canonical casing from the provider must be saved
+            assertThat(result.getLogin()).isEqualTo("MyOrg");
+            ArgumentCaptor<Organization> captor = ArgumentCaptor.forClass(Organization.class);
+            verify(organizationRepository).saveAndFlush(captor.capture());
+            assertThat(captor.getValue().getLogin()).isEqualTo("MyOrg");
+        }
+
+        @Test
+        @DisplayName("identical login preserves existing value unchanged")
+        void identicalLogin_preservesValue() {
+            Organization existing = createExistingOrg("MyOrg");
+            when(organizationRepository.findByNativeIdAndProviderId(NATIVE_ID, PROVIDER_ID)).thenReturn(
+                Optional.of(existing)
+            );
+
+            Organization result = service.upsertIdentity(NATIVE_ID, "MyOrg", PROVIDER_ID);
+
+            // Login unchanged — verify the value is still the original
+            assertThat(result.getLogin()).isEqualTo("MyOrg");
+
+            // Verify save was still called (upsertIdentity always saves)
+            ArgumentCaptor<Organization> captor = ArgumentCaptor.forClass(Organization.class);
+            verify(organizationRepository).saveAndFlush(captor.capture());
+            assertThat(captor.getValue().getLogin()).isEqualTo("MyOrg");
+        }
+
+        @Test
+        @DisplayName("full rename updates login")
+        void fullRename_updatesLogin() {
+            Organization existing = createExistingOrg("old-org");
+            when(organizationRepository.findByNativeIdAndProviderId(NATIVE_ID, PROVIDER_ID)).thenReturn(
+                Optional.of(existing)
+            );
+
+            Organization result = service.upsertIdentity(NATIVE_ID, "new-org", PROVIDER_ID);
+
+            assertThat(result.getLogin()).isEqualTo("new-org");
+        }
+
+        @Test
+        @DisplayName("null login throws IllegalArgumentException")
+        void nullLogin_throws() {
+            assertThatThrownBy(() -> service.upsertIdentity(NATIVE_ID, null, PROVIDER_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("login required");
+        }
+
+        @Test
+        @DisplayName("blank login throws IllegalArgumentException")
+        void blankLogin_throws() {
+            assertThatThrownBy(() -> service.upsertIdentity(NATIVE_ID, "  ", PROVIDER_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("login required");
+        }
+    }
+
+    private Organization createExistingOrg(String login) {
+        Organization org = new Organization();
+        org.setId(100L);
+        org.setNativeId(NATIVE_ID);
+        org.setLogin(login);
+        org.setHtmlUrl("https://github.com/" + login);
+        return org;
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/workspace/WorkspaceInstallationServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/workspace/WorkspaceInstallationServiceTest.java
@@ -1,0 +1,185 @@
+package de.tum.in.www1.hephaestus.workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderRepository;
+import de.tum.in.www1.hephaestus.gitprovider.common.github.app.GitHubAppTokenService;
+import de.tum.in.www1.hephaestus.gitprovider.organization.OrganizationService;
+import de.tum.in.www1.hephaestus.gitprovider.repository.RepositoryRepository;
+import de.tum.in.www1.hephaestus.gitprovider.sync.NatsConsumerService;
+import de.tum.in.www1.hephaestus.gitprovider.sync.NatsProperties;
+import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
+import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+@DisplayName("WorkspaceInstallationService")
+class WorkspaceInstallationServiceTest extends BaseUnitTest {
+
+    private static final long INSTALLATION_ID = 123L;
+
+    @Mock
+    private NatsProperties natsProperties;
+
+    @Mock
+    private WorkspaceRepository workspaceRepository;
+
+    @Mock
+    private RepositoryToMonitorRepository repositoryToMonitorRepository;
+
+    @Mock
+    private RepositoryRepository repositoryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GitProviderRepository gitProviderRepository;
+
+    @Mock
+    private WorkspaceSlugService workspaceSlugService;
+
+    @Mock
+    private WorkspaceMembershipService workspaceMembershipService;
+
+    @Mock
+    private NatsConsumerService natsConsumerService;
+
+    @Mock
+    private GitHubAppTokenService gitHubAppTokenService;
+
+    @Mock
+    private OrganizationService organizationService;
+
+    private WorkspaceInstallationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkspaceInstallationService(
+            natsProperties,
+            workspaceRepository,
+            repositoryToMonitorRepository,
+            repositoryRepository,
+            userRepository,
+            gitProviderRepository,
+            workspaceSlugService,
+            workspaceMembershipService,
+            natsConsumerService,
+            gitHubAppTokenService,
+            organizationService
+        );
+
+        lenient().when(natsProperties.enabled()).thenReturn(false);
+        lenient()
+            .when(workspaceRepository.save(any(Workspace.class)))
+            .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("handleAccountRename")
+    class HandleAccountRename {
+
+        @Test
+        @DisplayName("case-only rename updates accountLogin on workspace")
+        void caseOnlyRename_updatesAccountLogin() {
+            Workspace workspace = createWorkspace("myorg");
+            when(workspaceRepository.findByInstallationId(INSTALLATION_ID)).thenReturn(Optional.of(workspace));
+
+            service.handleAccountRename(INSTALLATION_ID, "myorg", "MyOrg");
+
+            // The canonical casing from GitHub must be persisted
+            ArgumentCaptor<Workspace> captor = ArgumentCaptor.forClass(Workspace.class);
+            verify(workspaceRepository).save(captor.capture());
+            assertThat(captor.getValue().getAccountLogin()).isEqualTo("MyOrg");
+        }
+
+        @Test
+        @DisplayName("case-only rename skips repository retargeting (equalsIgnoreCase guard)")
+        void caseOnlyRename_skipsRepositoryRetargeting() {
+            Workspace workspace = createWorkspace("myorg");
+            when(workspaceRepository.findByInstallationId(INSTALLATION_ID)).thenReturn(Optional.of(workspace));
+
+            service.handleAccountRename(INSTALLATION_ID, "myorg", "MyOrg");
+
+            // Repository retargeting should not query for repositories (old == new ignoring case)
+            verify(repositoryRepository, never()).findByNameWithOwnerStartingWithIgnoreCase(any());
+        }
+
+        @Test
+        @DisplayName("real rename updates accountLogin and retargets repositories")
+        void realRename_updatesAndRetargets() {
+            Workspace workspace = createWorkspace("old-org");
+            workspace.setId(1L);
+            when(workspaceRepository.findByInstallationId(INSTALLATION_ID)).thenReturn(Optional.of(workspace));
+            when(repositoryToMonitorRepository.findByWorkspaceId(1L)).thenReturn(Collections.emptyList());
+            when(repositoryRepository.findByNameWithOwnerStartingWithIgnoreCase("old-org/")).thenReturn(
+                Collections.emptyList()
+            );
+
+            service.handleAccountRename(INSTALLATION_ID, "old-org", "new-org");
+
+            ArgumentCaptor<Workspace> captor = ArgumentCaptor.forClass(Workspace.class);
+            verify(workspaceRepository).save(captor.capture());
+            assertThat(captor.getValue().getAccountLogin()).isEqualTo("new-org");
+
+            // Repository retargeting is attempted (different base names)
+            verify(repositoryRepository).findByNameWithOwnerStartingWithIgnoreCase("old-org/");
+        }
+
+        @Test
+        @DisplayName("identical login skips update entirely")
+        void identicalLogin_skipsUpdate() {
+            Workspace workspace = createWorkspace("MyOrg");
+            when(workspaceRepository.findByInstallationId(INSTALLATION_ID)).thenReturn(Optional.of(workspace));
+
+            service.handleAccountRename(INSTALLATION_ID, "MyOrg", "MyOrg");
+
+            // No save because login unchanged
+            verify(workspaceRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("blank newLogin is rejected")
+        void blankNewLogin_skips() {
+            service.handleAccountRename(INSTALLATION_ID, "old-org", "  ");
+
+            verify(workspaceRepository, never()).findByInstallationId(any());
+        }
+
+        @Test
+        @DisplayName("null newLogin is rejected")
+        void nullNewLogin_skips() {
+            service.handleAccountRename(INSTALLATION_ID, "old-org", null);
+
+            verify(workspaceRepository, never()).findByInstallationId(any());
+        }
+
+        @Test
+        @DisplayName("unknown installation is handled gracefully")
+        void unknownInstallation_noOp() {
+            when(workspaceRepository.findByInstallationId(INSTALLATION_ID)).thenReturn(Optional.empty());
+
+            service.handleAccountRename(INSTALLATION_ID, "old-org", "new-org");
+
+            verify(workspaceRepository, never()).save(any());
+        }
+    }
+
+    private Workspace createWorkspace(String accountLogin) {
+        Workspace workspace = new Workspace();
+        workspace.setAccountLogin(accountLogin);
+        workspace.setWorkspaceSlug("test-workspace");
+        return workspace;
+    }
+}


### PR DESCRIPTION
## Description

The Organization table used a **case-sensitive** unique constraint on `(provider_id, login)`, while the User table already enforced case-insensitive uniqueness via a functional index on `(provider_id, LOWER(login))`. This inconsistency allowed duplicate organizations differing only in login casing (e.g. `MyOrg` vs `myorg`) under concurrent webhook load, and contradicts the `ILIKE`/`LOWER()` patterns used in repository queries.

This PR:
1. **Adds a Liquibase migration** that safely deduplicates any existing case-variant organization rows (reassigning all FK references from `repository`, `workspace`, `issue_type`, and `organization_membership` to the canonical row), then replaces the case-sensitive constraint with a functional index on `(provider_id, LOWER(login))`.
2. **Removes the JPA `@UniqueConstraint` for login** from `Organization.java` (functional indexes aren't expressible in JPA annotations; `ddl-auto:update` would recreate the case-sensitive constraint). Matches the existing `User.java` pattern.
3. **Adds 13 unit tests** covering case-sensitive dirty-check semantics in `OrganizationService.upsertIdentity` and `WorkspaceInstallationService.handleAccountRename`.

**Key design decision**: The issue proposed changing `.equals()` to `.equalsIgnoreCase()` in service-layer dirty-checks. Analysis showed this would **suppress case-only renames** from Git providers (e.g. GitHub renaming `myorg` → `MyOrg`), causing data fidelity loss. The Java comparisons are intentionally case-sensitive (detect value changes for persistence). The actual bug was the DB constraint — fixed here at the database level.

Fixes #404

## How to test

- `npm run format && npm run check` — all pass
- `cd server/application-server && mvn test -Dsurefire.includedGroups="unit"` — 2087 tests pass (includes 13 new)
- Review migration SQL in `1774558928650_changelog.xml` for FK-safety
- Verify `Organization.java` no longer has `@UniqueConstraint` for login (matches `User.java` pattern)

## Screenshots

N/A — database-only change, no UI impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented case-insensitive uniqueness for organization logins to prevent duplicate organizations differing only in character casing.
  * Deduplicated existing organizations with identical logins regardless of casing.
  * Updated system references to consolidated organizations.

* **Tests**
  * Added test coverage for login handling and account rename scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->