### PR TITLE
fix(server): remove Hephaestus preferences link from review footer

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/FeedbackDeliveryService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/FeedbackDeliveryService.java
@@ -115,7 +115,7 @@ class FeedbackDeliveryService {
             log.debug("Practice note was empty after sanitization, skipping post: jobId={}", job.getId());
             return;
         }
-        String formatted = formatPracticeNote(sanitized, job, reviewProperties.appBaseUrl());
+        String formatted = formatPracticeNote(sanitized, job);
         String commentId = commentPoster.postFormattedBody(job, formatted);
         if (commentId != null) {
             job.setDeliveryCommentId(commentId);
@@ -139,20 +139,16 @@ class FeedbackDeliveryService {
 
     // ── Formatting ──────────────────────────────────────────────────────────
 
-    static String formatPracticeNote(String sanitizedBody, AgentJob job, @Nullable String appBaseUrl) {
+    static String formatPracticeNote(String sanitizedBody, AgentJob job) {
         var sb = new StringBuilder(sanitizedBody.length() + 512);
         sb.append("<!-- hephaestus:practice-review:").append(job.getId()).append(" -->\n");
         sb.append(sanitizedBody).append("\n\n");
-        appendFooter(sb, job, appBaseUrl);
+        appendFooter(sb, job);
         return sb.toString();
     }
 
-    private static void appendFooter(StringBuilder sb, AgentJob job, @Nullable String appBaseUrl) {
+    private static void appendFooter(StringBuilder sb, AgentJob job) {
         sb.append("---\n");
-        if (appBaseUrl != null && !appBaseUrl.isBlank()) {
-            sb.append("*[Hephaestus](").append(appBaseUrl).append(")");
-            sb.append(" · [Configure AI review preferences](").append(appBaseUrl).append("/settings)*\n\n");
-        }
         PullRequestCommentPoster.appendMetadataFooter(sb, job);
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/FeedbackDeliveryServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/FeedbackDeliveryServiceTest.java
@@ -321,7 +321,7 @@ class FeedbackDeliveryServiceTest extends BaseUnitTest {
             job.setStartedAt(Instant.parse("2024-01-01T00:00:00Z"));
             job.setCompletedAt(Instant.parse("2024-01-01T00:01:30Z"));
 
-            String result = FeedbackDeliveryService.formatPracticeNote("Test body content", job, null);
+            String result = FeedbackDeliveryService.formatPracticeNote("Test body content", job);
 
             assertThat(result).contains("<!-- hephaestus:practice-review:" + job.getId() + " -->");
             assertThat(result).contains("Test body content");
@@ -331,41 +331,17 @@ class FeedbackDeliveryServiceTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("includes preferences footer when appBaseUrl is set")
-        void includesPreferencesFooter() {
+        @DisplayName("does not include preferences or app link in footer")
+        void noPreferencesLink() {
             AgentJob job = createJob();
             job.setStartedAt(Instant.parse("2024-01-01T00:00:00Z"));
             job.setCompletedAt(Instant.parse("2024-01-01T00:01:30Z"));
 
-            String result = FeedbackDeliveryService.formatPracticeNote("Body", job, "https://hephaestus.example.com");
-
-            assertThat(result).contains("[Hephaestus](https://hephaestus.example.com)");
-            assertThat(result).contains("[Configure AI review preferences](https://hephaestus.example.com/settings)");
-        }
-
-        @Test
-        @DisplayName("omits preferences footer when appBaseUrl is empty")
-        void omitsPreferencesFooterWhenEmpty() {
-            AgentJob job = createJob();
-            job.setStartedAt(Instant.parse("2024-01-01T00:00:00Z"));
-            job.setCompletedAt(Instant.parse("2024-01-01T00:01:30Z"));
-
-            String result = FeedbackDeliveryService.formatPracticeNote("Body", job, "");
+            String result = FeedbackDeliveryService.formatPracticeNote("Body", job);
 
             assertThat(result).doesNotContain("Configure AI review preferences");
+            assertThat(result).doesNotContain("[Hephaestus]");
             assertThat(result).contains("Hephaestus Agent");
-        }
-
-        @Test
-        @DisplayName("omits preferences footer when appBaseUrl is null")
-        void omitsPreferencesFooterWhenNull() {
-            AgentJob job = createJob();
-            job.setStartedAt(Instant.parse("2024-01-01T00:00:00Z"));
-            job.setCompletedAt(Instant.parse("2024-01-01T00:01:30Z"));
-
-            String result = FeedbackDeliveryService.formatPracticeNote("Body", job, null);
-
-            assertThat(result).doesNotContain("Configure AI review preferences");
         }
     }
 }


### PR DESCRIPTION
## Description

Remove the "Hephaestus · Configure AI review preferences" link from the practice review MR summary comment footer. The metadata footer (agent name, model, duration, disclaimer) is preserved.

## How to Test

- Trigger a practice review and verify the posted MR comment no longer contains the Hephaestus/preferences link
- The `---` separator and `<sub>Hephaestus Agent · model · duration</sub>` metadata line should still appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified practice summary feedback formatting and removed the conditional configuration link from review footers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->