### PR TITLE
fix(server): provision first-login git provider users

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/account/AccountController.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/account/AccountController.java
@@ -1,12 +1,15 @@
 package de.tum.in.www1.hephaestus.account;
 
 import de.tum.in.www1.hephaestus.config.KeycloakProperties;
+import de.tum.in.www1.hephaestus.gitprovider.user.AuthenticatedGitProviderUserService;
+import de.tum.in.www1.hephaestus.gitprovider.user.User;
 import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
 import de.tum.in.www1.hephaestus.integrations.posthog.PosthogClientException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.Optional;
 import org.keycloak.admin.client.Keycloak;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,17 +47,20 @@ public class AccountController {
     private final Keycloak keycloak;
     private final UserRepository userRepository;
     private final KeycloakProperties keycloakProperties;
+    private final AuthenticatedGitProviderUserService authenticatedGitProviderUserService;
 
     public AccountController(
         AccountService accountService,
         Keycloak keycloak,
         UserRepository userRepository,
-        KeycloakProperties keycloakProperties
+        KeycloakProperties keycloakProperties,
+        AuthenticatedGitProviderUserService authenticatedGitProviderUserService
     ) {
         this.accountService = accountService;
         this.keycloak = keycloak;
         this.userRepository = userRepository;
         this.keycloakProperties = keycloakProperties;
+        this.authenticatedGitProviderUserService = authenticatedGitProviderUserService;
     }
 
     @DeleteMapping
@@ -96,8 +102,8 @@ public class AccountController {
         summary = "Get user settings",
         description = "Get the current user's notification, research participation, and AI review preferences"
     )
-    public ResponseEntity<UserSettingsDTO> getUserSettings() {
-        var user = userRepository.getCurrentUser();
+    public ResponseEntity<UserSettingsDTO> getUserSettings(@AuthenticationPrincipal JwtAuthenticationToken auth) {
+        var user = resolveOrProvisionCurrentUser(auth);
         if (user.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
@@ -115,7 +121,7 @@ public class AccountController {
         @AuthenticationPrincipal JwtAuthenticationToken auth,
         @Valid @RequestBody UserSettingsDTO userSettings
     ) {
-        var user = userRepository.getCurrentUser();
+        var user = resolveOrProvisionCurrentUser(auth);
         if (user.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
@@ -204,5 +210,13 @@ public class AccountController {
             return jwtAuthenticationToken;
         }
         return null;
+    }
+
+    private Optional<User> resolveOrProvisionCurrentUser(JwtAuthenticationToken auth) {
+        if (resolveAuthentication(auth) == null) {
+            return Optional.empty();
+        }
+
+        return authenticatedGitProviderUserService.resolveOrProvisionCurrentUser(null);
     }
 }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/user/AuthenticatedGitProviderUserService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/user/AuthenticatedGitProviderUserService.java
@@ -1,0 +1,208 @@
+package de.tum.in.www1.hephaestus.gitprovider.user;
+
+import de.tum.in.www1.hephaestus.SecurityUtils;
+import de.tum.in.www1.hephaestus.core.LoggingUtils;
+import de.tum.in.www1.hephaestus.gitprovider.common.GitProvider;
+import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderRepository;
+import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderType;
+import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabProperties;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class AuthenticatedGitProviderUserService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthenticatedGitProviderUserService.class);
+    private static final String GITHUB_SERVER_URL = "https://github.com";
+
+    private final UserRepository userRepository;
+    private final GitProviderRepository gitProviderRepository;
+    private final GitLabProperties gitLabProperties;
+
+    public AuthenticatedGitProviderUserService(
+        UserRepository userRepository,
+        GitProviderRepository gitProviderRepository,
+        GitLabProperties gitLabProperties
+    ) {
+        this.userRepository = userRepository;
+        this.gitProviderRepository = gitProviderRepository;
+        this.gitLabProperties = gitLabProperties;
+    }
+
+    @Transactional
+    public Optional<User> resolveOrProvisionCurrentUser(@Nullable String gitLabServerUrl) {
+        var currentUser = userRepository.getCurrentUser();
+        if (currentUser.isPresent()) {
+            return currentUser;
+        }
+
+        Optional<String> currentLogin = SecurityUtils.getCurrentUserLogin();
+        if (currentLogin.isEmpty()) {
+            return Optional.empty();
+        }
+        String login = currentLogin.orElseThrow();
+
+        Jwt jwt = getCurrentJwt();
+        if (jwt == null) {
+            return Optional.empty();
+        }
+
+        Long gitlabId = jwt.getClaim("gitlab_id");
+        if (gitlabId != null) {
+            String resolvedUrl = resolveGitLabServerUrl(gitLabServerUrl);
+            Long userId = upsertGitLabUser(
+                gitlabId,
+                login,
+                login,
+                "",
+                resolvedUrl + "/" + login,
+                resolvedUrl,
+                User.Type.USER
+            );
+            return userRepository.findById(userId);
+        }
+
+        Long githubId = jwt.getClaim("github_id");
+        if (githubId != null) {
+            Long userId = upsertGitHubUser(githubId, login, login, "", GITHUB_SERVER_URL + "/" + login, User.Type.USER);
+            return userRepository.findById(userId);
+        }
+
+        return Optional.empty();
+    }
+
+    @Transactional
+    public void ensureCurrentGitLabUserExists(@Nullable String gitLabServerUrl) {
+        String login = SecurityUtils.getCurrentUserLoginOrThrow();
+        if (userRepository.findByLogin(login).isPresent()) {
+            return;
+        }
+
+        Jwt jwt = getCurrentJwt();
+        if (jwt == null) {
+            throw new IllegalStateException("No JWT found for authenticated user");
+        }
+
+        Long gitlabId = jwt.getClaim("gitlab_id");
+        if (gitlabId != null) {
+            String resolvedUrl = resolveGitLabServerUrl(gitLabServerUrl);
+            upsertGitLabUser(gitlabId, login, login, "", resolvedUrl + "/" + login, resolvedUrl, User.Type.USER);
+            return;
+        }
+
+        Long githubId = jwt.getClaim("github_id");
+        if (githubId != null) {
+            throw new ResponseStatusException(
+                HttpStatus.CONFLICT,
+                "You need to link your GitLab account before creating a GitLab workspace. Go to Settings → Linked Accounts to connect your GitLab identity."
+            );
+        }
+
+        throw new ResponseStatusException(
+            HttpStatus.CONFLICT,
+            "No GitLab identity found. Please link your GitLab account in Settings → Linked Accounts."
+        );
+    }
+
+    @Nullable
+    private Jwt getCurrentJwt() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof Jwt jwt)) {
+            return null;
+        }
+        return jwt;
+    }
+
+    private String resolveGitLabServerUrl(@Nullable String configServerUrl) {
+        if (configServerUrl != null && !configServerUrl.isBlank()) {
+            String url = configServerUrl.trim();
+            return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+        }
+        return gitLabProperties.defaultServerUrl();
+    }
+
+    private Long upsertGitHubUser(
+        Long nativeId,
+        String login,
+        String name,
+        String avatarUrl,
+        String webUrl,
+        User.Type userType
+    ) {
+        GitProvider provider = gitProviderRepository
+            .findByTypeAndServerUrl(GitProviderType.GITHUB, GITHUB_SERVER_URL)
+            .orElseGet(() -> gitProviderRepository.save(new GitProvider(GitProviderType.GITHUB, GITHUB_SERVER_URL)));
+
+        return upsertUser(nativeId, login, name, avatarUrl, webUrl, userType, provider);
+    }
+
+    private Long upsertGitLabUser(
+        Long nativeId,
+        String login,
+        String name,
+        String avatarUrl,
+        String webUrl,
+        String serverUrl,
+        User.Type userType
+    ) {
+        String safeAvatar = avatarUrl != null ? (avatarUrl.startsWith("/") ? serverUrl + avatarUrl : avatarUrl) : "";
+        GitProvider provider = gitProviderRepository
+            .findByTypeAndServerUrl(GitProviderType.GITLAB, serverUrl)
+            .orElseGet(() -> {
+                log.info("Creating GitProvider for self-hosted GitLab: serverUrl={}", serverUrl);
+                return gitProviderRepository.save(new GitProvider(GitProviderType.GITLAB, serverUrl));
+            });
+
+        return upsertUser(nativeId, login, name, safeAvatar, webUrl, userType, provider);
+    }
+
+    private Long upsertUser(
+        Long nativeId,
+        String login,
+        String name,
+        String avatarUrl,
+        String webUrl,
+        User.Type userType,
+        GitProvider provider
+    ) {
+        String safeName = name != null ? name : login;
+        String safeAvatar = avatarUrl != null ? avatarUrl : "";
+        String safeWebUrl = webUrl != null ? webUrl : "";
+        Long providerId = provider.getId();
+
+        userRepository.acquireLoginLock(login, providerId);
+        userRepository.freeLoginConflicts(login, nativeId, providerId);
+        userRepository.upsertUser(
+            nativeId,
+            providerId,
+            login,
+            safeName,
+            safeAvatar,
+            safeWebUrl,
+            userType.name(),
+            null,
+            null,
+            null
+        );
+        log.info(
+            "Upserted authenticated git provider user: userLogin={}, nativeId={}, providerType={}, type={}",
+            LoggingUtils.sanitizeForLog(login),
+            nativeId,
+            provider.getType(),
+            userType
+        );
+        return userRepository
+            .findByLoginAndProviderId(login, providerId)
+            .map(User::getId)
+            .orElseThrow(() -> new IllegalStateException("User not found after upsert: login=" + login));
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceProvisioningService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceProvisioningService.java
@@ -11,6 +11,7 @@ import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderType;
 import de.tum.in.www1.hephaestus.gitprovider.common.github.app.GitHubAppTokenService;
 import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabProperties;
 import de.tum.in.www1.hephaestus.gitprovider.common.spi.ProvisioningListener;
+import de.tum.in.www1.hephaestus.gitprovider.user.AuthenticatedGitProviderUserService;
 import de.tum.in.www1.hephaestus.gitprovider.user.User;
 import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
 import de.tum.in.www1.hephaestus.workspace.WorkspaceMembership.WorkspaceRole;
@@ -21,7 +22,6 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -50,6 +50,7 @@ public class WorkspaceProvisioningService {
     private final WorkspaceMembershipService workspaceMembershipService;
     private final WorkspaceScopeFilter workspaceScopeFilter;
     private final GitLabProperties gitLabProperties;
+    private final AuthenticatedGitProviderUserService authenticatedGitProviderUserService;
     private final WebClient webClient;
 
     public WorkspaceProvisioningService(
@@ -65,7 +66,8 @@ public class WorkspaceProvisioningService {
         WorkspaceMembershipRepository workspaceMembershipRepository,
         WorkspaceMembershipService workspaceMembershipService,
         WorkspaceScopeFilter workspaceScopeFilter,
-        GitLabProperties gitLabProperties
+        GitLabProperties gitLabProperties,
+        AuthenticatedGitProviderUserService authenticatedGitProviderUserService
     ) {
         this.workspaceProperties = workspaceProperties;
         this.workspaceRepository = workspaceRepository;
@@ -80,6 +82,7 @@ public class WorkspaceProvisioningService {
         this.workspaceMembershipService = workspaceMembershipService;
         this.workspaceScopeFilter = workspaceScopeFilter;
         this.gitLabProperties = gitLabProperties;
+        this.authenticatedGitProviderUserService = authenticatedGitProviderUserService;
         this.webClient = WebClient.builder()
             .baseUrl(GITHUB_API_BASE_URL)
             .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
@@ -282,41 +285,7 @@ public class WorkspaceProvisioningService {
      */
     @Transactional
     public void ensureAuthenticatedUserExists(String gitLabServerUrl) {
-        String login = SecurityUtils.getCurrentUserLoginOrThrow();
-
-        // Fast path: if user already exists in ANY provider, we're done
-        if (userRepository.findByLogin(login).isPresent()) {
-            return;
-        }
-
-        // Read identity from JWT
-        Authentication auth =
-            org.springframework.security.core.context.SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !(auth.getPrincipal() instanceof org.springframework.security.oauth2.jwt.Jwt jwt)) {
-            throw new IllegalStateException("No JWT found for authenticated user");
-        }
-
-        Long gitlabId = jwt.getClaim("gitlab_id");
-        if (gitlabId != null) {
-            String resolvedUrl = resolveGitLabServerUrl(gitLabServerUrl);
-            upsertGitLabUser(gitlabId, login, login, "", resolvedUrl + "/" + login, resolvedUrl, User.Type.USER);
-            return;
-        }
-
-        // No GitLab identity — check if they at least have a GitHub identity
-        Long githubId = jwt.getClaim("github_id");
-        if (githubId != null) {
-            throw new org.springframework.web.server.ResponseStatusException(
-                org.springframework.http.HttpStatus.CONFLICT,
-                "You need to link your GitLab account before creating a GitLab workspace. " +
-                    "Go to Settings → Linked Accounts to connect your GitLab identity."
-            );
-        }
-
-        throw new org.springframework.web.server.ResponseStatusException(
-            org.springframework.http.HttpStatus.CONFLICT,
-            "No GitLab identity found. Please link your GitLab account in Settings → Linked Accounts."
-        );
+        authenticatedGitProviderUserService.ensureCurrentGitLabUserExists(gitLabServerUrl);
     }
 
     /**

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
@@ -2,8 +2,8 @@ package de.tum.in.www1.hephaestus.account;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabProperties;
 import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderType;
+import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabProperties;
 import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
 import de.tum.in.www1.hephaestus.testconfig.BaseIntegrationTest;
 import org.junit.jupiter.api.DisplayName;

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.hephaestus.account;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabProperties;
 import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderType;
 import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
 import de.tum.in.www1.hephaestus.testconfig.BaseIntegrationTest;
@@ -21,6 +22,9 @@ class AccountControllerIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private GitLabProperties gitLabProperties;
 
     @Test
     @Transactional
@@ -45,6 +49,8 @@ class AccountControllerIntegrationTest extends BaseIntegrationTest {
         assertThat(provisionedUser).isPresent();
         assertThat(provisionedUser.orElseThrow().getNativeId()).isEqualTo(18024L);
         assertThat(provisionedUser.orElseThrow().getProvider().getType()).isEqualTo(GitProviderType.GITLAB);
-        assertThat(provisionedUser.orElseThrow().getProvider().getServerUrl()).isEqualTo("https://gitlab.lrz.de");
+        assertThat(provisionedUser.orElseThrow().getProvider().getServerUrl()).isEqualTo(
+            gitLabProperties.defaultServerUrl()
+        );
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.transaction.annotation.Transactional;
 
 @AutoConfigureWebTestClient
 @DisplayName("Account controller integration")
@@ -22,6 +23,7 @@ class AccountControllerIntegrationTest extends BaseIntegrationTest {
     private UserRepository userRepository;
 
     @Test
+    @Transactional
     @DisplayName("GET /user/settings provisions a GitLab user from JWT claims when no user row exists yet")
     void getUserSettingsProvisionsGitLabUserWhenMissing() {
         assertThat(userRepository.findByLogin("gitlabuser")).isEmpty();
@@ -37,12 +39,12 @@ class AccountControllerIntegrationTest extends BaseIntegrationTest {
             .jsonPath("$.aiReviewEnabled")
             .isEqualTo(true)
             .jsonPath("$.participateInResearch")
-            .isEqualTo(false);
+            .isEqualTo(true);
 
         var provisionedUser = userRepository.findByLogin("gitlabuser");
         assertThat(provisionedUser).isPresent();
         assertThat(provisionedUser.orElseThrow().getNativeId()).isEqualTo(18024L);
         assertThat(provisionedUser.orElseThrow().getProvider().getType()).isEqualTo(GitProviderType.GITLAB);
-        assertThat(provisionedUser.orElseThrow().getProvider().getServerUrl()).isEqualTo("https://gitlab.com");
+        assertThat(provisionedUser.orElseThrow().getProvider().getServerUrl()).isEqualTo("https://gitlab.lrz.de");
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/account/AccountControllerIntegrationTest.java
@@ -1,0 +1,48 @@
+package de.tum.in.www1.hephaestus.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderType;
+import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
+import de.tum.in.www1.hephaestus.testconfig.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@AutoConfigureWebTestClient
+@DisplayName("Account controller integration")
+class AccountControllerIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("GET /user/settings provisions a GitLab user from JWT claims when no user row exists yet")
+    void getUserSettingsProvisionsGitLabUserWhenMissing() {
+        assertThat(userRepository.findByLogin("gitlabuser")).isEmpty();
+
+        webTestClient
+            .get()
+            .uri("/user/settings")
+            .headers(headers -> headers.setBearerAuth("mock-jwt-token-for-gitlab-user"))
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody()
+            .jsonPath("$.aiReviewEnabled")
+            .isEqualTo(true)
+            .jsonPath("$.participateInResearch")
+            .isEqualTo(false);
+
+        var provisionedUser = userRepository.findByLogin("gitlabuser");
+        assertThat(provisionedUser).isPresent();
+        assertThat(provisionedUser.orElseThrow().getNativeId()).isEqualTo(18024L);
+        assertThat(provisionedUser.orElseThrow().getProvider().getType()).isEqualTo(GitProviderType.GITLAB);
+        assertThat(provisionedUser.orElseThrow().getProvider().getServerUrl()).isEqualTo("https://gitlab.com");
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/testconfig/TestSecurityConfig.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/testconfig/TestSecurityConfig.java
@@ -47,6 +47,10 @@ public class TestSecurityConfig {
                 username = "mentor";
                 userId = "mentor-user-id";
                 roles = new String[] { "mentor_access" };
+            } else if ("mock-jwt-token-for-gitlab-user".equals(token)) {
+                username = "gitlabuser";
+                userId = "gitlab-user-id";
+                roles = new String[] {};
             } else if ("mock-jwt-token-for-admin-user".equals(token)) {
                 username = "admin";
                 userId = "admin-user-id";
@@ -68,6 +72,11 @@ public class TestSecurityConfig {
             claims.put("preferred_username", username);
             claims.put("iss", "https://test-issuer");
             claims.put("aud", "test-audience");
+
+            if ("mock-jwt-token-for-gitlab-user".equals(token)) {
+                claims.put("gitlab_id", 18024L);
+                claims.put("identity_provider", "gitlab-lrz");
+            }
 
             // Add realm_access with roles (same structure as Keycloak)
             if (roles.length > 0) {

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/workspace/WorkspaceProvisioningServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/workspace/WorkspaceProvisioningServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import de.tum.in.www1.hephaestus.gitprovider.common.GitProviderRepository;
 import de.tum.in.www1.hephaestus.gitprovider.common.github.app.GitHubAppTokenService;
 import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabProperties;
+import de.tum.in.www1.hephaestus.gitprovider.user.AuthenticatedGitProviderUserService;
 import de.tum.in.www1.hephaestus.gitprovider.user.User;
 import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
 import java.time.Duration;
@@ -58,6 +59,9 @@ class WorkspaceProvisioningServiceTest {
     @Mock
     private WorkspaceScopeFilter workspaceScopeFilter;
 
+    @Mock
+    private AuthenticatedGitProviderUserService authenticatedGitProviderUserService;
+
     private WorkspaceProvisioningService provisioningService;
 
     private WorkspaceProperties workspaceProperties;
@@ -92,7 +96,8 @@ class WorkspaceProvisioningServiceTest {
             workspaceMembershipRepository,
             workspaceMembershipService,
             workspaceScopeFilter,
-            gitLabProperties
+            gitLabProperties,
+            authenticatedGitProviderUserService
         );
     }
 


### PR DESCRIPTION
## Description

Provision the authenticated git-provider user on first access to account settings so GitLab users do not get a 404 before any workspace creation path has materialized their user row.

The bootstrap logic is extracted into a dedicated service and reused by workspace provisioning, avoiding controller-to-workspace-service coupling.

## How to Test

1. Run `npm run format && npm run check`.
2. Run `npm run build:intelligence-service`.
3. Run `npm run test:intelligence-service:unit`.
4. Run `cd server/application-server && ./mvnw test -Dsurefire.includedGroups="unit" -Dmaven.test.skip=false -T 2C --batch-mode -q`.
5. Run `cd server/application-server && ./mvnw -q -Dtest=AccountControllerIntegrationTest,GitLabWorkspaceCreationIntegrationTest test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic provisioning of Git provider accounts (GitLab/GitHub) when users access account settings; settings endpoint now resolves authentication tokens to identify/provision users.

* **Refactor**
  * Git-provider user provisioning moved into a dedicated service for clearer responsibility and reuse.

* **Tests**
  * Added integration test verifying automatic provisioning and extended test security mocks for GitLab scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->