### PR TITLE
fix(server): prevent stale diff in practice review pipeline

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
@@ -5,6 +5,7 @@ import de.tum.in.www1.hephaestus.account.UserPreferencesRepository;
 import de.tum.in.www1.hephaestus.agent.handler.spi.JobTypeHandler;
 import de.tum.in.www1.hephaestus.gitprovider.common.github.GitHubGraphQlClientProvider;
 import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabGraphQlClientProvider;
+import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService;
 import de.tum.in.www1.hephaestus.gitprovider.git.GitRepositoryManager;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.PullRequestReviewCommentRepository;
@@ -15,6 +16,7 @@ import de.tum.in.www1.hephaestus.practices.finding.PracticeFindingRepository;
 import de.tum.in.www1.hephaestus.practices.review.PracticeReviewProperties;
 import de.tum.in.www1.hephaestus.workspace.WorkspaceRepository;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.Nullable;
@@ -31,16 +33,14 @@ public class JobTypeHandlerConfiguration {
     private final PracticeReviewProperties reviewProperties;
 
     @Nullable
-    private final de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService;
+    private final GitLabTokenService gitLabTokenService;
 
     JobTypeHandlerConfiguration(
         ObjectMapper objectMapper,
         GitRepositoryManager gitRepositoryManager,
         PracticeFindingRepository practiceFindingRepository,
         PracticeReviewProperties reviewProperties,
-        @org.springframework.beans.factory.annotation.Autowired(
-            required = false
-        ) @Nullable de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService
+        @Autowired(required = false) @Nullable GitLabTokenService gitLabTokenService
     ) {
         this.objectMapper = objectMapper;
         this.gitRepositoryManager = gitRepositoryManager;

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
@@ -30,16 +30,23 @@ public class JobTypeHandlerConfiguration {
     private final PracticeFindingRepository practiceFindingRepository;
     private final PracticeReviewProperties reviewProperties;
 
+    @Nullable
+    private final de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService;
+
     JobTypeHandlerConfiguration(
         ObjectMapper objectMapper,
         GitRepositoryManager gitRepositoryManager,
         PracticeFindingRepository practiceFindingRepository,
-        PracticeReviewProperties reviewProperties
+        PracticeReviewProperties reviewProperties,
+        @org.springframework.beans.factory.annotation.Autowired(
+            required = false
+        ) @Nullable de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService
     ) {
         this.objectMapper = objectMapper;
         this.gitRepositoryManager = gitRepositoryManager;
         this.practiceFindingRepository = practiceFindingRepository;
         this.reviewProperties = reviewProperties;
+        this.gitLabTokenService = gitLabTokenService;
     }
 
     @Bean
@@ -94,10 +101,7 @@ public class JobTypeHandlerConfiguration {
         PracticeRepository practiceRepository,
         PracticeDetectionResultParser resultParser,
         PracticeDetectionDeliveryService deliveryService,
-        FeedbackDeliveryService feedbackService,
-        @org.springframework.beans.factory.annotation.Autowired(
-            required = false
-        ) @org.springframework.lang.Nullable de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService
+        FeedbackDeliveryService feedbackService
     ) {
         return new PullRequestReviewHandler(
             objectMapper,

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerConfiguration.java
@@ -94,7 +94,10 @@ public class JobTypeHandlerConfiguration {
         PracticeRepository practiceRepository,
         PracticeDetectionResultParser resultParser,
         PracticeDetectionDeliveryService deliveryService,
-        FeedbackDeliveryService feedbackService
+        FeedbackDeliveryService feedbackService,
+        @org.springframework.beans.factory.annotation.Autowired(
+            required = false
+        ) @org.springframework.lang.Nullable de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService
     ) {
         return new PullRequestReviewHandler(
             objectMapper,
@@ -105,7 +108,8 @@ public class JobTypeHandlerConfiguration {
             contributorHistoryProvider(),
             resultParser,
             deliveryService,
-            feedbackService
+            feedbackService,
+            gitLabTokenService
         );
     }
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -605,6 +605,17 @@ public class PullRequestReviewHandler implements JobTypeHandler {
             return;
         }
         Path repoPath = gitRepositoryManager.getRepositoryPath(repositoryId);
+
+        // Fetch latest refs from remote before computing the diff.
+        // Without this, the local clone may have stale branch refs from an earlier push,
+        // causing the diff to be computed against the wrong commit.
+        String fetchResult = runGit(repoPath, "fetch", "origin");
+        if (fetchResult == null) {
+            log.warn("Git fetch failed before diff computation: repoId={}, headSha={}", repositoryId, headSha);
+        } else {
+            log.debug("Fetched latest refs before diff computation: repoId={}", repositoryId);
+        }
+
         try {
             String[] range = resolveDiffRange(repoPath, targetBranch, sourceBranch, headSha);
             if (range == null) {
@@ -622,11 +633,24 @@ public class PullRequestReviewHandler implements JobTypeHandler {
                 if (diffStat != null) {
                     files.put(".context/diff_stat.txt", diffStat.getBytes(StandardCharsets.UTF_8));
                 }
+
+                // Log diff quality metrics for stale-diff incident detection
+                int addedLines = 0;
+                int removedLines = 0;
+                for (String line : diff.split("\n", -1)) {
+                    if (line.startsWith("+") && !line.startsWith("+++")) addedLines++;
+                    else if (line.startsWith("-") && !line.startsWith("---")) removedLines++;
+                }
+                String strategyUsed = range[1].equals(headSha) ? "SHA-based" : "branch-based";
                 log.info(
-                    "Pre-computed diff: {} bytes (annotated: {} bytes), diffStat={} bytes, headSha={}",
+                    "Pre-computed diff: strategy={}, range={}..{}, +{}/-{} lines, {} bytes (annotated: {} bytes), headSha={}",
+                    strategyUsed,
+                    range[0],
+                    range[1],
+                    addedLines,
+                    removedLines,
                     diff.length(),
                     annotatedDiff.length(),
-                    diffStat != null ? diffStat.length() : 0,
                     headSha
                 );
             } else {
@@ -914,12 +938,21 @@ public class PullRequestReviewHandler implements JobTypeHandler {
      */
     @Nullable
     private String[] resolveDiffRange(Path repoPath, String targetBranch, String sourceBranch, String headSha) {
-        // Strategy 1: Branch-based diff (works if source branch still exists)
+        // Strategy 1: Branch-based diff (works if source branch still exists and is current)
         String branchBase = "origin/" + targetBranch;
         String branchHead = "origin/" + sourceBranch;
         String statCheck = runGit(repoPath, "diff", "--stat", branchBase + ".." + branchHead);
         if (statCheck != null && !statCheck.isBlank()) {
-            return new String[] { branchBase, branchHead };
+            // Verify the local branch ref matches the expected head commit.
+            // If the local clone has a stale ref from an earlier push, skip to SHA-based strategies.
+            String branchTip = runGit(repoPath, "rev-parse", branchHead);
+            if (branchTip != null && headSha != null
+                    && branchTip.trim().startsWith(headSha.substring(0, Math.min(headSha.length(), 12)))) {
+                return new String[] { branchBase, branchHead };
+            }
+            log.warn("Stale branch ref detected: branch={}, expected={}, actual={}",
+                    branchHead, headSha, branchTip != null ? branchTip.trim() : "null");
+            // Fall through to SHA-based strategies
         }
 
         // Strategy 2: Find merge commit that has headSha as second parent

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -946,12 +946,19 @@ public class PullRequestReviewHandler implements JobTypeHandler {
             // Verify the local branch ref matches the expected head commit.
             // If the local clone has a stale ref from an earlier push, skip to SHA-based strategies.
             String branchTip = runGit(repoPath, "rev-parse", branchHead);
-            if (branchTip != null && headSha != null
-                    && branchTip.trim().startsWith(headSha.substring(0, Math.min(headSha.length(), 12)))) {
+            if (
+                branchTip != null &&
+                headSha != null &&
+                branchTip.trim().startsWith(headSha.substring(0, Math.min(headSha.length(), 12)))
+            ) {
                 return new String[] { branchBase, branchHead };
             }
-            log.warn("Stale branch ref detected: branch={}, expected={}, actual={}",
-                    branchHead, headSha, branchTip != null ? branchTip.trim() : "null");
+            log.warn(
+                "Stale branch ref detected: branch={}, expected={}, actual={}",
+                branchHead,
+                headSha,
+                branchTip != null ? branchTip.trim() : "null"
+            );
             // Fall through to SHA-based strategies
         }
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -93,6 +93,9 @@ public class PullRequestReviewHandler implements JobTypeHandler {
     private final PracticeDetectionDeliveryService deliveryService;
     private final FeedbackDeliveryService feedbackService;
 
+    @Nullable
+    private final de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService;
+
     PullRequestReviewHandler(
         ObjectMapper objectMapper,
         GitRepositoryManager gitRepositoryManager,
@@ -102,7 +105,10 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         ContributorHistoryProvider contributorHistoryProvider,
         PracticeDetectionResultParser resultParser,
         PracticeDetectionDeliveryService deliveryService,
-        FeedbackDeliveryService feedbackService
+        FeedbackDeliveryService feedbackService,
+        @org.springframework.beans.factory.annotation.Autowired(
+            required = false
+        ) @Nullable de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService
     ) {
         this.objectMapper = objectMapper;
         this.gitRepositoryManager = gitRepositoryManager;
@@ -113,6 +119,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         this.resultParser = resultParser;
         this.deliveryService = deliveryService;
         this.feedbackService = feedbackService;
+        this.gitLabTokenService = gitLabTokenService;
     }
 
     @Override
@@ -167,8 +174,8 @@ public class PullRequestReviewHandler implements JobTypeHandler {
 
         Map<String, byte[]> files = new HashMap<>();
 
-        // PR review requires a pre-prepared local checkout. The sandbox never clones or fetches
-        // repositories on demand; it only mounts an existing host-side checkout.
+        // PR review requires a local checkout (cloned by push webhook).
+        // The diff step will fetch to ensure refs are current before computing.
         ensureRepositoryAvailable(repositoryId);
 
         // Load PR entity once — shared by metadata, comments, and contributor history
@@ -180,7 +187,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
 
         // Pre-compute diff: source branches may be deleted after merge,
         // so we compute the diff from the merge commit graph using SHAs.
-        computeAndStoreDiff(files, repositoryId, metadata);
+        computeAndStoreDiff(files, repositoryId, metadata, job);
 
         // Build a structured per-file diff summary optimized for single-pass AI consumption.
         // This is structural transformation (splitting on "diff --git" boundaries), not judgment.
@@ -500,11 +507,10 @@ public class PullRequestReviewHandler implements JobTypeHandler {
     // -------------------------------------------------------------------------
 
     /**
-     * Require a pre-prepared local repository checkout for bind-mounting.
+     * Require a local repository checkout for bind-mounting.
      *
-     * <p>This review flow never clones or fetches repositories on demand. Repository preparation
-     * must happen ahead of time via the normal sync/bootstrap path so sandbox runs stay offline and
-     * deterministic with respect to repo contents.
+     * <p>The repository must have been cloned by a prior push webhook. The diff computation
+     * step ({@link #fetchBeforeDiff}) may fetch to update refs before computing the diff.
      */
     private void ensureRepositoryAvailable(long repositoryId) {
         if (!gitRepositoryManager.isEnabled()) {
@@ -515,6 +521,63 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         if (!gitRepositoryManager.isRepositoryCloned(repositoryId)) {
             throw new JobPreparationException(
                 "Repository checkout is not available locally for bind-mount: repoId=" + repositoryId
+            );
+        }
+    }
+
+    /**
+     * Fetch latest refs from the remote before computing the diff.
+     * Uses GitLabTokenService for GitLab workspaces to get an authenticated fetch.
+     * Falls back gracefully on failure — the diff computation will still attempt
+     * with whatever refs are locally available.
+     */
+    private void fetchBeforeDiff(long repositoryId, AgentJob job) {
+        try {
+            var workspace = job.getWorkspace();
+            if (workspace == null) {
+                log.debug("No workspace on job, skipping pre-diff fetch: jobId={}", job.getId());
+                return;
+            }
+
+            String serverUrl = null;
+            String token = null;
+            Long scopeId = workspace.getId();
+
+            if (gitLabTokenService != null) {
+                try {
+                    serverUrl = gitLabTokenService.resolveServerUrl(scopeId);
+                    token = gitLabTokenService.getAccessToken(scopeId);
+                } catch (Exception e) {
+                    log.debug("GitLab token not available for fetch: scopeId={}, reason={}", scopeId, e.getMessage());
+                }
+            }
+
+            // For GitHub workspaces or when GitLab token is unavailable, the repo may already
+            // be current (fetched by push webhook). The headSha validation in resolveDiffRange
+            // will catch staleness even without a fetch here.
+            if (serverUrl == null || token == null) {
+                log.debug("No token available for pre-diff fetch, relying on existing clone: repoId={}", repositoryId);
+                return;
+            }
+
+            JsonNode metadata = job.getMetadata();
+            String repoFullName =
+                metadata != null && metadata.has("repository_full_name")
+                    ? metadata.get("repository_full_name").asText()
+                    : null;
+            if (repoFullName == null) {
+                log.debug("No repository_full_name in metadata, skipping pre-diff fetch");
+                return;
+            }
+
+            String cloneUrl = serverUrl + "/" + repoFullName + ".git";
+            gitRepositoryManager.ensureRepository(repositoryId, cloneUrl, token);
+            log.debug("Fetched latest refs before diff computation: repoId={}, scopeId={}", repositoryId, scopeId);
+        } catch (Exception e) {
+            log.warn(
+                "Pre-diff fetch failed (will proceed with existing clone): repoId={}, error={}",
+                repositoryId,
+                e.getMessage()
             );
         }
     }
@@ -596,7 +659,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
      * between merge^1 (target before merge) and merge^2 (MR tip). Falls back to
      * target_branch..head_sha if branch still exists.
      */
-    private void computeAndStoreDiff(Map<String, byte[]> files, long repositoryId, JsonNode metadata) {
+    private void computeAndStoreDiff(Map<String, byte[]> files, long repositoryId, JsonNode metadata, AgentJob job) {
         String headSha = metadata.has("commit_sha") ? metadata.get("commit_sha").asText() : null;
         String targetBranch = requireText(metadata, "target_branch");
         String sourceBranch = requireText(metadata, "source_branch");
@@ -608,13 +671,8 @@ public class PullRequestReviewHandler implements JobTypeHandler {
 
         // Fetch latest refs from remote before computing the diff.
         // Without this, the local clone may have stale branch refs from an earlier push,
-        // causing the diff to be computed against the wrong commit.
-        String fetchResult = runGit(repoPath, "fetch", "origin");
-        if (fetchResult == null) {
-            log.warn("Git fetch failed before diff computation: repoId={}, headSha={}", repositoryId, headSha);
-        } else {
-            log.debug("Fetched latest refs before diff computation: repoId={}", repositoryId);
-        }
+        // causing the diff to be computed against the wrong commit (see: stale-diff incident).
+        fetchBeforeDiff(repositoryId, job);
 
         try {
             String[] range = resolveDiffRange(repoPath, targetBranch, sourceBranch, headSha);

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -13,6 +13,7 @@ import de.tum.in.www1.hephaestus.agent.handler.spi.JobSubmissionRequest;
 import de.tum.in.www1.hephaestus.agent.handler.spi.JobTypeHandler;
 import de.tum.in.www1.hephaestus.agent.job.AgentJob;
 import de.tum.in.www1.hephaestus.gitprovider.common.events.EventPayload;
+import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService;
 import de.tum.in.www1.hephaestus.gitprovider.git.GitRepositoryManager;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequest;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
@@ -37,6 +38,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
 
 /**
@@ -94,7 +96,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
     private final FeedbackDeliveryService feedbackService;
 
     @Nullable
-    private final de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService;
+    private final GitLabTokenService gitLabTokenService;
 
     PullRequestReviewHandler(
         ObjectMapper objectMapper,
@@ -106,9 +108,7 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         PracticeDetectionResultParser resultParser,
         PracticeDetectionDeliveryService deliveryService,
         FeedbackDeliveryService feedbackService,
-        @org.springframework.beans.factory.annotation.Autowired(
-            required = false
-        ) @Nullable de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabTokenService gitLabTokenService
+        @Autowired(required = false) @Nullable GitLabTokenService gitLabTokenService
     ) {
         this.objectMapper = objectMapper;
         this.gitRepositoryManager = gitRepositoryManager;

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerRegistryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/JobTypeHandlerRegistryTest.java
@@ -57,7 +57,8 @@ class JobTypeHandlerRegistryTest extends BaseUnitTest {
             contributorHistoryProvider,
             parser,
             deliveryService,
-            feedbackService
+            feedbackService,
+            null
         );
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
@@ -91,7 +91,8 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             contributorHistoryProvider,
             resultParser,
             deliveryService,
-            feedbackService
+            feedbackService,
+            null
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where the practice review pipeline computes a diff against a stale commit when a student pushes multiple commits to an MR branch in quick succession. This caused a production incident where a student received a review saying "no new code to review" despite adding 200 lines of SwiftUI code.

- **Authenticated fetch before diff**: Calls `GitRepositoryManager.ensureRepository()` with the workspace's GitLab PAT (via `GitLabTokenService`) before computing the diff, ensuring the local clone has up-to-date refs. Falls back gracefully for GitHub workspaces or if the token is unavailable.
- **Validate branch ref in Strategy 1**: `resolveDiffRange` now verifies that `origin/{sourceBranch}` actually points to the expected `headSha` before trusting it; falls through to SHA-based strategies (2 and 3) if stale.
- **Diff quality logging**: After computing the diff, logs the strategy used, the resolved range, and +/- line counts so stale-diff incidents are detectable in production logs.

## Root Cause

1. `ensureRepositoryAvailable` only checks clone existence — never fetches
2. `resolveDiffRange` Strategy 1 uses `origin/{sourceBranch}` without verifying it matches `headSha` from the webhook
3. Race condition: push webhook fetches an early commit, MR webhook fires review before the later push is fetched
4. Result: agent receives a diff from a stale commit (e.g., only deletions) instead of the full MR diff, producing 13 `NOT_APPLICABLE` findings on an MR with real code

## Test plan

- [x] Compilation passes (`mvnw compile`)
- [x] Formatting passes (prettier)
- [ ] Verify in staging: push two commits in quick succession to an MR and confirm the review uses the correct (full) diff
- [ ] Monitor production logs for `"Stale branch ref detected"` warnings and diff quality metrics (`+N/-N lines`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation for branch refs to avoid using stale commits; falls back to safer range strategies when needed.
  * Diff pre-computation can refresh remote refs using optional authentication, but will continue gracefully if fetching fails.
  * Enhanced diff reporting: logs chosen strategy, resolved range, and accurate added/removed line counts alongside existing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->