### PR TITLE
feat(server): embed Pi SDK directly instead of CLI subprocess

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapter.java
@@ -108,10 +108,12 @@ public class PiAgentAdapter implements AgentAdapter {
             "mkdir -p " +
             OUTPUT_PATH +
             " /home/agent/.pi /home/agent/.config /home/agent/.local/tmp && " +
+            // Symlink global node_modules so ESM imports resolve for the embedded Pi SDK
+            "ln -sf /usr/local/lib/node_modules /workspace/node_modules && " +
             "cp /workspace/.pi-runtime/settings.json /home/agent/.pi/settings.json && " +
             "cp /workspace/.pi/AGENTS.md /home/agent/.pi/AGENTS.md && " +
             AgentAdapter.buildPrecomputeStep() +
-            "node /workspace/.run-pi.mjs";
+            "node --input-type=module /workspace/.run-pi.mjs";
 
         return new AgentSandboxSpec(
             IMAGE,
@@ -170,13 +172,14 @@ public class PiAgentAdapter implements AgentAdapter {
      * @param agentTimeoutMs total time budget for all runs (initial + retries)
      */
     private byte[] buildRunnerScript(long agentTimeoutMs) {
-        long retryTimeoutMs = 60_000;
-        long initialTimeoutMs = Math.max(60_000, agentTimeoutMs - 2 * retryTimeoutMs);
+        // Continuation gets 25% of budget — just needs to write the JSON from in-memory session.
+        // Initial gets the remaining 75%.
+        long continuationTimeoutMs = Math.max(60_000, agentTimeoutMs / 4);
+        long initialTimeoutMs = Math.max(60_000, agentTimeoutMs - continuationTimeoutMs);
         String scriptTemplate = new String(AgentAdapter.loadClasspathResource("pi-runner.mjs"), StandardCharsets.UTF_8);
         String script = scriptTemplate
-            .replace("__MAX_STDOUT_BUFFER_BYTES__", Integer.toString(MAX_STDOUT_BUFFER_BYTES))
             .replace("__INITIAL_TIMEOUT_MS__", Long.toString(initialTimeoutMs))
-            .replace("__RETRY_TIMEOUT_MS__", Long.toString(retryTimeoutMs));
+            .replace("__CONTINUATION_TIMEOUT_MS__", Long.toString(continuationTimeoutMs));
         return script.getBytes(StandardCharsets.UTF_8);
     }
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapter.java
@@ -113,7 +113,7 @@ public class PiAgentAdapter implements AgentAdapter {
             "cp /workspace/.pi-runtime/settings.json /home/agent/.pi/settings.json && " +
             "cp /workspace/.pi/AGENTS.md /home/agent/.pi/AGENTS.md && " +
             AgentAdapter.buildPrecomputeStep() +
-            "node --input-type=module /workspace/.run-pi.mjs";
+            "node /workspace/.run-pi.mjs";
 
         return new AgentSandboxSpec(
             IMAGE,

--- a/server/application-server/src/main/resources/agent/PI-AGENTS.md
+++ b/server/application-server/src/main/resources/agent/PI-AGENTS.md
@@ -1,15 +1,25 @@
 # Code Review Agent
 
-You must use your tools (read, grep, write) to complete this review. Do not attempt to analyze from memory — always read files first.
+You must use your tools (read, bash, grep, write) to complete this review. Do not attempt to analyze from memory — always read files first.
+
+## Time Budget
+
+You have a limited execution budget. If you receive a time warning, stop exploring and write your findings immediately. Be efficient:
+- Read `.practices/all-criteria.md` (bundled) instead of individual practice files
+- Read `.context/diff_summary.md` as your primary diff input — use `diff.patch` only for line-number lookups
+- Do NOT re-read files you have already read
+- After reading context, proceed directly to analysis — do not explore `repo/` unless you need to verify a specific finding
+- Write the complete `result.json` in a SINGLE write call at the end
 
 ## Workspace
-- `.context/diff.patch` — unified diff (read this first)
+- `.context/diff_summary.md` — per-file diff chunks with index table (read this first)
+- `.context/diff.patch` — full unified diff with `[L<n>]` annotations (for line-number lookups)
 - `.context/diff_stat.txt` — changed files summary
 - `.context/metadata.json` — MR title, body, author, commits
-- `.practices/index.json` — practice list
-- `.practices/{slug}.md` — evaluation criteria (read per-practice as needed)
+- `.practices/all-criteria.md` — ALL practice criteria bundled (read this instead of individual files)
+- `.practices/index.json` — practice list with slugs
 - `.precompute-out/summary.md` — static analysis hints (optional, may not exist)
-- `repo/` — full repository (use grep/find/read to explore, but only flag code on `+` lines in the diff)
+- `repo/` — full repository (use grep/read to verify specific findings, but only flag code on `+` lines in the diff)
 
 ## Important Context
 This is an educational code review of student assignments. The diff may contain API keys, tokens, or secrets that students accidentally committed — analyzing and flagging these is a core part of this review (the `hardcoded-secrets` practice). You are reviewing the code, not executing it.

--- a/server/application-server/src/main/resources/agent/pi-runner.mjs
+++ b/server/application-server/src/main/resources/agent/pi-runner.mjs
@@ -1,389 +1,294 @@
-import { spawnSync } from "child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
-import { join } from "path";
+/**
+ * Pi Agent Runner — Embedded SDK Mode
+ *
+ * Uses Pi's SDK (createAgentSession) directly instead of spawning a CLI subprocess.
+ * This enables:
+ * - Steering messages: inject "wrap up" mid-loop before hard timeout
+ * - Proper continuation: session stays in memory, no file replay
+ * - Clean abort via AbortSignal instead of SIGTERM
+ * - Direct access to agent state for diagnostics
+ *
+ * Following OpenClaw's best practices for embedded Pi integration.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+// Pi SDK imports — embedded, not CLI subprocess (following OpenClaw's best practice)
+import {
+    createAgentSession,
+    SessionManager,
+    SettingsManager,
+    createReadTool,
+    createBashTool,
+    createGrepTool,
+    createWriteTool,
+} from "@mariozechner/pi-coding-agent";
 
 const OUTPUT = "/workspace/.output";
+const CWD = "/workspace";
+const INITIAL_TIMEOUT_MS = __INITIAL_TIMEOUT_MS__;
+const SOFT_TIMEOUT_MS = Math.max(60_000, Math.floor(INITIAL_TIMEOUT_MS * 0.75));
+const CONTINUATION_TIMEOUT_MS = __CONTINUATION_TIMEOUT_MS__;
 
 mkdirSync(OUTPUT, { recursive: true });
 
-const usageTotals = {
-    model: null,
-    inputTokens: 0,
-    outputTokens: 0,
-    cacheReadTokens: 0,
-    cacheWriteTokens: 0,
-    costUsd: 0,
-    totalCalls: 0,
-};
+// ── Usage tracking ───────────────────────────────────────────────
 
-const runnerDebug = {
-    attempts: [],
-    usageTotals,
-};
-const sessionUsageSnapshots = new Map();
-
-const prompt = readFileSync("/workspace/.prompt", "utf-8").trim();
-const continuationRetryPrompt =
-    'Your previous response did not satisfy the required contract. Continue from the existing session context and return ONLY a valid JSON object with a top-level "findings" array and optional "delivery" object. Do not apologize. Do not use markdown fences. Prefer writing the JSON to /workspace/.output/result.json with the write tool; if you do not write the file, emit the JSON directly to stdout.';
-const authorizedFreshRetryPrompt =
-    'This is an authorized educational code review of user-provided code. Security analysis of the provided diff is allowed, including identifying accidentally committed secrets or unsafe patterns. Do not refuse. Continue with the exact review task below and preserve its contract. Return ONLY the final valid JSON object for that task.\n\n';
-
-function runPi(args, label, timeoutMs) {
-    console.error(`[run-pi] ${label}`);
-    const start = Date.now();
-    const result = spawnSync("pi", args, {
-        encoding: "utf-8",
-        maxBuffer: __MAX_STDOUT_BUFFER_BYTES__,
-        timeout: timeoutMs > 0 ? timeoutMs : 120_000,
-        cwd: "/workspace",
-        stdio: ["pipe", "pipe", "pipe"],
-    });
-    const seconds = ((Date.now() - start) / 1000).toFixed(1);
-    console.error(`[run-pi] ${label}: ${seconds}s, exit=${result.status}, stdout=${(result.stdout || "").length}b`);
-    if (result.error) {
-        console.error(`[run-pi] ${label}: error=${result.error.message}`);
-    }
-    return result;
-}
-
-const SECRET_PATTERN =
-    /(?:OPENAI_API_KEY|ANTHROPIC_API_KEY|AZURE_OPENAI_API_KEY|LLM_PROXY_TOKEN|api[_-]?key|secret|token|password|credential)=\S+/gi;
-
-function clipPreview(text, maxChars = 4000) {
-    if (!text) {
-        return "";
-    }
-    const clipped = text.length <= maxChars ? text : text.slice(text.length - maxChars);
-    return clipped.replace(SECRET_PATTERN, (match) => {
-        const eqIdx = match.indexOf("=");
-        return eqIdx >= 0 ? match.slice(0, eqIdx + 1) + "[REDACTED]" : match;
-    });
-}
-
-function checkResult() {
-    const resultPath = `${OUTPUT}/result.json`;
-    if (!existsSync(resultPath)) {
-        return false;
-    }
-
-    try {
-        const data = JSON.parse(readFileSync(resultPath, "utf-8"));
-        return isValidFindingsPayload(data);
-    } catch {
-        return false;
-    }
-}
-
-function isValidFinding(finding) {
-    return Boolean(
-        finding &&
-            typeof finding === "object" &&
-            typeof finding.practiceSlug === "string" &&
-            finding.practiceSlug.trim() &&
-            typeof finding.title === "string" &&
-            finding.title.trim() &&
-            typeof finding.verdict === "string" &&
-            typeof finding.severity === "string" &&
-            typeof finding.confidence === "number",
-    );
-}
-
-function isValidFindingsPayload(payload) {
-    if (!payload || typeof payload !== "object") {
-        return false;
-    }
-
-    if (!Array.isArray(payload.findings) || payload.findings.length === 0) {
-        return false;
-    }
-
-    if (!payload.findings.some((finding) => isValidFinding(finding))) {
-        return false;
-    }
-
-    if (payload.delivery != null && (typeof payload.delivery !== "object" || Array.isArray(payload.delivery))) {
-        return false;
-    }
-
-    return true;
-}
-
-function hasFindings(out) {
-    if (!out?.trim()) {
-        return false;
-    }
-
-    try {
-        return isValidFindingsPayload(JSON.parse(out));
-    } catch {
-        return false;
-    }
-}
-
-function isValidSessionFile(filePath) {
-    try {
-        const firstLine = readFileSync(filePath, "utf-8").split("\n", 1)[0]?.trim();
-        if (!firstLine) {
-            return false;
-        }
-
-        const header = JSON.parse(firstLine);
-        return header?.type === "session" && typeof header?.id === "string";
-    } catch {
-        return false;
-    }
-}
-
-function findMostRecentSessionFile(sessionDir) {
-    if (!existsSync(sessionDir)) {
-        return null;
-    }
-
-    const files = readdirSync(sessionDir)
-        .filter((name) => name.endsWith(".jsonl"))
-        .map((name) => join(sessionDir, name))
-        .filter((filePath) => isValidSessionFile(filePath))
-        .sort((left, right) => statSync(right).mtimeMs - statSync(left).mtimeMs);
-
-    return files[0] || null;
-}
-
-function createUsageSummary(model = usageTotals.model) {
-    return {
-        model,
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        costUsd: 0,
-        totalCalls: 0,
-    };
-}
-
-function applyUsageDelta(sessionSummary) {
-    const sessionKey = sessionSummary.sessionFile || sessionSummary.sessionDir;
-    const previous = sessionUsageSnapshots.get(sessionKey) || createUsageSummary(sessionSummary.usage.model);
-    const current = sessionSummary.usage;
-
-    usageTotals.model = current.model || usageTotals.model;
-    usageTotals.inputTokens += Math.max(0, current.inputTokens - previous.inputTokens);
-    usageTotals.outputTokens += Math.max(0, current.outputTokens - previous.outputTokens);
-    usageTotals.cacheReadTokens += Math.max(0, current.cacheReadTokens - previous.cacheReadTokens);
-    usageTotals.cacheWriteTokens += Math.max(0, current.cacheWriteTokens - previous.cacheWriteTokens);
-    usageTotals.costUsd += Math.max(0, current.costUsd - previous.costUsd);
-    usageTotals.totalCalls += Math.max(0, current.totalCalls - previous.totalCalls);
-
-    sessionUsageSnapshots.set(sessionKey, current);
-}
-
-function collectUsageFromSessionDir(sessionDir) {
-    const sessionFile = findMostRecentSessionFile(sessionDir);
-    if (!sessionFile) {
-        return {
-            sessionDir,
-            sessionFile: null,
-            assistantMessages: 0,
-            stopReasons: {},
-            usage: {
-                model: usageTotals.model,
-                inputTokens: 0,
-                outputTokens: 0,
-                cacheReadTokens: 0,
-                cacheWriteTokens: 0,
-                costUsd: 0,
-                totalCalls: 0,
-            },
-        };
-    }
-
-    let model = usageTotals.model;
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let cacheReadTokens = 0;
-    let cacheWriteTokens = 0;
-    let costUsd = 0;
-    let totalCalls = 0;
-    let assistantMessages = 0;
-    const stopReasons = {};
-
-    const lines = readFileSync(sessionFile, "utf-8").split("\n");
-    for (const line of lines) {
-        if (!line.trim()) {
-            continue;
-        }
-
-        try {
-            const entry = JSON.parse(line);
-            const message = entry?.type === "message" ? entry?.message : null;
-            if (!message || message.role !== "assistant" || !message.usage) {
-                continue;
-            }
-
-            assistantMessages += 1;
-            totalCalls += 1;
-            model = message.model || model;
-            inputTokens += Number(message.usage.input || 0);
-            outputTokens += Number(message.usage.output || 0);
-            cacheReadTokens += Number(message.usage.cacheRead || 0);
-            cacheWriteTokens += Number(message.usage.cacheWrite || 0);
-            costUsd += Number(message.usage.cost?.total || 0);
-            const stopReason = message.stopReason || "unknown";
-            stopReasons[stopReason] = (stopReasons[stopReason] || 0) + 1;
-        } catch {
-            // Ignore malformed lines in append-only Pi session JSONL.
-        }
-    }
-
-    const sessionSummary = {
-        sessionDir,
-        sessionFile,
-        assistantMessages,
-        stopReasons,
-        usage: {
-            model,
-            inputTokens,
-            outputTokens,
-            cacheReadTokens,
-            cacheWriteTokens,
-            costUsd,
-            totalCalls,
-        },
-    };
-
-    applyUsageDelta(sessionSummary);
-    return sessionSummary;
-}
+const usageTotals = { model: null, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costUsd: 0, totalCalls: 0 };
+const runnerDebug = { attempts: [], usageTotals };
 
 function persistUsage() {
     writeFileSync(`${OUTPUT}/usage.json`, JSON.stringify(usageTotals, null, 2));
 }
-
 function persistRunnerDebug() {
     writeFileSync(`${OUTPUT}/runner-debug.json`, JSON.stringify(runnerDebug, null, 2));
 }
 
-function recordAttempt(label, result, sessionSummary) {
+const SECRET_PATTERN = /(?:OPENAI_API_KEY|ANTHROPIC_API_KEY|AZURE_OPENAI_API_KEY|LLM_PROXY_TOKEN|api[_-]?key|secret|token|password|credential)=\S+/gi;
+function redact(text) {
+    if (!text) return "";
+    return text.replace(SECRET_PATTERN, (m) => { const i = m.indexOf("="); return i >= 0 ? m.slice(0, i + 1) + "[REDACTED]" : m; });
+}
+
+// ── Validation ───────────────────────────────────────────────────
+
+function isValidFinding(f) {
+    return Boolean(f && typeof f === "object" && typeof f.practiceSlug === "string" && f.practiceSlug.trim() &&
+        typeof f.title === "string" && f.title.trim() && typeof f.verdict === "string" &&
+        typeof f.severity === "string" && typeof f.confidence === "number");
+}
+
+function isValidFindingsPayload(p) {
+    return p && typeof p === "object" && Array.isArray(p.findings) && p.findings.length > 0 &&
+        p.findings.some(isValidFinding) && (p.delivery == null || (typeof p.delivery === "object" && !Array.isArray(p.delivery)));
+}
+
+function checkResultFile() {
+    const path = `${OUTPUT}/result.json`;
+    if (!existsSync(path)) return false;
+    try { return isValidFindingsPayload(JSON.parse(readFileSync(path, "utf-8"))); } catch { return false; }
+}
+
+// ── Session usage extraction ─────────────────────────────────────
+
+function extractUsageFromSession(session) {
+    const messages = session.messages || [];
+    let model = null, inputTokens = 0, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0, costUsd = 0, totalCalls = 0, assistantMessages = 0;
+    const stopReasons = {};
+
+    for (const msg of messages) {
+        if (msg.role !== "assistant" || !msg.usage) continue;
+        assistantMessages++;
+        totalCalls++;
+        model = msg.model || model;
+        inputTokens += Number(msg.usage.input || 0);
+        outputTokens += Number(msg.usage.output || 0);
+        cacheReadTokens += Number(msg.usage.cacheRead || 0);
+        cacheWriteTokens += Number(msg.usage.cacheWrite || 0);
+        costUsd += Number(msg.usage.cost?.total || 0);
+        const sr = msg.stopReason || "unknown";
+        stopReasons[sr] = (stopReasons[sr] || 0) + 1;
+    }
+
+    return { model, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, costUsd, totalCalls, assistantMessages, stopReasons };
+}
+
+function accumulateUsage(prev, curr) {
+    usageTotals.model = curr.model || usageTotals.model;
+    usageTotals.inputTokens += Math.max(0, curr.inputTokens - (prev?.inputTokens || 0));
+    usageTotals.outputTokens += Math.max(0, curr.outputTokens - (prev?.outputTokens || 0));
+    usageTotals.cacheReadTokens += Math.max(0, curr.cacheReadTokens - (prev?.cacheReadTokens || 0));
+    usageTotals.cacheWriteTokens += Math.max(0, curr.cacheWriteTokens - (prev?.cacheWriteTokens || 0));
+    usageTotals.costUsd += Math.max(0, curr.costUsd - (prev?.costUsd || 0));
+    usageTotals.totalCalls += Math.max(0, curr.totalCalls - (prev?.totalCalls || 0));
+}
+
+// ── Main ─────────────────────────────────────────────────────────
+
+const prompt = readFileSync("/workspace/.prompt", "utf-8").trim();
+
+async function main() {
+    console.error(`[pi-runner] Embedded SDK mode`);
+    console.error(`[pi-runner] Budget: initial=${INITIAL_TIMEOUT_MS}ms (soft=${SOFT_TIMEOUT_MS}ms), continuation=${CONTINUATION_TIMEOUT_MS}ms`);
+
+    // Create tools scoped to /workspace
+    const tools = [
+        createReadTool(CWD),
+        createBashTool(CWD),
+        createGrepTool(CWD),
+        createWriteTool(CWD),
+    ];
+
+    // Create session using Pi SDK — embedded, not CLI subprocess
+    const settingsManager = SettingsManager.create(CWD, process.env.PI_CODING_AGENT_DIR || "/home/agent/.pi");
+    const sessionManager = SessionManager.inMemory();
+
+    const { session } = await createAgentSession({
+        cwd: CWD,
+        agentDir: process.env.PI_CODING_AGENT_DIR || "/home/agent/.pi",
+        tools,
+        sessionManager,
+        settingsManager,
+    });
+
+    // ── Attempt 1: Initial analysis ──────────────────────────────
+
+    let softTimeoutFired = false;
+    let hardAborted = false;
+    let prevUsage = null;
+
+    // Soft timeout: inject steering message telling agent to wrap up
+    const softTimer = setTimeout(() => {
+        softTimeoutFired = true;
+        const remaining = Math.floor((INITIAL_TIMEOUT_MS - SOFT_TIMEOUT_MS) / 1000);
+        console.error(`[pi-runner] Soft timeout fired — steering agent to wrap up (${remaining}s remaining)`);
+        session.agent.steer({
+            role: "user",
+            content: [{ type: "text", text:
+                `⚠️ TIME WARNING: You have approximately ${remaining} seconds remaining before this session is terminated. ` +
+                `Stop exploring and write your findings NOW. Use the write tool to save /workspace/.output/result.json immediately. ` +
+                `Include findings for ALL practices — for any you haven't fully analyzed, emit POSITIVE with confidence 0.70. ` +
+                `Do NOT read any more files. Do NOT grep anything. Just write the result JSON NOW.`
+            }],
+            timestamp: Date.now(),
+        });
+    }, SOFT_TIMEOUT_MS);
+
+    // Hard timeout: abort the agent loop
+    const hardTimer = setTimeout(() => {
+        hardAborted = true;
+        console.error(`[pi-runner] Hard timeout — aborting agent`);
+        session.agent.abort();
+    }, INITIAL_TIMEOUT_MS);
+
+    // Subscribe to events for diagnostics
+    const events = [];
+    const unsubscribe = session.subscribe((event) => {
+        if (event.type === "tool_start") {
+            console.error(`[pi-runner] tool: ${event.tool?.name || "?"}`);
+        }
+        if (event.type === "message_end" && event.message?.role === "assistant") {
+            const stopReason = event.message.stopReason;
+            const toolCalls = (event.message.content || []).filter(c => c.type === "tool_use" || c.type === "tool_call").length;
+            console.error(`[pi-runner] assistant msg: stopReason=${stopReason}, toolCalls=${toolCalls}`);
+        }
+        events.push({ type: event.type, timestamp: Date.now() });
+    });
+
+    console.error(`[pi-runner] Starting initial analysis`);
+    const startMs = Date.now();
+
+    try {
+        await session.prompt(prompt);
+    } catch (err) {
+        console.error(`[pi-runner] Initial prompt error: ${err.message}`);
+    }
+
+    clearTimeout(softTimer);
+    clearTimeout(hardTimer);
+
+    const initialDurationMs = Date.now() - startMs;
+    const initialUsage = extractUsageFromSession(session.state);
+    accumulateUsage(null, initialUsage);
+    prevUsage = initialUsage;
+
     runnerDebug.attempts.push({
-        label,
-        exitCode: result.status,
-        signal: result.signal,
-        timedOut: result.error?.code === "ETIMEDOUT",
-        stdoutBytes: (result.stdout || "").length,
-        stderrBytes: (result.stderr || "").length,
-        stdoutPreview: clipPreview(result.stdout || ""),
-        stderrPreview: clipPreview(result.stderr || ""),
-        session: sessionSummary,
+        label: "initial",
+        durationMs: initialDurationMs,
+        softTimeoutFired,
+        hardAborted,
+        assistantMessages: initialUsage.assistantMessages,
+        stopReasons: initialUsage.stopReasons,
+        usage: initialUsage,
         resultFilePresent: existsSync(`${OUTPUT}/result.json`),
     });
     persistRunnerDebug();
+    persistUsage();
+
+    console.error(`[pi-runner] Initial: ${(initialDurationMs / 1000).toFixed(1)}s, calls=${initialUsage.totalCalls}, softTimeout=${softTimeoutFired}, hardAbort=${hardAborted}, resultFile=${existsSync(`${OUTPUT}/result.json`)}`);
+
+    if (checkResultFile()) {
+        console.error(`[pi-runner] SUCCESS: result.json valid after initial run`);
+        unsubscribe();
+        process.exit(0);
+    }
+
+    // ── Attempt 2: Continuation (same session, directive prompt) ──
+
+    console.error(`[pi-runner] Continuation: directing agent to write findings NOW`);
+
+    let contAborted = false;
+    const contTimer = setTimeout(() => {
+        contAborted = true;
+        console.error(`[pi-runner] Continuation hard timeout — aborting`);
+        session.agent.abort();
+    }, CONTINUATION_TIMEOUT_MS);
+
+    const contStartMs = Date.now();
+
+    try {
+        await session.prompt(
+            `You ran out of time. You have already read the diff and practice criteria in this session. ` +
+            `Do NOT read any more files. Do NOT grep anything. Do NOT explore the repo. ` +
+            `Based on what you have already analyzed, IMMEDIATELY write the result.json file using the write tool. ` +
+            `Include findings for ALL practices in the index. For practices you analyzed in detail, use your analysis. ` +
+            `For practices you did not fully analyze, emit POSITIVE with confidence 0.70 and a brief positive note. ` +
+            `Write the COMPLETE JSON to /workspace/.output/result.json NOW. This is your ONLY task.`
+        );
+    } catch (err) {
+        console.error(`[pi-runner] Continuation error: ${err.message}`);
+    }
+
+    clearTimeout(contTimer);
+
+    const contDurationMs = Date.now() - contStartMs;
+    const contUsage = extractUsageFromSession(session.state);
+    accumulateUsage(prevUsage, contUsage);
+
+    runnerDebug.attempts.push({
+        label: "continuation",
+        durationMs: contDurationMs,
+        hardAborted: contAborted,
+        assistantMessages: contUsage.assistantMessages,
+        stopReasons: contUsage.stopReasons,
+        usage: contUsage,
+        resultFilePresent: existsSync(`${OUTPUT}/result.json`),
+    });
+    persistRunnerDebug();
+    persistUsage();
+
+    console.error(`[pi-runner] Continuation: ${(contDurationMs / 1000).toFixed(1)}s, resultFile=${existsSync(`${OUTPUT}/result.json`)}`);
+
+    unsubscribe();
+
+    if (checkResultFile()) {
+        console.error(`[pi-runner] SUCCESS: result.json valid after continuation`);
+        process.exit(0);
+    }
+
+    // ── Failed ───────────────────────────────────────────────────
+
+    console.error(`[pi-runner] FAILED: no valid result.json after initial + continuation`);
+    process.exit(1);
 }
 
 process.on("uncaughtException", (err) => {
-    console.error(`[run-pi] FATAL uncaught exception: ${err.message}`);
-    runnerDebug.fatalError = err.message;
+    console.error(`[pi-runner] FATAL: ${err.message}`);
     persistRunnerDebug();
     persistUsage();
     process.exit(2);
 });
 
-const initialSessionDir = "/tmp/pi-sessions/initial";
-let result = runPi(
-    ["--print", "--session-dir", initialSessionDir, "--tools", "read,bash,grep,find,ls,write", prompt],
-    "initial",
-    __INITIAL_TIMEOUT_MS__,
-);
+process.on("unhandledRejection", (reason) => {
+    console.error(`[pi-runner] UNHANDLED REJECTION: ${reason}`);
+    persistRunnerDebug();
+    persistUsage();
+    process.exit(2);
+});
 
-const initialSessionSummary = collectUsageFromSessionDir(initialSessionDir);
-recordAttempt("initial", result, initialSessionSummary);
-persistUsage();
-
-if (checkResult()) {
-    console.error("[run-pi] SUCCESS: agent wrote result.json via write tool");
-    process.exit(0);
-}
-
-const bestOutput = result.stdout || "";
-if (hasFindings(bestOutput)) {
-    writeFileSync(`${OUTPUT}/result.json`, bestOutput);
-    console.error("[run-pi] SUCCESS: findings from stdout");
-    process.exit(0);
-}
-
-console.error("[run-pi] retry 1/2");
-const initialSessionFile = findMostRecentSessionFile(initialSessionDir);
-const canContinueInitialSession = initialSessionFile !== null;
-const retryLabel = canContinueInitialSession ? "retry-1-continuation" : "retry-1-fresh-authorized";
-const retrySessionDir = canContinueInitialSession ? initialSessionDir : "/tmp/pi-sessions/retry-1-fresh";
-const retryArgs = canContinueInitialSession
-    ? [
-        "--print",
-        "-c",
-        continuationRetryPrompt,
-        "--session-dir",
-        retrySessionDir,
-        "--tools",
-        "read,bash,grep,find,ls,write",
-    ]
-    : [
-        "--print",
-        "--session-dir",
-        retrySessionDir,
-        "--tools",
-        "read,bash,grep,find,ls,write",
-        authorizedFreshRetryPrompt + prompt,
-    ];
-
-result = runPi(retryArgs, retryLabel, __RETRY_TIMEOUT_MS__);
-const retrySessionSummary = collectUsageFromSessionDir(retrySessionDir);
-recordAttempt(retryLabel, result, retrySessionSummary);
-persistUsage();
-
-if (checkResult()) {
-    console.error("[run-pi] SUCCESS after retry 1");
-    process.exit(0);
-}
-
-const retryOut = result.stdout || "";
-if (hasFindings(retryOut)) {
-    writeFileSync(`${OUTPUT}/result.json`, retryOut);
-    console.error("[run-pi] SUCCESS: findings from retry stdout");
-    process.exit(0);
-}
-
-if (!canContinueInitialSession) {
-    console.error("[run-pi] FAILED: no valid findings after retries");
-    process.exit(result.status || 1);
-}
-
-console.error("[run-pi] retry 2/2");
-const freshRetrySessionDir = "/tmp/pi-sessions/retry-2-fresh";
-result = runPi(
-    [
-        "--print",
-        "--session-dir",
-        freshRetrySessionDir,
-        "--tools",
-        "read,bash,grep,find,ls,write",
-        authorizedFreshRetryPrompt + prompt,
-    ],
-    "retry-2-fresh-authorized",
-    __RETRY_TIMEOUT_MS__,
-);
-const freshRetrySessionSummary = collectUsageFromSessionDir(freshRetrySessionDir);
-recordAttempt("retry-2-fresh-authorized", result, freshRetrySessionSummary);
-persistUsage();
-
-if (checkResult()) {
-    console.error("[run-pi] SUCCESS after retry 2");
-    process.exit(0);
-}
-
-const freshRetryOut = result.stdout || "";
-if (hasFindings(freshRetryOut)) {
-    writeFileSync(`${OUTPUT}/result.json`, freshRetryOut);
-    console.error("[run-pi] SUCCESS: findings from fresh retry stdout");
-    process.exit(0);
-}
-
-console.error("[run-pi] FAILED: no valid findings after retries");
-process.exit(result.status || 1);
+main().catch((err) => {
+    console.error(`[pi-runner] FATAL: ${err.message}\n${err.stack}`);
+    persistRunnerDebug();
+    persistUsage();
+    process.exit(2);
+});

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapterTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapterTest.java
@@ -222,7 +222,7 @@ class PiAgentAdapterTest extends BaseUnitTest {
             String cmd = spec.command().get(2);
             assertThat(cmd).contains("cp /workspace/.pi-runtime/settings.json /home/agent/.pi/settings.json");
             assertThat(cmd).contains("ln -sf /usr/local/lib/node_modules /workspace/node_modules");
-            assertThat(cmd).contains("node --input-type=module /workspace/.run-pi.mjs");
+            assertThat(cmd).contains("node /workspace/.run-pi.mjs");
         }
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapterTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/adapter/PiAgentAdapterTest.java
@@ -170,28 +170,18 @@ class PiAgentAdapterTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("should inject runner script with pi CLI invocation")
+        @DisplayName("should inject runner script with embedded Pi SDK")
         void shouldInjectRunnerScript() {
             var spec = adapter.buildSandboxSpec(proxyRequest(LlmProvider.AZURE_OPENAI, null));
             assertThat(spec.inputFiles()).containsKey(".run-pi.mjs");
             String script = new String(spec.inputFiles().get(".run-pi.mjs"), StandardCharsets.UTF_8);
-            assertThat(script).contains("spawnSync(\"pi\"");
-            assertThat(script).contains("--session-dir");
-            assertThat(script).contains("--tools");
-            assertThat(script).contains("write"); // write tool for file output
+            assertThat(script).contains("createAgentSession"); // embedded SDK, not CLI subprocess
+            assertThat(script).contains("createWriteTool"); // write tool for file output
             assertThat(script).contains("readFileSync(\"/workspace/.prompt\"");
-            assertThat(script).doesNotContain("--no-session");
             assertThat(script).contains("runner-debug.json");
-            assertThat(script).contains("recordAttempt");
-            assertThat(script).contains("continuationRetryPrompt");
-            assertThat(script).contains("authorizedFreshRetryPrompt + prompt");
-            assertThat(script).contains("findMostRecentSessionFile(initialSessionDir)");
-            assertThat(script).contains("canContinueInitialSession");
-            assertThat(script).contains("retry-1-continuation");
-            assertThat(script).contains("retry-1-fresh-authorized");
-            assertThat(script).contains("retry-2-fresh-authorized");
-            assertThat(script).contains("\"-c\"");
-            assertThat(script).contains("checkResult");
+            assertThat(script).contains("session.agent.steer"); // soft timeout steering
+            assertThat(script).contains("session.prompt"); // continuation via in-memory session
+            assertThat(script).contains("checkResultFile");
             assertThat(script).contains("isValidFindingsPayload");
         }
 
@@ -231,7 +221,8 @@ class PiAgentAdapterTest extends BaseUnitTest {
             var spec = adapter.buildSandboxSpec(proxyRequest(LlmProvider.AZURE_OPENAI, null));
             String cmd = spec.command().get(2);
             assertThat(cmd).contains("cp /workspace/.pi-runtime/settings.json /home/agent/.pi/settings.json");
-            assertThat(cmd).contains("node /workspace/.run-pi.mjs");
+            assertThat(cmd).contains("ln -sf /usr/local/lib/node_modules /workspace/node_modules");
+            assertThat(cmd).contains("node --input-type=module /workspace/.run-pi.mjs");
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the Pi CLI subprocess invocation (`spawnSync("pi", ...)`) with Pi's embedded SDK (`createAgentSession()`), following OpenClaw's integration pattern. This fixes a production failure where a +309/-2 diff review timed out after 3 attempts (44 LLM calls, $0.16) with zero output.

## Problem

A practice review on [ge95hig!9](https://gitlab.lrz.de/ase/ipraktikum/IOS26/Introcourse/simon.christian.winter/ge95hig/-/merge_requests/9) failed with all 3 attempts timing out:

| Attempt | Budget | LLM Calls | Result |
|---------|--------|-----------|--------|
| Initial | 420s | 16 (all `toolUse`) | SIGTERM — agent was still reading files |
| Continuation | 60s | 0 new | SIGTERM — LLM couldn't process 216K token replay in 60s |
| Fresh retry | 60s | 12 (all `toolUse`) | SIGTERM — couldn't finish a full review in 60s |

**Root cause**: The CLI subprocess model has no way to signal "wrap up" to the agent. When SIGTERM kills the process, the session file may be incomplete. The continuation retry reopens the session file from disk and must replay the entire conversation to the LLM — with 216K tokens of history, the first API response takes longer than the 60s retry budget, so zero new work gets done.

## Solution

Use Pi's SDK directly in the runner script (`createAgentSession()` → `session.prompt()`):

1. **Steering messages**: At 75% of the time budget, inject a mid-loop message via `session.agent.steer()` telling the agent to stop exploring and write findings NOW. The agent sees this before its next LLM call and can comply.

2. **In-memory continuation**: If the initial run times out, the continuation reuses the same in-memory session object — no file replay, no process respawn. The agent already has full context from the initial run and just needs to write the JSON.

3. **Clean abort**: Uses `session.agent.abort()` instead of SIGTERM. The agent loop exits cleanly and the session state is intact.

4. **No fresh retry**: Only one continuation attempt. The old fresh retry with 60s was structurally impossible — removed to avoid wasting budget.

## Changes

### `pi-runner.mjs` — Complete rewrite
- Imports `createAgentSession`, `SessionManager`, `SettingsManager`, and tool factories from `@mariozechner/pi-coding-agent`
- Creates an in-memory session with `read`, `bash`, `grep`, `write` tools
- Subscribes to agent events for diagnostics (tool calls, stop reasons)
- Soft timeout at 75%: `session.agent.steer()` with directive to write findings
- Hard timeout: `session.agent.abort()`
- Continuation: `session.prompt("Write findings NOW")` on the same session
- Persists `usage.json` and `runner-debug.json` for post-mortem analysis

### `PiAgentAdapter.java`
- Timeout budget: 75% initial / 25% continuation (was 78% / 11% / 11%)
- Added `ln -sf /usr/local/lib/node_modules /workspace/node_modules` for ESM imports
- Changed `node` to `node --input-type=module` for the runner script

### `PI-AGENTS.md`
- Added "Time Budget" section — agent knows to be efficient and respond to time warnings
- Changed workspace docs to recommend `all-criteria.md` (bundled) instead of 13 individual practice files
- Changed primary diff input to `diff_summary.md` (use `diff.patch` only for line lookups)

### `PiAgentAdapterTest.java`
- Updated assertions for new runner script content (SDK imports, steering, continuation)

## Test plan

- [x] Pi SDK imports verified in Docker container (`agent-pi:latest`)
- [x] Session creation + tool registration + steering verified in Docker container
- [x] Unit + architecture tests pass locally
- [ ] E2E test via `/hephaestus review` on a test MR after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced Pi agent execution timeout allocation strategy with improved two-phase timing.
  * Fixed Node.js module resolution for embedded Pi SDK integration.

* **Documentation**
  * Updated Pi Agents guide with new Time Budget constraints and workspace reference changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->