### PR TITLE
fix(agent): harden review checkout and diff scoping

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -165,9 +165,9 @@ public class PullRequestReviewHandler implements JobTypeHandler {
 
         Map<String, byte[]> files = new HashMap<>();
 
-        // Ensure repo is cloned/fetched before volumeMounts() resolves the path
-        String gitToken = job.getWorkspace() != null ? job.getWorkspace().getPersonalAccessToken() : null;
-        ensureRepositoryCloned(metadata, repositoryId, gitToken);
+        // PR review requires a pre-prepared local checkout. The sandbox never clones or fetches
+        // repositories on demand; it only mounts an existing host-side checkout.
+        ensureRepositoryAvailable(repositoryId);
 
         // Load PR entity once — shared by metadata, comments, and contributor history
         PullRequest pullRequest = pullRequestRepository.findByIdWithAllForGate(pullRequestId).orElse(null);
@@ -491,38 +491,21 @@ public class PullRequestReviewHandler implements JobTypeHandler {
     // -------------------------------------------------------------------------
 
     /**
-     * Ensure the repository is cloned/fetched locally. Throws on failure because the bind-mount
-     * approach requires a valid local clone — there is no fallback.
+     * Require a pre-prepared local repository checkout for bind-mounting.
+     *
+     * <p>This review flow never clones or fetches repositories on demand. Repository preparation
+     * must happen ahead of time via the normal sync/bootstrap path so sandbox runs stay offline and
+     * deterministic with respect to repo contents.
      */
-    private void ensureRepositoryCloned(JsonNode metadata, long repositoryId, @Nullable String gitToken) {
+    private void ensureRepositoryAvailable(long repositoryId) {
         if (!gitRepositoryManager.isEnabled()) {
             throw new JobPreparationException(
                 "Git local checkout is disabled but required for bind-mount: repoId=" + repositoryId
             );
         }
-        String repoFullName = requireText(metadata, "repository_full_name");
-
-        // Derive clone URL from PR URL (works for both GitHub and GitLab).
-        // PR URL format: https://<host>/<path>/-/merge_requests/<iid> (GitLab)
-        //                https://<host>/<path>/pull/<number> (GitHub)
-        String prUrl = requireText(metadata, "pr_url");
-        String cloneUrl;
-        int mrIdx = prUrl.indexOf("/-/merge_requests/");
-        int pullIdx = prUrl.indexOf("/pull/");
-        if (mrIdx > 0) {
-            cloneUrl = prUrl.substring(0, mrIdx) + ".git";
-        } else if (pullIdx > 0) {
-            cloneUrl = prUrl.substring(0, pullIdx) + ".git";
-        } else {
-            // Fallback: construct from repo name (GitHub assumed)
-            cloneUrl = "https://github.com/" + repoFullName + ".git";
-        }
-        try {
-            gitRepositoryManager.ensureRepository(repositoryId, cloneUrl, gitToken);
-        } catch (Exception e) {
+        if (!gitRepositoryManager.isRepositoryCloned(repositoryId)) {
             throw new JobPreparationException(
-                "Failed to clone/fetch repository for bind-mount: repoId=" + repositoryId,
-                e
+                "Repository checkout is not available locally for bind-mount: repoId=" + repositoryId
             );
         }
     }
@@ -865,7 +848,12 @@ public class PullRequestReviewHandler implements JobTypeHandler {
             boolean hasInScopeLocation = false;
             for (JsonNode loc : locations) {
                 JsonNode pathNode = loc.get("path");
-                if (pathNode != null && diffFiles.contains(pathNode.asText())) {
+                if (pathNode == null) {
+                    continue;
+                }
+
+                String path = pathNode.asText();
+                if (diffFiles.contains(path) || isInternalContextPath(path)) {
                     hasInScopeLocation = true;
                     break;
                 }
@@ -877,6 +865,10 @@ public class PullRequestReviewHandler implements JobTypeHandler {
             }
         }
         return filtered;
+    }
+
+    private static boolean isInternalContextPath(String path) {
+        return path.startsWith(".context/");
     }
 
     /**

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
@@ -40,6 +40,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -320,6 +321,17 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             assertThatThrownBy(() -> handler.prepareInputFiles(job))
                 .isInstanceOf(JobPreparationException.class)
                 .hasMessageContaining("no metadata");
+        }
+
+        @Test
+        @DisplayName("should throw when local repository checkout is missing")
+        void shouldThrowWhenLocalRepositoryCheckoutMissing() {
+            lenient().when(gitRepositoryManager.isEnabled()).thenReturn(true);
+            when(gitRepositoryManager.isRepositoryCloned(123L)).thenReturn(false);
+
+            assertThatThrownBy(() -> handler.prepareInputFiles(jobWithMetadata(sampleJobMetadata())))
+                .isInstanceOf(JobPreparationException.class)
+                .hasMessageContaining("Repository checkout is not available locally for bind-mount");
         }
 
         @Test
@@ -638,6 +650,83 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             assertThat(annotated).contains("[L7]  more context");
             // The deleted line should NOT have [L prefix
             assertThat(annotated).containsPattern("(?m)^-deleted line$");
+        }
+    }
+
+    @Nested
+    @DisplayName("filterByDiffScope")
+    class FilterByDiffScope {
+
+        @Test
+        @DisplayName("keeps finding whose evidence path is in diff")
+        void keepsFindingInDiff() {
+            var finding = new PracticeDetectionResultParser.ValidatedFinding(
+                "fatal-error-crash",
+                "Crashes on tap",
+                Verdict.NEGATIVE,
+                Severity.MAJOR,
+                0.9f,
+                objectMapper.createObjectNode().set(
+                    "locations",
+                    objectMapper
+                        .createArrayNode()
+                        .add(objectMapper.createObjectNode().put("path", "Sources/View.swift"))
+                ),
+                null,
+                null
+            );
+
+            var filtered = PullRequestReviewHandler.filterByDiffScope(List.of(finding), Set.of("Sources/View.swift"));
+
+            assertThat(filtered).containsExactly(finding);
+        }
+
+        @Test
+        @DisplayName("keeps finding backed by internal metadata context")
+        void keepsMetadataBackedFinding() {
+            var finding = new PracticeDetectionResultParser.ValidatedFinding(
+                "mr-description-quality",
+                "Description is vague",
+                Verdict.NEGATIVE,
+                Severity.MINOR,
+                0.8f,
+                objectMapper.createObjectNode().set(
+                    "locations",
+                    objectMapper
+                        .createArrayNode()
+                        .add(objectMapper.createObjectNode().put("path", ".context/metadata.json"))
+                ),
+                null,
+                null
+            );
+
+            var filtered = PullRequestReviewHandler.filterByDiffScope(List.of(finding), Set.of("Sources/View.swift"));
+
+            assertThat(filtered).containsExactly(finding);
+        }
+
+        @Test
+        @DisplayName("filters finding whose evidence points only outside diff")
+        void filtersOutOfScopeFinding() {
+            var finding = new PracticeDetectionResultParser.ValidatedFinding(
+                "view-logic-separation",
+                "Out-of-scope issue",
+                Verdict.NEGATIVE,
+                Severity.MINOR,
+                0.8f,
+                objectMapper.createObjectNode().set(
+                    "locations",
+                    objectMapper
+                        .createArrayNode()
+                        .add(objectMapper.createObjectNode().put("path", "Sources/Other.swift"))
+                ),
+                null,
+                null
+            );
+
+            var filtered = PullRequestReviewHandler.filterByDiffScope(List.of(finding), Set.of("Sources/View.swift"));
+
+            assertThat(filtered).isEmpty();
         }
     }
 


### PR DESCRIPTION
## Summary
This PR contains the smallest code change justified by the review reliability investigation.

It fixes two concrete problems:
- PR review preparation no longer clones or fetches repositories on demand. It now requires an already prepared local checkout.
- Diff scoping no longer drops findings backed by internal review context like .context/metadata.json.

## Why
Production investigation showed:
- the production app already has local checkout storage enabled at /data/git-repos
- the iOS26 Intro Course workspace already has all monitored repositories available as local checkouts
- review-time clone/fetch is therefore unnecessary and undermines the intended offline/prepared execution model

Local validation also showed that metadata-backed practices such as MR description checks could be dropped by diff scoping even when the raw review output was valid.

## Changes
- replace review-time ensureRepository(...) behavior with a strict local-checkout availability check
- allow .context/* evidence paths through diff-scope filtering
- add focused unit tests for both behaviors

## Validation
- mvn -q -Dtest=PullRequestReviewHandlerTest test
- mvn -q -DskipTests compile

## Not Included
This PR intentionally does not include broader rollout work such as:
- production agent config creation
- production practice import or enablement
- rerun freshness semantics
- prompt or parser tuning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and messaging for missing repository checkout scenarios, providing clearer feedback to users.

* **Improvements**
  * Enhanced analysis finding filters to properly handle internal metadata paths alongside regular source file entries in diff scope filtering.

* **Tests**
  * Added comprehensive test coverage for repository availability validation and diff-scope filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->