### PR TITLE
fix(docker): harden GitLab rollout contract

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -202,8 +202,8 @@ GITLAB_WORKSPACE_CREATION=false
 # Enable the Docker sandbox for running agent containers
 SANDBOX_ENABLED=false
 
-# Practice review requires SANDBOX_ENABLED, AGENT_NATS_ENABLED, and
-# GIT_CHECKOUT_ENABLED to be enabled together.
+# Practice review requires SANDBOX_ENABLED, AGENT_NATS_ENABLED,
+# GIT_CHECKOUT_ENABLED, and NATS_ENABLED to be enabled together.
 
 # Docker daemon endpoint (default: local socket)
 # SANDBOX_DOCKER_HOST=unix:///var/run/docker.sock

--- a/docker/preview/.env.example
+++ b/docker/preview/.env.example
@@ -90,17 +90,7 @@ LANGFUSE_BASE_URL=
 # UI debugging
 TANSTACK_DEVTOOLS_ENABLED=true
 
-# Optional limited rollout overrides.
-# Leave these unset for the default preview deployment.
-# Set them only when preview is intentionally being used to validate a larger rollout.
-# KEYCLOAK_GITLAB_ENABLED=true
-# KEYCLOAK_GITLAB_CLIENT_ID=
-# KEYCLOAK_GITLAB_CLIENT_SECRET=
-# KEYCLOAK_GITLAB_BASE_URL=https://gitlab.lrz.de
-# GITLAB_ENABLED=true
-# GITLAB_WORKSPACE_CREATION=true
-# PRACTICE_REVIEW_FOR_ALL=true
-# SANDBOX_ENABLED=true
-# AGENT_NATS_ENABLED=true
-# GIT_CHECKOUT_ENABLED=true
-# LLM_PROXY_AZURE_OPENAI_URL=https://your-resource.openai.azure.com
+# Preview remains intentionally limited.
+# GitLab login, GitLab workspace creation, sandbox execution, git checkout,
+# and practice-review rollout validation are not supported by this preview stack.
+# Use the production compose topology on local or staging when validating issue #970.

--- a/docker/preview/README.md
+++ b/docker/preview/README.md
@@ -71,4 +71,4 @@ docker rm -f "$TEMP_CTN"
 ## Files
 
 - `compose.app.yaml` - Main Docker Compose for preview deployments
-- `compose.proxy.yaml` - Traefik proxy configuration (shared)
+- `compose.shared-infra.yaml` - Shared Keycloak, webhook-ingest, and NATS stack for previews

--- a/docs/admin/production-setup.mdx
+++ b/docs/admin/production-setup.mdx
@@ -86,7 +86,7 @@ Practice review is not enabled by a single flag. The following settings must be 
 | `NATS_ENABLED` | Enables webhook-driven sync consumption |
 | `NATS_DURABLE_CONSUMER_NAME` | Durable consumer name for sync processing |
 
-`SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, and `GIT_CHECKOUT_ENABLED` must be `true` together for practice review. Anything else is a half-configured deployment.
+`SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` must be `true` together for practice review. Anything else is a half-configured deployment.
 
 ### Rollout tiers
 
@@ -95,7 +95,7 @@ Use the same variables differently across environments:
 | Environment | Intended scope |
 | --- | --- |
 | Preview | Limited by default. Keep GitLab login, GitLab workspaces, sandbox, git checkout, and agent job execution disabled unless preview is explicitly being used as rollout validation. |
-| Staging | Uses the production compose files, but should still be a controlled rollout. Start by enabling GitLab login and GitLab workspace creation first. Only enable `SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, and `GIT_CHECKOUT_ENABLED` when staging is intentionally validating practice review execution. |
+| Staging | Uses the production compose files, but should still be a controlled rollout. Start by enabling GitLab login and GitLab workspace creation first. Only enable `SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` when staging is intentionally validating practice review execution. |
 | Production | Full rollout only after staging has validated the exact same bundle. |
 
 Staging and production both use the production compose files. The difference should come from the `.env` values, not from a different compose topology.
@@ -157,7 +157,7 @@ The sync scheduler fetches recent GitHub activity (issues, PRs, reviews) for mon
    - Sign in via GitHub with the account configured in `KEYCLOAK_GITHUB_ADMIN_USERNAME` and confirm it lands in Keycloak with both the `admin` realm role and the `realm-management` → `realm-admin` client role automatically applied.
    - Verify that the super admin user can access workspace admin endpoints for workspaces where they have membership (they are automatically elevated to workspace ADMIN level for those workspaces).
    - Trigger a test webhook from GitHub or GitLab to validate the ingest pipeline.
-   - Verify that `GITLAB_ENABLED`, `GITLAB_WORKSPACE_CREATION`, `SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, and `GIT_CHECKOUT_ENABLED` are all present in the deployed environment before testing GitLab practice review.
+   - Verify that `GITLAB_ENABLED`, `GITLAB_WORKSPACE_CREATION`, `SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` are all present in the deployed environment before testing GitLab practice review.
 
 ## Global admin privileges
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/config/JwtDecoderConfigTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/config/JwtDecoderConfigTest.java
@@ -1,0 +1,57 @@
+package de.tum.in.www1.hephaestus.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+@Tag("unit")
+@DisplayName("JwtDecoderConfig")
+class JwtDecoderConfigTest {
+
+    @EnableConfigurationProperties(KeycloakProperties.class)
+    static class TestConfiguration {}
+
+    private ApplicationContextRunner contextRunner() {
+        return new ApplicationContextRunner()
+            .withUserConfiguration(TestConfiguration.class, JwtDecoderConfig.class)
+            .withPropertyValues(
+                "spring.profiles.active=prod",
+                "hephaestus.keycloak.url=https://auth.example.com/keycloak",
+                "hephaestus.keycloak.realm=hephaestus",
+                "hephaestus.keycloak.client-id=hephaestus-confidential",
+                "hephaestus.keycloak.internal-url=http://keycloak:8080",
+                "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.com/keycloak/realms/hephaestus"
+            );
+    }
+
+    @Test
+    @DisplayName("creates NimbusJwtDecoder in prod when JWK set URI is configured")
+    void createsDecoderWhenJwkSetUriConfigured() {
+        contextRunner()
+            .withPropertyValues(
+                "hephaestus.keycloak.jwk-set-uri=http://keycloak:8080/realms/hephaestus/protocol/openid-connect/certs"
+            )
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).hasSingleBean(JwtDecoder.class);
+                assertThat(context.getBean(JwtDecoder.class)).isInstanceOf(NimbusJwtDecoder.class);
+            });
+    }
+
+    @Test
+    @DisplayName("does not create custom decoder when JWK set URI is blank")
+    void doesNotCreateDecoderWhenJwkSetUriBlank() {
+        contextRunner()
+            .withPropertyValues("hephaestus.keycloak.jwk-set-uri=")
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                assertThat(context).doesNotHaveBean(JwtDecoder.class);
+            });
+    }
+}


### PR DESCRIPTION
## Description

Hardens the GitLab practice-review rollout contract by making the deployment guidance explicit instead of pretending preview proves production readiness.
It also adds focused coverage for the production JWT decoder path that uses an internal JWKS URI while validating the public issuer.

Closes #970.

## How to Test

1. Run `npm run format && npm run check`.
2. Run `npm run build:intelligence-service`.
3. Run `npm run test:intelligence-service:unit`.
4. Run `cd server/application-server && ./mvnw test -Dsurefire.includedGroups="unit" -Dmaven.test.skip=false -T 2C --batch-mode -q`.
5. Confirm the preview docs now explicitly say preview is not rollout evidence, and the production docs/env examples consistently require `NATS_ENABLED` for practice review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified configuration requirements: NATS_ENABLED must now be enabled alongside existing practice review dependencies.
  * Updated preview environment documentation to clearly state unsupported features and provide guidance on appropriate deployment topology.
  * Enhanced production setup checklist for practice review validation.

* **Tests**
  * Added automated test coverage for JWT decoder configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->