### PR TITLE
feat(server): audit and fix GitLab workspace event scoring

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/activity/ActivityEventListener.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/activity/ActivityEventListener.java
@@ -8,6 +8,8 @@ import de.tum.in.www1.hephaestus.gitprovider.issuecomment.IssueComment;
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.IssueCommentRepository;
 import de.tum.in.www1.hephaestus.gitprovider.project.Project;
 import de.tum.in.www1.hephaestus.gitprovider.project.ProjectRepository;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequest;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreview.PullRequestReview;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreview.PullRequestReviewRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewthread.PullRequestReviewThread;
@@ -50,6 +52,7 @@ public class ActivityEventListener {
     private final ActivityEventService activityEventService;
     private final ExperiencePointCalculator xpCalc;
     private final PullRequestReviewRepository reviewRepository;
+    private final PullRequestRepository pullRequestRepository;
     private final IssueCommentRepository issueCommentRepository;
     private final PullRequestReviewThreadRepository reviewThreadRepository;
     private final UserRepository userRepository;
@@ -650,11 +653,13 @@ public class ActivityEventListener {
     /**
      * Handle review comment (inline code comment) created events.
      *
-     * <p>Records with 0 XP because the review's XP calculation already factors in
-     * the number of inline comments via {@code calculateCodeReviewBonus()}. Adding
-     * separate XP here would double-count the same comments.
+     * <p>For comments linked to a review (GitHub-style), records with 0 XP because
+     * the review's XP calculation already factors in inline comments via
+     * {@code calculateCodeReviewBonus()}.
      *
-     * <p>We still record the event for audit trail and activity tracking purposes.
+     * <p>For standalone comments without a parent review (GitLab diff notes),
+     * awards flat-rate XP directly since there is no parent review
+     * to carry the code review bonus.
      */
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -674,8 +679,16 @@ public class ActivityEventListener {
             return;
         }
         Instant occurredAt = commentData.createdAt() != null ? commentData.createdAt() : Instant.now();
-        // Record with 0 XP - the review's calculateCodeReviewBonus() already factors in comment count.
-        // Recording the event for audit purposes only.
+
+        // Standalone review comments (GitLab diff notes without a parent review) get
+        // flat-rate XP directly. Comments linked to a review get 0 XP since
+        // the review's calculateCodeReviewBonus() already factors in comment count.
+        double xp = 0.0;
+        if (commentData.reviewId() == null && commentData.pullRequestId() != null) {
+            xp = calculateStandaloneReviewCommentXp(commentData);
+        }
+
+        final double finalXp = xp;
         safeRecord("review comment", commentData.id(), () ->
             activityEventService.record(
                 event.context().scopeId(),
@@ -685,8 +698,27 @@ public class ActivityEventListener {
                 repositoryRepository.getReferenceById(commentData.repositoryId()),
                 ActivityTargetType.REVIEW_COMMENT,
                 commentData.id(),
-                0.0 // No XP - already counted in review's code review bonus
+                finalXp
             )
+        );
+    }
+
+    /**
+     * Calculates XP for a standalone review comment (not linked to a review).
+     * Self-review check and XP formula are handled inside the calculator
+     * to maintain the single-source-of-truth contract.
+     */
+    private double calculateStandaloneReviewCommentXp(EventPayload.ReviewCommentData commentData) {
+        PullRequest pr = pullRequestRepository.findById(commentData.pullRequestId()).orElse(null);
+        if (pr == null) {
+            log.warn("PR not found for standalone review comment XP: prId={}", commentData.pullRequestId());
+            return 0.0;
+        }
+
+        return xpCalc.calculateStandaloneReviewCommentXp(
+            pr,
+            commentData.authorId(),
+            commentData.body() != null ? commentData.body().length() : 0
         );
     }
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/activity/scoring/ExperiencePointCalculator.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/activity/scoring/ExperiencePointCalculator.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Hibernate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 /**
@@ -324,6 +325,53 @@ public class ExperiencePointCalculator implements ExperiencePointStrategy {
         // Substantive comments (>50 chars) earn full XP, trivial ones earn half
         double base = properties.xpAwards().reviewComment();
         return bodyLength > 50 ? base : base * 0.5;
+    }
+
+    /**
+     * Calculate XP for a standalone review comment (not linked to a review).
+     *
+     * <p>Used for GitLab diff notes which are posted individually without
+     * a parent review entity. Uses the same flat-rate formula as
+     * {@link #calculateReviewCommentExperiencePoints(int)}, awarding a small
+     * fixed XP per comment based on comment length.
+     *
+     * <p><strong>Design rationale:</strong> On GitHub, inline comments are grouped
+     * into a review and their count feeds into the review's
+     * {@code calculateCodeReviewBonus()}. On GitLab, each diff note is standalone.
+     * Using a complexity-weighted harmonic mean per-comment would be unbounded
+     * (N comments × full review-level XP), creating a large platform disparity.
+     * A flat rate keeps GitLab comments as a small bonus, consistent with how
+     * GitHub accounts for them via the code review bonus curve.
+     *
+     * <p><strong>Self-review check only:</strong> This method checks whether the
+     * comment author is the same as the PR author (no XP for self-review). It does
+     * NOT apply the {@code selfReviewAuthorLogins} bot-assignee exclusion because
+     * that check requires assignee data (see {@link #isSelfAssignedReview}) and
+     * would incorrectly penalise all humans reviewing bot-authored PRs.
+     *
+     * @param pullRequest the PR (used for self-review check)
+     * @param commentAuthorId the comment author's ID (for self-review check)
+     * @param bodyLength length of the comment body
+     * @return XP for the standalone review comment
+     */
+    public double calculateStandaloneReviewCommentXp(
+        PullRequest pullRequest,
+        @Nullable Long commentAuthorId,
+        int bodyLength
+    ) {
+        // Self-review check: no XP for commenting on your own PR
+        User prAuthor = pullRequest.getAuthor();
+        if (
+            prAuthor != null &&
+            commentAuthorId != null &&
+            prAuthor.getId() != null &&
+            prAuthor.getId().equals(commentAuthorId)
+        ) {
+            return 0.0;
+        }
+
+        // Flat-rate XP: substantive comments (>50 chars) get full XP, trivial ones get half
+        return calculateReviewCommentExperiencePoints(bodyLength);
     }
 
     /**

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandler.java
@@ -192,14 +192,17 @@ public class GitLabNoteMessageHandler extends GitLabMessageHandler<GitLabNoteEve
         if (pullRequest == null) return;
 
         // Self-review guard: skip if reviewer == MR author
-        if (pullRequest.getAuthor() != null &&
+        if (
+            pullRequest.getAuthor() != null &&
             pullRequest.getAuthor().getNativeId() != null &&
-            pullRequest.getAuthor().getNativeId().equals(event.user().id().longValue())) {
+            pullRequest.getAuthor().getNativeId().equals(event.user().id().longValue())
+        ) {
             return;
         }
 
-        User reviewer = userRepository.findByNativeIdAndProviderId(
-            event.user().id(), context.providerId()).orElse(null);
+        User reviewer = userRepository
+            .findByNativeIdAndProviderId(event.user().id(), context.providerId())
+            .orElse(null);
         if (reviewer == null) return;
 
         mergeRequestProcessor.processRequestedChangesFromNote(pullRequest, reviewer, context);

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandler.java
@@ -10,7 +10,12 @@ import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabEventType;
 import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabMessageHandler;
 import de.tum.in.www1.hephaestus.gitprovider.common.gitlab.GitLabWebhookContextResolver;
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.gitlab.dto.GitLabNoteEventDTO;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequest;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.gitlab.GitLabMergeRequestProcessor;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.gitlab.GitLabDiffNoteWebhookProcessor;
+import de.tum.in.www1.hephaestus.gitprovider.user.User;
+import de.tum.in.www1.hephaestus.gitprovider.user.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,13 +33,19 @@ public class GitLabNoteMessageHandler extends GitLabMessageHandler<GitLabNoteEve
 
     private final GitLabIssueCommentProcessor issueCommentProcessor;
     private final GitLabDiffNoteWebhookProcessor diffNoteProcessor;
+    private final GitLabMergeRequestProcessor mergeRequestProcessor;
     private final GitLabWebhookContextResolver contextResolver;
+    private final PullRequestRepository pullRequestRepository;
+    private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     GitLabNoteMessageHandler(
         GitLabIssueCommentProcessor issueCommentProcessor,
         GitLabDiffNoteWebhookProcessor diffNoteProcessor,
+        GitLabMergeRequestProcessor mergeRequestProcessor,
         GitLabWebhookContextResolver contextResolver,
+        PullRequestRepository pullRequestRepository,
+        UserRepository userRepository,
         NatsMessageDeserializer deserializer,
         TransactionTemplate transactionTemplate,
         ApplicationEventPublisher eventPublisher
@@ -42,7 +53,10 @@ public class GitLabNoteMessageHandler extends GitLabMessageHandler<GitLabNoteEve
         super(GitLabNoteEventDTO.class, deserializer, transactionTemplate);
         this.issueCommentProcessor = issueCommentProcessor;
         this.diffNoteProcessor = diffNoteProcessor;
+        this.mergeRequestProcessor = mergeRequestProcessor;
         this.contextResolver = contextResolver;
+        this.pullRequestRepository = pullRequestRepository;
+        this.userRepository = userRepository;
         this.eventPublisher = eventPublisher;
     }
 
@@ -130,6 +144,10 @@ public class GitLabNoteMessageHandler extends GitLabMessageHandler<GitLabNoteEve
                 } else {
                     issueCommentProcessor.processMergeRequestNote(event, context);
                 }
+                // Detect "Request changes" signal: GitLab's batch review with "Request changes"
+                // does NOT fire an MR webhook (GitLab bug #517909). Instead, the note events
+                // carry merge_request.detailed_merge_status = "requested_changes".
+                detectRequestedChanges(event, context);
             }
             case "Commit" -> log.debug(
                 "Skipped commit note: projectPath={}, noteId={}",
@@ -147,6 +165,44 @@ public class GitLabNoteMessageHandler extends GitLabMessageHandler<GitLabNoteEve
 
     private static boolean isBotCommand(String noteBody) {
         return noteBody != null && !noteBody.isBlank() && noteBody.strip().toLowerCase().startsWith(BOT_COMMAND_PREFIX);
+    }
+
+    /**
+     * Detects the "Request changes" signal from MR note events.
+     *
+     * <p>GitLab's "Request changes" (Premium, GA 17.3) fires NO dedicated webhook.
+     * However, note events from the batch review carry the updated
+     * {@code merge_request.detailed_merge_status}. When this transitions to
+     * {@code "requested_changes"}, we create a CHANGES_REQUESTED review for the note author.
+     */
+    private void detectRequestedChanges(GitLabNoteEventDTO event, ProcessingContext context) {
+        var mr = event.mergeRequest();
+        if (mr == null || mr.iid() == null || mr.detailedMergeStatus() == null) return;
+
+        if (!"requested_changes".equals(mr.detailedMergeStatus())) return;
+
+        // The note author is the person who requested changes
+        if (event.user() == null || event.user().id() == null) return;
+
+        // Don't create CHANGES_REQUESTED for the MR author commenting on their own PR
+        if (context.repository() == null) return;
+        var pullRequest = pullRequestRepository
+            .findByRepositoryIdAndNumber(context.repository().getId(), mr.iid())
+            .orElse(null);
+        if (pullRequest == null) return;
+
+        // Self-review guard: skip if reviewer == MR author
+        if (pullRequest.getAuthor() != null &&
+            pullRequest.getAuthor().getNativeId() != null &&
+            pullRequest.getAuthor().getNativeId().equals(event.user().id().longValue())) {
+            return;
+        }
+
+        User reviewer = userRepository.findByNativeIdAndProviderId(
+            event.user().id(), context.providerId()).orElse(null);
+        if (reviewer == null) return;
+
+        mergeRequestProcessor.processRequestedChangesFromNote(pullRequest, reviewer, context);
     }
 
     private void handleBotCommand(GitLabNoteEventDTO event, ProcessingContext context, String safeProjectPath) {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/dto/GitLabNoteEventDTO.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/dto/GitLabNoteEventDTO.java
@@ -30,7 +30,9 @@ public record GitLabNoteEventDTO(
         String action,
         String url,
         @JsonProperty("created_at") String createdAt,
-        @JsonProperty("updated_at") String updatedAt
+        @JsonProperty("updated_at") String updatedAt,
+        @Nullable @JsonProperty("discussion_id") String discussionId,
+        @Nullable String type
     ) {}
 
     /** Embedded issue data — enough fields for stub creation if the parent doesn't exist yet. */
@@ -60,7 +62,8 @@ public record GitLabNoteEventDTO(
         @JsonProperty("target_branch") String targetBranch,
         String url,
         @JsonProperty("created_at") String createdAt,
-        @JsonProperty("updated_at") String updatedAt
+        @JsonProperty("updated_at") String updatedAt,
+        @Nullable @JsonProperty("detailed_merge_status") String detailedMergeStatus
     ) {}
 
     public boolean isSystemNote() {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessor.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessor.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -322,6 +323,9 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
 
     /**
      * Process an approval event.
+     *
+     * <p>Creates a new APPROVED review or updates an existing review (e.g., from
+     * CHANGES_REQUESTED after a previous unapproval) to APPROVED state.
      */
     @Transactional
     @Nullable
@@ -333,7 +337,24 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
         if (approver == null) return pr;
 
         long approvalNativeId = generateApprovalNativeId(pr.getNativeId(), approver.getNativeId());
-        if (reviewRepository.findByNativeIdAndProviderId(approvalNativeId, context.providerId()).isEmpty()) {
+        var existingReview = reviewRepository.findByNativeIdAndProviderId(approvalNativeId, context.providerId());
+
+        if (existingReview.isPresent()) {
+            // Re-approval: update existing review (may be CHANGES_REQUESTED from prior unapproval)
+            PullRequestReview review = existingReview.get();
+            if (review.getState() != PullRequestReview.State.APPROVED) {
+                review.setState(PullRequestReview.State.APPROVED);
+                review.setSubmittedAt(Instant.now());
+                review.setUpdatedAt(Instant.now());
+                reviewRepository.save(review);
+
+                EventPayload.ReviewData.from(review).ifPresent(reviewData ->
+                    eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(context)))
+                );
+                log.debug("Updated review to APPROVED: prId={}, reviewerId={}", pr.getId(), approver.getLogin());
+            }
+        } else {
+            // First approval: create new review
             PullRequestReview review = createApprovalReview(approvalNativeId, pr, approver);
             reviewRepository.save(review);
             pr.addReview(review);
@@ -349,6 +370,11 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
 
     /**
      * Process an unapproval event.
+     *
+     * <p>Maps GitLab "unapproval" to CHANGES_REQUESTED state instead of deleting
+     * the review. This bridges the GitLab/GitHub model gap: GitLab's unapproval
+     * semantically means "this needs changes before I approve again", which is the
+     * closest equivalent to GitHub's CHANGES_REQUESTED review state.
      */
     @Transactional
     @Nullable
@@ -363,17 +389,81 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
         reviewRepository
             .findByNativeIdAndProviderId(approvalNativeId, context.providerId())
             .ifPresent(review -> {
-                // Capture event payload BEFORE removeReview() nullifies the PR back-reference
-                var reviewData = EventPayload.ReviewData.from(review);
-                pr.removeReview(review);
-                reviewRepository.delete(review);
-                reviewData.ifPresent(data ->
-                    eventPublisher.publishEvent(new DomainEvent.ReviewDismissed(data, EventContext.from(context)))
+                // Idempotency: skip if already in CHANGES_REQUESTED state
+                if (review.getState() == PullRequestReview.State.CHANGES_REQUESTED) {
+                    log.debug("Review already CHANGES_REQUESTED, skipping: prId={}, reviewerId={}",
+                        pr.getId(), approver.getLogin());
+                    return;
+                }
+                review.setState(PullRequestReview.State.CHANGES_REQUESTED);
+                review.setSubmittedAt(Instant.now());
+                review.setUpdatedAt(Instant.now());
+                reviewRepository.save(review);
+
+                EventPayload.ReviewData.from(review).ifPresent(reviewData ->
+                    eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(context)))
                 );
-                log.debug("Removed approval review: prId={}, reviewerId={}", pr.getId(), approver.getLogin());
+                log.debug(
+                    "Updated review to CHANGES_REQUESTED (unapproval): prId={}, reviewerId={}",
+                    pr.getId(),
+                    approver.getLogin()
+                );
             });
 
         return pr;
+    }
+
+    /**
+     * Updates an existing review to CHANGES_REQUESTED when detected from a note event.
+     *
+     * <p>GitLab's "Request changes" feature (Premium, GA 17.3) does NOT fire a dedicated
+     * MR webhook. Instead, note events from the batch review carry
+     * {@code merge_request.detailed_merge_status = "requested_changes"}.
+     * This method is called from the note handler when that signal is detected.
+     *
+     * <p><b>Important:</b> This method only UPDATES existing reviews — it does NOT create
+     * new ones. The {@code detailed_merge_status} is an MR-level status that persists on
+     * ALL subsequent note events (not just notes from the reviewer who requested changes).
+     * Creating new reviews from this signal would cause false positives: any commenter on
+     * an MR with active change requests would be falsely attributed. New CHANGES_REQUESTED
+     * reviews without a prior approval are created by the GraphQL sync path instead.
+     *
+     * @param pr the pull request
+     * @param reviewer the user who requested changes (note author)
+     * @param context the processing context
+     */
+    @Transactional
+    public void processRequestedChangesFromNote(PullRequest pr, User reviewer, ProcessingContext context) {
+        if (pr.getNativeId() == null || reviewer.getNativeId() == null) return;
+
+        long approvalNativeId = generateApprovalNativeId(pr.getNativeId(), reviewer.getNativeId());
+        var existingReview = reviewRepository.findByNativeIdAndProviderId(approvalNativeId, context.providerId());
+
+        if (existingReview.isEmpty()) {
+            // No existing review for this reviewer — cannot safely attribute from note signal.
+            // The sync path will create the review with correct attribution.
+            log.debug("No existing review to update from note signal, deferring to sync: prId={}, reviewer={}",
+                pr.getId(), reviewer.getLogin());
+            return;
+        }
+
+        PullRequestReview review = existingReview.get();
+        if (review.getState() == PullRequestReview.State.CHANGES_REQUESTED) {
+            log.debug("Review already CHANGES_REQUESTED from note signal: prId={}, reviewer={}",
+                pr.getId(), reviewer.getLogin());
+            return;
+        }
+        review.setState(PullRequestReview.State.CHANGES_REQUESTED);
+        review.setSubmittedAt(Instant.now());
+        review.setUpdatedAt(Instant.now());
+        reviewRepository.save(review);
+
+        EventPayload.ReviewData.from(review).ifPresent(reviewData ->
+            eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(
+                reviewData, EventContext.from(context)))
+        );
+        log.info("Updated review to CHANGES_REQUESTED (from note signal): prId={}, reviewer={}",
+            pr.getId(), reviewer.getLogin());
     }
 
     // ========================================================================
@@ -693,7 +783,7 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             case "broken_status", "ci_must_pass", "ci_still_running" -> "UNSTABLE";
             case "checking" -> "UNKNOWN";
             case "conflict", "need_rebase" -> "DIRTY";
-            case "not_approved", "blocked_status", "policies_denied" -> "BLOCKED";
+            case "not_approved", "blocked_status", "policies_denied", "requested_changes" -> "BLOCKED";
             case "not_open" -> "BEHIND";
             default -> "UNKNOWN";
         };
@@ -743,14 +833,14 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
     ) {
         if (syncApprovers == null) return;
 
-        // Pre-load existing review nativeIds in memory to avoid N+1 lookups
-        Set<Long> existingNativeIds = pr
+        Set<Long> expectedNativeIds = new HashSet<>();
+
+        // Map existing reviews by nativeId for efficient lookup
+        Map<Long, PullRequestReview> existingReviewsByNativeId = pr
             .getReviews()
             .stream()
-            .map(PullRequestReview::getNativeId)
-            .collect(Collectors.toSet());
-
-        Set<Long> expectedNativeIds = new HashSet<>();
+            .filter(r -> r.getProvider() != null && r.getProvider().getId().equals(providerId))
+            .collect(Collectors.toMap(PullRequestReview::getNativeId, r -> r, (a, b) -> a));
 
         for (SyncUserData approver : syncApprovers) {
             User user = findOrCreateUser(
@@ -766,13 +856,29 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             long approvalNativeId = generateApprovalNativeId(pr.getNativeId(), user.getNativeId());
             expectedNativeIds.add(approvalNativeId);
 
-            if (!existingNativeIds.contains(approvalNativeId)) {
+            PullRequestReview existingReview = existingReviewsByNativeId.get(approvalNativeId);
+            if (existingReview != null) {
+                // Review exists - update to APPROVED if it was CHANGES_REQUESTED
+                if (existingReview.getState() != PullRequestReview.State.APPROVED) {
+                    existingReview.setState(PullRequestReview.State.APPROVED);
+                    existingReview.setSubmittedAt(Instant.now());
+                    existingReview.setUpdatedAt(Instant.now());
+                    reviewRepository.save(existingReview);
+                    log.debug("Updated review to APPROVED from sync: prId={}, reviewerId={}", pr.getId(), user.getLogin());
+
+                    if (ctx != null) {
+                        EventPayload.ReviewData.from(existingReview).ifPresent(reviewData ->
+                            eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(ctx)))
+                        );
+                    }
+                }
+            } else {
+                // No review exists - create new
                 PullRequestReview review = createApprovalReview(approvalNativeId, pr, user);
                 reviewRepository.save(review);
                 pr.addReview(review);
                 log.debug("Created approval review from sync: prId={}, reviewerId={}", pr.getId(), user.getLogin());
 
-                // Emit activity event for the new approval
                 if (ctx != null) {
                     EventPayload.ReviewData.from(review).ifPresent(reviewData ->
                         eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(ctx)))
@@ -781,7 +887,7 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             }
         }
 
-        // Remove stale approval reviews (user no longer in approvedBy)
+        // Transition stale approval reviews to CHANGES_REQUESTED (user no longer in approvedBy)
         // Only target reviews from this provider with APPROVED state
         Set<PullRequestReview> staleReviews = pr
             .getReviews()
@@ -792,9 +898,17 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             .collect(Collectors.toSet());
 
         for (PullRequestReview stale : staleReviews) {
-            pr.removeReview(stale);
-            reviewRepository.delete(stale);
-            log.debug("Removed stale approval review from sync: prId={}, nativeId={}", pr.getId(), stale.getNativeId());
+            stale.setState(PullRequestReview.State.CHANGES_REQUESTED);
+            stale.setSubmittedAt(Instant.now());
+            stale.setUpdatedAt(Instant.now());
+            reviewRepository.save(stale);
+            log.debug("Updated stale review to CHANGES_REQUESTED from sync: prId={}, nativeId={}", pr.getId(), stale.getNativeId());
+
+            if (ctx != null) {
+                EventPayload.ReviewData.from(stale).ifPresent(reviewData ->
+                    eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(ctx)))
+                );
+            }
         }
     }
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessor.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessor.java
@@ -340,7 +340,7 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
         var existingReview = reviewRepository.findByNativeIdAndProviderId(approvalNativeId, context.providerId());
 
         if (existingReview.isPresent()) {
-            // Re-approval: update existing review (may be CHANGES_REQUESTED from prior unapproval)
+            // Re-approval: update existing review (may be DISMISSED from unapproval or CHANGES_REQUESTED)
             PullRequestReview review = existingReview.get();
             if (review.getState() != PullRequestReview.State.APPROVED) {
                 review.setState(PullRequestReview.State.APPROVED);
@@ -371,10 +371,16 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
     /**
      * Process an unapproval event.
      *
-     * <p>Maps GitLab "unapproval" to CHANGES_REQUESTED state instead of deleting
-     * the review. This bridges the GitLab/GitHub model gap: GitLab's unapproval
-     * semantically means "this needs changes before I approve again", which is the
-     * closest equivalent to GitHub's CHANGES_REQUESTED review state.
+     * <p>Dismisses the existing approval review. Unapproval means "I retract my approval"
+     * — it does NOT mean "I request changes." These are distinct actions in GitLab:
+     * <ul>
+     *   <li><b>Unapproval</b> ({@code unapproved} webhook): revokes an existing approval.
+     *       Fires when the user clicks "Revoke approval" or when the system auto-revokes
+     *       after new commits. The review transitions to DISMISSED.</li>
+     *   <li><b>Request changes</b> (detected via note {@code detailed_merge_status}):
+     *       explicitly blocks the MR. Handled by
+     *       {@link #processRequestedChangesFromNote}.</li>
+     * </ul>
      */
     @Transactional
     @Nullable
@@ -389,28 +395,23 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
         reviewRepository
             .findByNativeIdAndProviderId(approvalNativeId, context.providerId())
             .ifPresent(review -> {
-                // Idempotency: skip if already in CHANGES_REQUESTED state
-                if (review.getState() == PullRequestReview.State.CHANGES_REQUESTED) {
+                if (review.getState() == PullRequestReview.State.DISMISSED) {
                     log.debug(
-                        "Review already CHANGES_REQUESTED, skipping: prId={}, reviewerId={}",
+                        "Review already DISMISSED, skipping: prId={}, reviewerId={}",
                         pr.getId(),
                         approver.getLogin()
                     );
                     return;
                 }
-                review.setState(PullRequestReview.State.CHANGES_REQUESTED);
-                review.setSubmittedAt(Instant.now());
+                review.setState(PullRequestReview.State.DISMISSED);
+                review.setDismissed(true);
                 review.setUpdatedAt(Instant.now());
                 reviewRepository.save(review);
 
                 EventPayload.ReviewData.from(review).ifPresent(reviewData ->
-                    eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(context)))
+                    eventPublisher.publishEvent(new DomainEvent.ReviewDismissed(reviewData, EventContext.from(context)))
                 );
-                log.debug(
-                    "Updated review to CHANGES_REQUESTED (unapproval): prId={}, reviewerId={}",
-                    pr.getId(),
-                    approver.getLogin()
-                );
+                log.debug("Dismissed review (unapproval): prId={}, reviewerId={}", pr.getId(), approver.getLogin());
             });
 
         return pr;
@@ -904,7 +905,7 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             }
         }
 
-        // Transition stale approval reviews to CHANGES_REQUESTED (user no longer in approvedBy)
+        // Dismiss stale approval reviews (user no longer in approvedBy — approval was revoked)
         // Only target reviews from this provider with APPROVED state
         Set<PullRequestReview> staleReviews = pr
             .getReviews()
@@ -915,19 +916,15 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             .collect(Collectors.toSet());
 
         for (PullRequestReview stale : staleReviews) {
-            stale.setState(PullRequestReview.State.CHANGES_REQUESTED);
-            stale.setSubmittedAt(Instant.now());
+            stale.setState(PullRequestReview.State.DISMISSED);
+            stale.setDismissed(true);
             stale.setUpdatedAt(Instant.now());
             reviewRepository.save(stale);
-            log.debug(
-                "Updated stale review to CHANGES_REQUESTED from sync: prId={}, nativeId={}",
-                pr.getId(),
-                stale.getNativeId()
-            );
+            log.debug("Dismissed stale review from sync: prId={}, nativeId={}", pr.getId(), stale.getNativeId());
 
             if (ctx != null) {
                 EventPayload.ReviewData.from(stale).ifPresent(reviewData ->
-                    eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(ctx)))
+                    eventPublisher.publishEvent(new DomainEvent.ReviewDismissed(reviewData, EventContext.from(ctx)))
                 );
             }
         }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessor.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessor.java
@@ -391,8 +391,11 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             .ifPresent(review -> {
                 // Idempotency: skip if already in CHANGES_REQUESTED state
                 if (review.getState() == PullRequestReview.State.CHANGES_REQUESTED) {
-                    log.debug("Review already CHANGES_REQUESTED, skipping: prId={}, reviewerId={}",
-                        pr.getId(), approver.getLogin());
+                    log.debug(
+                        "Review already CHANGES_REQUESTED, skipping: prId={}, reviewerId={}",
+                        pr.getId(),
+                        approver.getLogin()
+                    );
                     return;
                 }
                 review.setState(PullRequestReview.State.CHANGES_REQUESTED);
@@ -442,15 +445,21 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
         if (existingReview.isEmpty()) {
             // No existing review for this reviewer — cannot safely attribute from note signal.
             // The sync path will create the review with correct attribution.
-            log.debug("No existing review to update from note signal, deferring to sync: prId={}, reviewer={}",
-                pr.getId(), reviewer.getLogin());
+            log.debug(
+                "No existing review to update from note signal, deferring to sync: prId={}, reviewer={}",
+                pr.getId(),
+                reviewer.getLogin()
+            );
             return;
         }
 
         PullRequestReview review = existingReview.get();
         if (review.getState() == PullRequestReview.State.CHANGES_REQUESTED) {
-            log.debug("Review already CHANGES_REQUESTED from note signal: prId={}, reviewer={}",
-                pr.getId(), reviewer.getLogin());
+            log.debug(
+                "Review already CHANGES_REQUESTED from note signal: prId={}, reviewer={}",
+                pr.getId(),
+                reviewer.getLogin()
+            );
             return;
         }
         review.setState(PullRequestReview.State.CHANGES_REQUESTED);
@@ -459,11 +468,13 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
         reviewRepository.save(review);
 
         EventPayload.ReviewData.from(review).ifPresent(reviewData ->
-            eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(
-                reviewData, EventContext.from(context)))
+            eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(context)))
         );
-        log.info("Updated review to CHANGES_REQUESTED (from note signal): prId={}, reviewer={}",
-            pr.getId(), reviewer.getLogin());
+        log.info(
+            "Updated review to CHANGES_REQUESTED (from note signal): prId={}, reviewer={}",
+            pr.getId(),
+            reviewer.getLogin()
+        );
     }
 
     // ========================================================================
@@ -864,11 +875,17 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
                     existingReview.setSubmittedAt(Instant.now());
                     existingReview.setUpdatedAt(Instant.now());
                     reviewRepository.save(existingReview);
-                    log.debug("Updated review to APPROVED from sync: prId={}, reviewerId={}", pr.getId(), user.getLogin());
+                    log.debug(
+                        "Updated review to APPROVED from sync: prId={}, reviewerId={}",
+                        pr.getId(),
+                        user.getLogin()
+                    );
 
                     if (ctx != null) {
                         EventPayload.ReviewData.from(existingReview).ifPresent(reviewData ->
-                            eventPublisher.publishEvent(new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(ctx)))
+                            eventPublisher.publishEvent(
+                                new DomainEvent.ReviewSubmitted(reviewData, EventContext.from(ctx))
+                            )
                         );
                     }
                 }
@@ -902,7 +919,11 @@ public class GitLabMergeRequestProcessor extends BaseGitLabProcessor {
             stale.setSubmittedAt(Instant.now());
             stale.setUpdatedAt(Instant.now());
             reviewRepository.save(stale);
-            log.debug("Updated stale review to CHANGES_REQUESTED from sync: prId={}, nativeId={}", pr.getId(), stale.getNativeId());
+            log.debug(
+                "Updated stale review to CHANGES_REQUESTED from sync: prId={}, nativeId={}",
+                pr.getId(),
+                stale.getNativeId()
+            );
 
             if (ctx != null) {
                 EventPayload.ReviewData.from(stale).ifPresent(reviewData ->

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewcomment/gitlab/GitLabDiffNoteWebhookProcessor.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewcomment/gitlab/GitLabDiffNoteWebhookProcessor.java
@@ -34,13 +34,13 @@ import org.springframework.transaction.annotation.Transactional;
  * When a diff note webhook arrives, we:
  * <ol>
  *   <li>Find the parent MR (PullRequest) by repository + IID</li>
- *   <li>Create/find a thread using the note ID as nativeId (webhooks don't carry discussion IDs)</li>
+ *   <li>Create/find a thread using the discussion_id from the webhook payload</li>
  *   <li>Create the review comment within that thread</li>
  * </ol>
  * <p>
- * Note: Webhook diff notes don't carry discussion/thread IDs, so we use the note ID
- * itself as the thread native ID for the root note. The full discussion structure is
- * reconciled during GraphQL sync via {@link GitLabDiscussionSyncService}.
+ * Note: GitLab webhook payloads include {@code discussion_id} in {@code object_attributes},
+ * which uniquely identifies the discussion thread. Reply notes to the same discussion share
+ * the same discussion_id, enabling correct thread grouping without waiting for GraphQL sync.
  */
 @Service
 @ConditionalOnProperty(prefix = "hephaestus.gitlab", name = "enabled", havingValue = "true")
@@ -92,14 +92,18 @@ public class GitLabDiffNoteWebhookProcessor extends BaseGitLabProcessor {
             return null;
         }
 
-        // Find parent MR
+        // Find parent MR, creating a minimal stub if it doesn't exist yet
+        // (diff note webhooks can arrive before the MR webhook)
         PullRequest pr = pullRequestRepository
             .findByRepositoryIdAndNumber(context.repository().getId(), embeddedMr.iid())
             .orElse(null);
 
         if (pr == null) {
-            log.warn("Skipped diff note: reason=mrNotFound, mrIid={}, noteId={}", embeddedMr.iid(), attrs.id());
-            return null;
+            pr = createMinimalPullRequestWithRetry(embeddedMr, context);
+            if (pr == null) {
+                log.warn("Skipped diff note: reason=failedToCreateParent, mrIid={}, noteId={}", embeddedMr.iid(), attrs.id());
+                return null;
+            }
         }
 
         GitProvider provider = context.provider();
@@ -134,11 +138,20 @@ public class GitLabDiffNoteWebhookProcessor extends BaseGitLabProcessor {
         Instant createdAt = parseWebhookTimestamp(attrs.createdAt());
         Instant updatedAt = parseWebhookTimestamp(attrs.updatedAt());
 
-        // Create a synthetic thread for this diff note via the thread processor.
-        // Webhooks don't provide the discussion ID, so we use the note ID as the thread nativeId.
-        // The GraphQL discussion sync will reconcile this into the proper discussion later.
+        // Use the discussion_id from the webhook as the thread nativeId.
+        // This correctly groups reply notes into the same thread and matches the
+        // GraphQL sync's discussion-based threads. Falls back to note ID if absent.
+        long threadNativeId;
+        if (attrs.discussionId() != null) {
+            // Build the same GID format as the GraphQL sync uses, then hash with the same algorithm
+            String discussionGid = "gid://gitlab/Discussion/" + attrs.discussionId();
+            threadNativeId = GitLabPullRequestReviewThreadProcessor.deterministicNativeId(discussionGid);
+        } else {
+            log.warn("Diff note webhook missing discussion_id, falling back to note ID: noteId={}", attrs.id());
+            threadNativeId = attrs.id();
+        }
         var webhookThreadData = new GitLabPullRequestReviewThreadProcessor.WebhookThreadData(
-            attrs.id(),
+            threadNativeId,
             threadPath,
             threadLine,
             createdAt,
@@ -189,5 +202,77 @@ public class GitLabDiffNoteWebhookProcessor extends BaseGitLabProcessor {
         // Delegates to BaseGitLabProcessor which handles both webhook format
         // ("2026-01-31 19:03:35 +0100") and ISO-8601 ("2026-01-31T19:03:35Z")
         return parseGitLabTimestamp(value);
+    }
+
+    /**
+     * Creates a minimal stub PullRequest from the embedded MR data in a note webhook,
+     * with retry on concurrent creation (DataIntegrityViolationException).
+     */
+    @Nullable
+    private PullRequest createMinimalPullRequestWithRetry(
+        GitLabNoteEventDTO.EmbeddedMergeRequest dto,
+        ProcessingContext context
+    ) {
+        try {
+            return createMinimalPullRequest(dto, context);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            log.debug("Concurrent MR creation, looking up: iid={}", dto.iid());
+            return pullRequestRepository
+                .findByRepositoryIdAndNumber(context.repository().getId(), dto.iid())
+                .orElse(null);
+        }
+    }
+
+    @Nullable
+    private PullRequest createMinimalPullRequest(
+        GitLabNoteEventDTO.EmbeddedMergeRequest dto,
+        ProcessingContext context
+    ) {
+        de.tum.in.www1.hephaestus.gitprovider.repository.Repository repository = context.repository();
+        if (repository == null || dto.id() == null) return null;
+
+        de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State mappedState = convertMrState(dto.state());
+
+        PullRequest pr = new PullRequest();
+        pr.setNativeId(dto.id());
+        pr.setProvider(context.provider());
+        pr.setNumber(dto.iid());
+        pr.setTitle(sanitize(dto.title()));
+        pr.setBody(sanitize(dto.description()));
+        pr.setState(mappedState);
+        pr.setHtmlUrl(dto.url());
+        pr.setDraft(dto.draft());
+        pr.setMerged(mappedState == de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.MERGED);
+        pr.setAdditions(0);
+        pr.setDeletions(0);
+        pr.setChangedFiles(0);
+        pr.setCommits(0);
+        pr.setHeadRefName(dto.sourceBranch());
+        pr.setBaseRefName(dto.targetBranch());
+        pr.setCreatedAt(parseGitLabTimestamp(dto.createdAt()));
+        pr.setUpdatedAt(parseGitLabTimestamp(dto.updatedAt()));
+        pr.setRepository(repository);
+        pr.setLastSyncAt(Instant.now());
+
+        PullRequest saved = pullRequestRepository.save(pr);
+        log.info(
+            "Created stub PullRequest from diff note webhook: prId={}, iid={}, repo={}",
+            saved.getId(),
+            saved.getNumber(),
+            repository.getNameWithOwner()
+        );
+        return saved;
+    }
+
+    private static de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State convertMrState(
+        @Nullable String state
+    ) {
+        if (state == null) return de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.OPEN;
+        return switch (state.toLowerCase()) {
+            case "opened" -> de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.OPEN;
+            case "closed" -> de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.CLOSED;
+            case "merged" -> de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.MERGED;
+            default -> de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.OPEN;
+        };
     }
 }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewcomment/gitlab/GitLabDiffNoteWebhookProcessor.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewcomment/gitlab/GitLabDiffNoteWebhookProcessor.java
@@ -101,7 +101,11 @@ public class GitLabDiffNoteWebhookProcessor extends BaseGitLabProcessor {
         if (pr == null) {
             pr = createMinimalPullRequestWithRetry(embeddedMr, context);
             if (pr == null) {
-                log.warn("Skipped diff note: reason=failedToCreateParent, mrIid={}, noteId={}", embeddedMr.iid(), attrs.id());
+                log.warn(
+                    "Skipped diff note: reason=failedToCreateParent, mrIid={}, noteId={}",
+                    embeddedMr.iid(),
+                    attrs.id()
+                );
                 return null;
             }
         }
@@ -264,9 +268,7 @@ public class GitLabDiffNoteWebhookProcessor extends BaseGitLabProcessor {
         return saved;
     }
 
-    private static de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State convertMrState(
-        @Nullable String state
-    ) {
+    private static de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State convertMrState(@Nullable String state) {
         if (state == null) return de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.OPEN;
         return switch (state.toLowerCase()) {
             case "opened" -> de.tum.in.www1.hephaestus.gitprovider.issue.Issue.State.OPEN;

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewthread/gitlab/GitLabPullRequestReviewThreadProcessor.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/pullrequestreviewthread/gitlab/GitLabPullRequestReviewThreadProcessor.java
@@ -99,13 +99,13 @@ public class GitLabPullRequestReviewThreadProcessor {
     }
 
     /**
-     * Finds or creates a thread from a webhook diff note, where only the note ID is available.
+     * Finds or creates a thread from a webhook diff note.
      * <p>
-     * Webhooks don't carry the discussion ID, so we use the note's numeric ID as nativeId.
-     * The GraphQL discussion sync will reconcile this into the proper discussion later
-     * by matching on the note within the thread.
+     * Uses the discussion_id from the webhook payload (hashed via {@link #deterministicNativeId})
+     * as the thread nativeId. This matches the GraphQL sync's discussion-based threads,
+     * enabling correct thread grouping without reconciliation.
      *
-     * @param data the webhook-level data (note native ID, file position, timestamps)
+     * @param data the webhook-level data (thread native ID, file position, timestamps)
      * @param pr the parent pull request
      * @param provider the git provider
      * @return the thread entity (never null)
@@ -231,7 +231,7 @@ public class GitLabPullRequestReviewThreadProcessor {
      * to produce a stable Long. This is collision-resistant enough for our use case
      * since it's scoped per provider.
      */
-    static long deterministicNativeId(String discussionGlobalId) {
+    public static long deterministicNativeId(String discussionGlobalId) {
         // Use the same approach as java.lang.String.hashCode() but with long accumulator
         // for better distribution. FNV-1a inspired.
         long hash = 0xcbf29ce484222325L; // FNV offset basis

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/activity/ActivityEventListenerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/activity/ActivityEventListenerTest.java
@@ -719,29 +719,26 @@ class ActivityEventListenerTest extends BaseUnitTest {
             pullRequest.setAuthor(prAuthor);
 
             when(pullRequestRepository.findById(50L)).thenReturn(Optional.of(pullRequest));
-            when(experiencePointCalculator.calculateStandaloneReviewCommentXp(any(), any(), anyInt()))
-                .thenReturn(0.5);
+            when(experiencePointCalculator.calculateStandaloneReviewCommentXp(any(), any(), anyInt())).thenReturn(0.5);
 
             var commentData = new EventPayload.ReviewCommentData(
-                77L,         // id
-                "This is a substantive review comment with enough length",  // body
+                77L, // id
+                "This is a substantive review comment with enough length", // body
                 "src/Main.java", // path
-                42,          // line
+                42, // line
                 "https://github.com/test/test-repo/pull/1#discussion_r77", // htmlUrl
-                null,        // reviewId - null = standalone
-                100L,        // authorId
+                null, // reviewId - null = standalone
+                100L, // authorId
                 Instant.now(), // createdAt
-                50L,         // pullRequestId
-                200L         // repositoryId
+                50L, // pullRequestId
+                200L // repositoryId
             );
             var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, createContext());
 
             listener.onReviewCommentCreated(event);
 
             verify(pullRequestRepository).findById(50L);
-            verify(experiencePointCalculator).calculateStandaloneReviewCommentXp(
-                eq(pullRequest), eq(100L), anyInt()
-            );
+            verify(experiencePointCalculator).calculateStandaloneReviewCommentXp(eq(pullRequest), eq(100L), anyInt());
             verify(activityEventService).record(
                 eq(42L),
                 eq(ActivityEventType.REVIEW_COMMENT_CREATED),
@@ -758,16 +755,16 @@ class ActivityEventListenerTest extends BaseUnitTest {
         @DisplayName("comment linked to review (reviewId!=null) awards zero XP")
         void onReviewCommentCreated_linkedToReview_awardsZeroXp() {
             var commentData = new EventPayload.ReviewCommentData(
-                78L,         // id
-                "Some comment",  // body
+                78L, // id
+                "Some comment", // body
                 "src/Main.java", // path
-                10,          // line
+                10, // line
                 "https://github.com/test/test-repo/pull/1#discussion_r78", // htmlUrl
-                42L,         // reviewId - linked to review
-                100L,        // authorId
+                42L, // reviewId - linked to review
+                100L, // authorId
                 Instant.now(), // createdAt
-                50L,         // pullRequestId
-                200L         // repositoryId
+                50L, // pullRequestId
+                200L // repositoryId
             );
             var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, createContext());
 
@@ -791,9 +788,16 @@ class ActivityEventListenerTest extends BaseUnitTest {
         @DisplayName("skips recording when scopeId is null")
         void onReviewCommentCreated_nullScopeId_skips() {
             var commentData = new EventPayload.ReviewCommentData(
-                79L, "body", "path.java", 1,
+                79L,
+                "body",
+                "path.java",
+                1,
                 "https://example.com/comment",
-                null, 100L, Instant.now(), 50L, 200L
+                null,
+                100L,
+                Instant.now(),
+                50L,
+                200L
             );
             RepositoryRef repoRef = new RepositoryRef(testRepository.getId(), testRepository.getName(), "test");
             EventContext contextWithNullScope = new EventContext(
@@ -817,11 +821,16 @@ class ActivityEventListenerTest extends BaseUnitTest {
         @DisplayName("skips recording when authorId is null")
         void onReviewCommentCreated_nullAuthorId_skips() {
             var commentData = new EventPayload.ReviewCommentData(
-                80L, "body", "path.java", 1,
+                80L,
+                "body",
+                "path.java",
+                1,
                 "https://example.com/comment",
-                null,  // reviewId
-                null,  // authorId - null
-                Instant.now(), 50L, 200L
+                null, // reviewId
+                null, // authorId - null
+                Instant.now(),
+                50L,
+                200L
             );
             var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, createContext());
 
@@ -841,10 +850,10 @@ class ActivityEventListenerTest extends BaseUnitTest {
                 "src/Main.java",
                 1,
                 "https://example.com/comment",
-                null,  // reviewId - standalone
-                100L,  // authorId
+                null, // reviewId - standalone
+                100L, // authorId
                 Instant.now(),
-                999L,  // pullRequestId - not found
+                999L, // pullRequestId - not found
                 200L
             );
             var event = new DomainEvent.ReviewCommentCreated(commentData, 999L, createContext());
@@ -874,16 +883,15 @@ class ActivityEventListenerTest extends BaseUnitTest {
             pullRequest.setAuthor(prAuthor);
 
             when(pullRequestRepository.findById(50L)).thenReturn(Optional.of(pullRequest));
-            when(experiencePointCalculator.calculateStandaloneReviewCommentXp(any(), any(), eq(0)))
-                .thenReturn(0.25);
+            when(experiencePointCalculator.calculateStandaloneReviewCommentXp(any(), any(), eq(0))).thenReturn(0.25);
 
             var commentData = new EventPayload.ReviewCommentData(
                 82L,
-                null,  // null body
+                null, // null body
                 "src/Main.java",
                 1,
                 "https://example.com/comment",
-                null,  // reviewId - standalone
+                null, // reviewId - standalone
                 100L,
                 Instant.now(),
                 50L,
@@ -894,9 +902,7 @@ class ActivityEventListenerTest extends BaseUnitTest {
             listener.onReviewCommentCreated(event);
 
             // Verify body length 0 was passed to calculator (not NPE)
-            verify(experiencePointCalculator).calculateStandaloneReviewCommentXp(
-                eq(pullRequest), eq(100L), eq(0)
-            );
+            verify(experiencePointCalculator).calculateStandaloneReviewCommentXp(eq(pullRequest), eq(100L), eq(0));
         }
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/activity/ActivityEventListenerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/activity/ActivityEventListenerTest.java
@@ -17,6 +17,7 @@ import de.tum.in.www1.hephaestus.gitprovider.issue.IssueRepository;
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.IssueCommentRepository;
 import de.tum.in.www1.hephaestus.gitprovider.project.ProjectRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequest;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreview.PullRequestReview;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreview.PullRequestReviewRepository;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewthread.PullRequestReviewThreadRepository;
@@ -53,6 +54,9 @@ class ActivityEventListenerTest extends BaseUnitTest {
 
     @Mock
     private PullRequestReviewRepository reviewRepository;
+
+    @Mock
+    private PullRequestRepository pullRequestRepository;
 
     @Mock
     private IssueCommentRepository issueCommentRepository;
@@ -98,6 +102,7 @@ class ActivityEventListenerTest extends BaseUnitTest {
             activityEventService,
             experiencePointCalculator,
             reviewRepository,
+            pullRequestRepository,
             issueCommentRepository,
             reviewThreadRepository,
             userRepository,
@@ -695,6 +700,202 @@ class ActivityEventListenerTest extends BaseUnitTest {
                 any(Instant.class),
                 eq(ActivityTargetType.DISCUSSION),
                 eq(36L)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Review Comment Created Event")
+    class ReviewCommentCreatedTests {
+
+        @Test
+        @DisplayName("standalone comment (reviewId=null) awards XP from calculator")
+        void onReviewCommentCreated_standaloneComment_awardsXp() {
+            PullRequest pullRequest = createPullRequest(50L);
+            // Different author so it's not a self-review
+            User prAuthor = new User();
+            prAuthor.setId(999L);
+            prAuthor.setLogin("pr-author");
+            pullRequest.setAuthor(prAuthor);
+
+            when(pullRequestRepository.findById(50L)).thenReturn(Optional.of(pullRequest));
+            when(experiencePointCalculator.calculateStandaloneReviewCommentXp(any(), any(), anyInt()))
+                .thenReturn(0.5);
+
+            var commentData = new EventPayload.ReviewCommentData(
+                77L,         // id
+                "This is a substantive review comment with enough length",  // body
+                "src/Main.java", // path
+                42,          // line
+                "https://github.com/test/test-repo/pull/1#discussion_r77", // htmlUrl
+                null,        // reviewId - null = standalone
+                100L,        // authorId
+                Instant.now(), // createdAt
+                50L,         // pullRequestId
+                200L         // repositoryId
+            );
+            var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, createContext());
+
+            listener.onReviewCommentCreated(event);
+
+            verify(pullRequestRepository).findById(50L);
+            verify(experiencePointCalculator).calculateStandaloneReviewCommentXp(
+                eq(pullRequest), eq(100L), anyInt()
+            );
+            verify(activityEventService).record(
+                eq(42L),
+                eq(ActivityEventType.REVIEW_COMMENT_CREATED),
+                any(Instant.class),
+                eq(testUser),
+                eq(testRepository),
+                eq(ActivityTargetType.REVIEW_COMMENT),
+                eq(77L),
+                eq(0.5)
+            );
+        }
+
+        @Test
+        @DisplayName("comment linked to review (reviewId!=null) awards zero XP")
+        void onReviewCommentCreated_linkedToReview_awardsZeroXp() {
+            var commentData = new EventPayload.ReviewCommentData(
+                78L,         // id
+                "Some comment",  // body
+                "src/Main.java", // path
+                10,          // line
+                "https://github.com/test/test-repo/pull/1#discussion_r78", // htmlUrl
+                42L,         // reviewId - linked to review
+                100L,        // authorId
+                Instant.now(), // createdAt
+                50L,         // pullRequestId
+                200L         // repositoryId
+            );
+            var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, createContext());
+
+            listener.onReviewCommentCreated(event);
+
+            // pullRequestRepository.findById should never be called for linked comments
+            verify(pullRequestRepository, never()).findById(any());
+            verify(activityEventService).record(
+                eq(42L),
+                eq(ActivityEventType.REVIEW_COMMENT_CREATED),
+                any(Instant.class),
+                eq(testUser),
+                eq(testRepository),
+                eq(ActivityTargetType.REVIEW_COMMENT),
+                eq(78L),
+                eq(0.0)
+            );
+        }
+
+        @Test
+        @DisplayName("skips recording when scopeId is null")
+        void onReviewCommentCreated_nullScopeId_skips() {
+            var commentData = new EventPayload.ReviewCommentData(
+                79L, "body", "path.java", 1,
+                "https://example.com/comment",
+                null, 100L, Instant.now(), 50L, 200L
+            );
+            RepositoryRef repoRef = new RepositoryRef(testRepository.getId(), testRepository.getName(), "test");
+            EventContext contextWithNullScope = new EventContext(
+                UUID.randomUUID(),
+                Instant.now(),
+                null, // null scopeId
+                repoRef,
+                DataSource.WEBHOOK,
+                null,
+                UUID.randomUUID().toString(),
+                null
+            );
+            var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, contextWithNullScope);
+
+            listener.onReviewCommentCreated(event);
+
+            verifyNoInteractions(activityEventService);
+        }
+
+        @Test
+        @DisplayName("skips recording when authorId is null")
+        void onReviewCommentCreated_nullAuthorId_skips() {
+            var commentData = new EventPayload.ReviewCommentData(
+                80L, "body", "path.java", 1,
+                "https://example.com/comment",
+                null,  // reviewId
+                null,  // authorId - null
+                Instant.now(), 50L, 200L
+            );
+            var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, createContext());
+
+            listener.onReviewCommentCreated(event);
+
+            verifyNoInteractions(activityEventService);
+        }
+
+        @Test
+        @DisplayName("standalone comment with PR not found records zero XP")
+        void onReviewCommentCreated_prNotFound_recordsZeroXp() {
+            when(pullRequestRepository.findById(999L)).thenReturn(Optional.empty());
+
+            var commentData = new EventPayload.ReviewCommentData(
+                81L,
+                "This comment's PR doesn't exist yet",
+                "src/Main.java",
+                1,
+                "https://example.com/comment",
+                null,  // reviewId - standalone
+                100L,  // authorId
+                Instant.now(),
+                999L,  // pullRequestId - not found
+                200L
+            );
+            var event = new DomainEvent.ReviewCommentCreated(commentData, 999L, createContext());
+
+            listener.onReviewCommentCreated(event);
+
+            verify(pullRequestRepository).findById(999L);
+            verify(activityEventService).record(
+                eq(42L),
+                eq(ActivityEventType.REVIEW_COMMENT_CREATED),
+                any(Instant.class),
+                eq(testUser),
+                eq(testRepository),
+                eq(ActivityTargetType.REVIEW_COMMENT),
+                eq(81L),
+                eq(0.0) // Zero XP because PR not found
+            );
+        }
+
+        @Test
+        @DisplayName("standalone comment with null body passes 0 as body length")
+        void onReviewCommentCreated_nullBody_passesZeroLength() {
+            PullRequest pullRequest = createPullRequest(50L);
+            User prAuthor = new User();
+            prAuthor.setId(999L);
+            prAuthor.setLogin("pr-author");
+            pullRequest.setAuthor(prAuthor);
+
+            when(pullRequestRepository.findById(50L)).thenReturn(Optional.of(pullRequest));
+            when(experiencePointCalculator.calculateStandaloneReviewCommentXp(any(), any(), eq(0)))
+                .thenReturn(0.25);
+
+            var commentData = new EventPayload.ReviewCommentData(
+                82L,
+                null,  // null body
+                "src/Main.java",
+                1,
+                "https://example.com/comment",
+                null,  // reviewId - standalone
+                100L,
+                Instant.now(),
+                50L,
+                200L
+            );
+            var event = new DomainEvent.ReviewCommentCreated(commentData, 50L, createContext());
+
+            listener.onReviewCommentCreated(event);
+
+            // Verify body length 0 was passed to calculator (not NPE)
+            verify(experiencePointCalculator).calculateStandaloneReviewCommentXp(
+                eq(pullRequest), eq(100L), eq(0)
             );
         }
     }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/activity/scoring/ExperiencePointCalculatorTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/activity/scoring/ExperiencePointCalculatorTest.java
@@ -210,6 +210,95 @@ class ExperiencePointCalculatorTest extends BaseUnitTest {
     }
 
     @Nested
+    @DisplayName("Standalone Review Comment XP")
+    class StandaloneReviewCommentXp {
+
+        @Test
+        @DisplayName("substantive comment (>50 chars) returns full XP_REVIEW_COMMENT")
+        void calculateStandaloneReviewCommentXp_substantiveComment_returnsFullXp() {
+            User prAuthor = createUser(10L, "pr-author");
+            PullRequest pullRequest = createPullRequest(prAuthor);
+
+            double xp = calculator.calculateStandaloneReviewCommentXp(pullRequest, 99L, 100);
+
+            assertThat(xp).isEqualTo(0.5);
+        }
+
+        @Test
+        @DisplayName("trivial comment (<=50 chars) returns half XP_REVIEW_COMMENT")
+        void calculateStandaloneReviewCommentXp_trivialComment_returnsHalfXp() {
+            User prAuthor = createUser(10L, "pr-author");
+            PullRequest pullRequest = createPullRequest(prAuthor);
+
+            double xp = calculator.calculateStandaloneReviewCommentXp(pullRequest, 99L, 10);
+
+            assertThat(xp).isEqualTo(0.25);
+        }
+
+        @Test
+        @DisplayName("self-review (comment author == PR author) returns zero XP")
+        void calculateStandaloneReviewCommentXp_selfReview_returnsZero() {
+            User prAuthor = createUser(10L, "pr-author");
+            PullRequest pullRequest = createPullRequest(prAuthor);
+
+            // Comment author ID matches PR author ID
+            double xp = calculator.calculateStandaloneReviewCommentXp(pullRequest, 10L, 100);
+
+            assertThat(xp).isZero();
+        }
+
+        @Test
+        @DisplayName("null commentAuthorId does not match PR author — returns normal XP")
+        void calculateStandaloneReviewCommentXp_nullAuthorId_returnsXp() {
+            User prAuthor = createUser(10L, "pr-author");
+            PullRequest pullRequest = createPullRequest(prAuthor);
+
+            // null commentAuthorId should not match prAuthor.getId()
+            double xp = calculator.calculateStandaloneReviewCommentXp(pullRequest, null, 100);
+
+            assertThat(xp).isEqualTo(0.5);
+        }
+
+        @Test
+        @DisplayName("boundary: exactly 50 chars returns half XP (> 50 threshold)")
+        void calculateStandaloneReviewCommentXp_boundary50Chars_returnsHalfXp() {
+            User prAuthor = createUser(10L, "pr-author");
+            PullRequest pullRequest = createPullRequest(prAuthor);
+
+            // Exactly 50 chars: NOT > 50, so should get half XP
+            double xp50 = calculator.calculateStandaloneReviewCommentXp(pullRequest, 99L, 50);
+            assertThat(xp50).as("50 chars (boundary) should return half XP").isEqualTo(0.25);
+
+            // 51 chars: IS > 50, should get full XP
+            double xp51 = calculator.calculateStandaloneReviewCommentXp(pullRequest, 99L, 51);
+            assertThat(xp51).as("51 chars should return full XP").isEqualTo(0.5);
+        }
+
+        @Test
+        @DisplayName("bot-authored PR still awards XP to human commenter (no blanket bot exclusion)")
+        void calculateStandaloneReviewCommentXp_botAuthoredPr_humanGetsXp() {
+            // PR authored by a configured bot login — human commenter should STILL get XP
+            User botAuthor = createUser(50L, "copilot[bot]");
+            PullRequest pullRequest = createPullRequest(botAuthor);
+
+            // Human commenter (different ID from bot author) — should earn XP
+            double xp = calculator.calculateStandaloneReviewCommentXp(pullRequest, 99L, 100);
+
+            assertThat(xp).as("Human reviewing bot PR should still earn XP").isEqualTo(0.5);
+        }
+
+        @Test
+        @DisplayName("null PR author allows XP (defensive null safety)")
+        void calculateStandaloneReviewCommentXp_nullPrAuthor_returnsXp() {
+            PullRequest pullRequest = createPullRequest(null);
+
+            double xp = calculator.calculateStandaloneReviewCommentXp(pullRequest, 99L, 100);
+
+            assertThat(xp).as("Null PR author should not block XP").isEqualTo(0.5);
+        }
+    }
+
+    @Nested
     @DisplayName("XP Constants")
     class ExperiencePointConstants {
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandlerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandlerTest.java
@@ -19,11 +19,14 @@ import de.tum.in.www1.hephaestus.gitprovider.issuecomment.gitlab.dto.GitLabNoteE
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.gitlab.dto.GitLabNoteEventDTO.EmbeddedIssue;
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.gitlab.dto.GitLabNoteEventDTO.EmbeddedMergeRequest;
 import de.tum.in.www1.hephaestus.gitprovider.issuecomment.gitlab.dto.GitLabNoteEventDTO.NoteAttributes;
+import de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequest;
 import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.gitlab.GitLabDiffNoteWebhookProcessor;
 import de.tum.in.www1.hephaestus.gitprovider.repository.Repository;
+import de.tum.in.www1.hephaestus.gitprovider.user.User;
 import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
 import io.nats.client.Message;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +52,16 @@ class GitLabNoteMessageHandlerTest extends BaseUnitTest {
     private GitLabDiffNoteWebhookProcessor diffNoteProcessor;
 
     @Mock
+    private de.tum.in.www1.hephaestus.gitprovider.pullrequest.gitlab.GitLabMergeRequestProcessor mergeRequestProcessor;
+
+    @Mock
     private GitLabWebhookContextResolver contextResolver;
+
+    @Mock
+    private de.tum.in.www1.hephaestus.gitprovider.pullrequest.PullRequestRepository pullRequestRepository;
+
+    @Mock
+    private de.tum.in.www1.hephaestus.gitprovider.user.UserRepository userRepository;
 
     @Mock
     private NatsMessageDeserializer deserializer;
@@ -76,7 +88,10 @@ class GitLabNoteMessageHandlerTest extends BaseUnitTest {
         handler = new GitLabNoteMessageHandler(
             issueCommentProcessor,
             diffNoteProcessor,
+            mergeRequestProcessor,
             contextResolver,
+            pullRequestRepository,
+            userRepository,
             deserializer,
             transactionTemplate,
             eventPublisher
@@ -261,6 +276,138 @@ class GitLabNoteMessageHandlerTest extends BaseUnitTest {
         }
     }
 
+    @Nested
+    @DisplayName("Request changes detection")
+    class RequestChangesDetection {
+
+        @Test
+        @DisplayName("detects requested_changes and delegates to MR processor")
+        void detectedRequestedChanges_delegatesToProcessor() throws IOException {
+            var mr = createEmbeddedMergeRequestWithStatus("requested_changes");
+            NoteAttributes attrs = createNoteAttributes("MergeRequest", "create", false, false, null);
+            var event = new GitLabNoteEventDTO("note", "note", createUser(), createProject(), attrs, null, mr);
+
+            PullRequest pr = new PullRequest();
+            pr.setId(100L);
+            pr.setNativeId(334047L);
+            User prAuthor = new User();
+            prAuthor.setId(999L);
+            prAuthor.setNativeId(99999L);
+            pr.setAuthor(prAuthor);
+
+            User reviewer = new User();
+            reviewer.setId(2L);
+            reviewer.setNativeId(18024L);
+
+            when(pullRequestRepository.findByRepositoryIdAndNumber(-246765L, 2)).thenReturn(Optional.of(pr));
+            when(userRepository.findByNativeIdAndProviderId(eq(18024L), any())).thenReturn(Optional.of(reviewer));
+
+            Message msg = mockMessage(event);
+            handler.onMessage(msg);
+
+            verify(mergeRequestProcessor).processRequestedChangesFromNote(eq(pr), eq(reviewer), any());
+        }
+
+        @Test
+        @DisplayName("skips when detailedMergeStatus is not requested_changes")
+        void mergeableStatus_skipsDetection() throws IOException {
+            var mr = createEmbeddedMergeRequestWithStatus("mergeable");
+            NoteAttributes attrs = createNoteAttributes("MergeRequest", "create", false, false, null);
+            var event = new GitLabNoteEventDTO("note", "note", createUser(), createProject(), attrs, null, mr);
+
+            Message msg = mockMessage(event);
+            handler.onMessage(msg);
+
+            verify(mergeRequestProcessor, never()).processRequestedChangesFromNote(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("skips when detailedMergeStatus is null")
+        void nullStatus_skipsDetection() throws IOException {
+            var mr = createEmbeddedMergeRequestWithStatus(null);
+            NoteAttributes attrs = createNoteAttributes("MergeRequest", "create", false, false, null);
+            var event = new GitLabNoteEventDTO("note", "note", createUser(), createProject(), attrs, null, mr);
+
+            Message msg = mockMessage(event);
+            handler.onMessage(msg);
+
+            verify(mergeRequestProcessor, never()).processRequestedChangesFromNote(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("skips when note author is the MR author (self-review guard)")
+        void selfReview_skipsDetection() throws IOException {
+            var mr = createEmbeddedMergeRequestWithStatus("requested_changes");
+            NoteAttributes attrs = createNoteAttributes("MergeRequest", "create", false, false, null);
+            // User ID 18024 matches the PR author's nativeId
+            var event = new GitLabNoteEventDTO("note", "note", createUser(), createProject(), attrs, null, mr);
+
+            PullRequest pr = new PullRequest();
+            pr.setId(100L);
+            pr.setNativeId(334047L);
+            User prAuthor = new User();
+            prAuthor.setId(2L);
+            prAuthor.setNativeId(18024L); // Same as event user
+            pr.setAuthor(prAuthor);
+
+            when(pullRequestRepository.findByRepositoryIdAndNumber(-246765L, 2)).thenReturn(Optional.of(pr));
+
+            Message msg = mockMessage(event);
+            handler.onMessage(msg);
+
+            verify(mergeRequestProcessor, never()).processRequestedChangesFromNote(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("skips when PR not found in DB")
+        void prNotFound_skipsDetection() throws IOException {
+            var mr = createEmbeddedMergeRequestWithStatus("requested_changes");
+            NoteAttributes attrs = createNoteAttributes("MergeRequest", "create", false, false, null);
+            var event = new GitLabNoteEventDTO("note", "note", createUser(), createProject(), attrs, null, mr);
+
+            when(pullRequestRepository.findByRepositoryIdAndNumber(-246765L, 2)).thenReturn(Optional.empty());
+
+            Message msg = mockMessage(event);
+            handler.onMessage(msg);
+
+            verify(mergeRequestProcessor, never()).processRequestedChangesFromNote(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("skips when reviewer user not found in DB")
+        void reviewerNotFound_skipsDetection() throws IOException {
+            var mr = createEmbeddedMergeRequestWithStatus("requested_changes");
+            NoteAttributes attrs = createNoteAttributes("MergeRequest", "create", false, false, null);
+            var event = new GitLabNoteEventDTO("note", "note", createUser(), createProject(), attrs, null, mr);
+
+            PullRequest pr = new PullRequest();
+            pr.setId(100L);
+            pr.setNativeId(334047L);
+            User prAuthor = new User();
+            prAuthor.setId(999L);
+            prAuthor.setNativeId(99999L);
+            pr.setAuthor(prAuthor);
+
+            when(pullRequestRepository.findByRepositoryIdAndNumber(-246765L, 2)).thenReturn(Optional.of(pr));
+            when(userRepository.findByNativeIdAndProviderId(eq(18024L), any())).thenReturn(Optional.empty());
+
+            Message msg = mockMessage(event);
+            handler.onMessage(msg);
+
+            verify(mergeRequestProcessor, never()).processRequestedChangesFromNote(any(), any(), any());
+        }
+
+        private EmbeddedMergeRequest createEmbeddedMergeRequestWithStatus(String detailedMergeStatus) {
+            return new EmbeddedMergeRequest(
+                334047L, 2, "Test MR", "Description", "opened", false,
+                "feature/test", "main",
+                "https://gitlab.lrz.de/test/-/merge_requests/2",
+                "2026-01-31 19:03:54 +0100", "2026-01-31 19:03:56 +0100",
+                detailedMergeStatus
+            );
+        }
+    }
+
     private Repository setupRepository() {
         Repository repo = new Repository();
         repo.setId(-246765L);
@@ -326,7 +473,9 @@ class GitLabNoteMessageHandlerTest extends BaseUnitTest {
             action,
             "https://gitlab.lrz.de/hephaestustest/demo-repository/-/issues/5#note_4406174",
             "2026-01-31 19:03:37 +0100",
-            "2026-01-31 19:03:37 +0100"
+            "2026-01-31 19:03:37 +0100",
+            "abc123def456",
+            null
         );
     }
 
@@ -356,7 +505,8 @@ class GitLabNoteMessageHandlerTest extends BaseUnitTest {
             "main",
             "https://gitlab.lrz.de/hephaestustest/demo-repository/-/merge_requests/2",
             "2026-01-31 19:03:54 +0100",
-            "2026-01-31 19:03:56 +0100"
+            "2026-01-31 19:03:56 +0100",
+            null
         );
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandlerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/issuecomment/gitlab/GitLabNoteMessageHandlerTest.java
@@ -399,10 +399,17 @@ class GitLabNoteMessageHandlerTest extends BaseUnitTest {
 
         private EmbeddedMergeRequest createEmbeddedMergeRequestWithStatus(String detailedMergeStatus) {
             return new EmbeddedMergeRequest(
-                334047L, 2, "Test MR", "Description", "opened", false,
-                "feature/test", "main",
+                334047L,
+                2,
+                "Test MR",
+                "Description",
+                "opened",
+                false,
+                "feature/test",
+                "main",
                 "https://gitlab.lrz.de/test/-/merge_requests/2",
-                "2026-01-31 19:03:54 +0100", "2026-01-31 19:03:56 +0100",
+                "2026-01-31 19:03:54 +0100",
+                "2026-01-31 19:03:56 +0100",
                 detailedMergeStatus
             );
         }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestMessageHandlerIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestMessageHandlerIntegrationTest.java
@@ -323,20 +323,22 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
 
         @Test
         @DisplayName("deletes review on 'unapproved' event")
-        void unapproveMergeRequest_deletesReview() throws Exception {
+        void unapproveMergeRequest_updatesToChangesRequested() throws Exception {
             // Create MR !4 and approve it
             handler.handleEvent(loadPayload("merge_request.approved"));
             eventListener.clear();
 
-            // Unapprove MR !4
+            // Unapprove MR !4 — should update to CHANGES_REQUESTED (not delete)
             handler.handleEvent(loadPayload("merge_request.unapproved"));
 
             transactionTemplate.executeWithoutResult(status -> {
                 long nativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(NATIVE_MR4_ID, NATIVE_APPROVER_ID);
-                assertThat(reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId())).isEmpty();
+                var review = reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId());
+                assertThat(review).isPresent();
+                assertThat(review.get().getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
             });
 
-            assertThat(eventListener.getReviewDismissedEvents()).hasSize(1);
+            assertThat(eventListener.getReviewSubmittedEvents()).hasSize(1);
         }
     }
 
@@ -420,13 +422,15 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
                 assertThat(reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId())).isPresent();
             });
 
-            // Unapprove MR !4
+            // Unapprove MR !4 — should update to CHANGES_REQUESTED (not delete)
             handler.handleEvent(loadPayload("merge_request.unapproved"));
-            assertThat(eventListener.getReviewDismissedEvents()).hasSize(1);
+            assertThat(eventListener.getReviewSubmittedEvents()).hasSize(2); // 1 from approve + 1 from unapprove
 
             transactionTemplate.executeWithoutResult(status -> {
                 long nativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(NATIVE_MR4_ID, NATIVE_APPROVER_ID);
-                assertThat(reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId())).isEmpty();
+                var review = reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId());
+                assertThat(review).isPresent();
+                assertThat(review.get().getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
             });
         }
 
@@ -552,9 +556,9 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
 
             eventListener.clear();
 
-            // Unapprove -> ReviewDismissed
+            // Unapprove -> ReviewSubmitted (CHANGES_REQUESTED)
             handler.handleEvent(loadPayload("merge_request.unapproved"));
-            assertThat(eventListener.getReviewDismissedEvents()).hasSize(1);
+            assertThat(eventListener.getReviewSubmittedEvents()).hasSize(1);
         }
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestMessageHandlerIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestMessageHandlerIntegrationTest.java
@@ -323,22 +323,22 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
 
         @Test
         @DisplayName("deletes review on 'unapproved' event")
-        void unapproveMergeRequest_updatesToChangesRequested() throws Exception {
+        void unapproveMergeRequest_dismissesReview() throws Exception {
             // Create MR !4 and approve it
             handler.handleEvent(loadPayload("merge_request.approved"));
             eventListener.clear();
 
-            // Unapprove MR !4 — should update to CHANGES_REQUESTED (not delete)
+            // Unapprove MR !4 — should dismiss the review (not delete, not CHANGES_REQUESTED)
             handler.handleEvent(loadPayload("merge_request.unapproved"));
 
             transactionTemplate.executeWithoutResult(status -> {
                 long nativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(NATIVE_MR4_ID, NATIVE_APPROVER_ID);
                 var review = reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId());
                 assertThat(review).isPresent();
-                assertThat(review.get().getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
+                assertThat(review.get().getState()).isEqualTo(PullRequestReview.State.DISMISSED);
             });
 
-            assertThat(eventListener.getReviewSubmittedEvents()).hasSize(1);
+            assertThat(eventListener.getReviewDismissedEvents()).hasSize(1);
         }
     }
 
@@ -422,15 +422,15 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
                 assertThat(reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId())).isPresent();
             });
 
-            // Unapprove MR !4 — should update to CHANGES_REQUESTED (not delete)
+            // Unapprove MR !4 — should dismiss the review (not delete, not CHANGES_REQUESTED)
             handler.handleEvent(loadPayload("merge_request.unapproved"));
-            assertThat(eventListener.getReviewSubmittedEvents()).hasSize(2); // 1 from approve + 1 from unapprove
+            assertThat(eventListener.getReviewDismissedEvents()).hasSize(1);
 
             transactionTemplate.executeWithoutResult(status -> {
                 long nativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(NATIVE_MR4_ID, NATIVE_APPROVER_ID);
                 var review = reviewRepository.findByNativeIdAndProviderId(nativeId, savedProvider.getId());
                 assertThat(review).isPresent();
-                assertThat(review.get().getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
+                assertThat(review.get().getState()).isEqualTo(PullRequestReview.State.DISMISSED);
             });
         }
 
@@ -556,9 +556,9 @@ class GitLabMergeRequestMessageHandlerIntegrationTest extends BaseIntegrationTes
 
             eventListener.clear();
 
-            // Unapprove -> ReviewSubmitted (CHANGES_REQUESTED)
+            // Unapprove -> ReviewDismissed (not CHANGES_REQUESTED — unapproval is a distinct action)
             handler.handleEvent(loadPayload("merge_request.unapproved"));
-            assertThat(eventListener.getReviewSubmittedEvents()).hasSize(1);
+            assertThat(eventListener.getReviewDismissedEvents()).hasSize(1);
         }
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessorTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessorTest.java
@@ -690,8 +690,8 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("processUnapproved() updates review to CHANGES_REQUESTED and publishes ReviewSubmitted")
-        void processUnapprovedUpdatesReview() {
+        @DisplayName("processUnapproved() dismisses review and publishes ReviewDismissed")
+        void processUnapprovedDismissesReview() {
             PullRequest pr = createPullRequestEntity();
             pr.setNativeId(RAW_MR_ID);
             // 2 calls: stale+isNew check (process), post-upsert fetch (upsertMergeRequest)
@@ -727,19 +727,20 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
 
             assertThat(result).isNotNull();
 
-            // Verify the review was updated to CHANGES_REQUESTED and saved
-            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
+            // Verify the review was dismissed and saved
+            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.DISMISSED);
+            assertThat(existingReview.isDismissed()).isTrue();
             verify(reviewRepository).save(existingReview);
 
-            // ReviewSubmitted is published for the state change
+            // ReviewDismissed is published (not ReviewSubmitted)
             ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
             verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
 
-            boolean hasReviewSubmitted = eventCaptor
+            boolean hasReviewDismissed = eventCaptor
                 .getAllValues()
                 .stream()
-                .anyMatch(e -> e instanceof DomainEvent.ReviewSubmitted);
-            assertThat(hasReviewSubmitted).isTrue();
+                .anyMatch(e -> e instanceof DomainEvent.ReviewDismissed);
+            assertThat(hasReviewDismissed).isTrue();
         }
 
         @Test
@@ -955,8 +956,8 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("processUnapproved() is idempotent when review is already CHANGES_REQUESTED")
-        void processUnapproved_alreadyChangesRequested_isIdempotent() {
+        @DisplayName("processUnapproved() is idempotent when review is already DISMISSED")
+        void processUnapproved_alreadyDismissed_isIdempotent() {
             PullRequest pr = createPullRequestEntity();
             pr.setNativeId(RAW_MR_ID);
             when(pullRequestRepository.findByRepositoryIdAndNumber(REPO_ID, MR_IID))
@@ -972,11 +973,12 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
                 approver
             );
 
-            // Review already in CHANGES_REQUESTED state
+            // Review already in DISMISSED state
             long expectedNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_APPROVER_ID);
             PullRequestReview existingReview = new PullRequestReview();
             existingReview.setNativeId(expectedNativeId);
-            existingReview.setState(PullRequestReview.State.CHANGES_REQUESTED);
+            existingReview.setState(PullRequestReview.State.DISMISSED);
+            existingReview.setDismissed(true);
             existingReview.setHtmlUrl("https://gitlab.com/gitlab-org/gitlab/-/merge_requests/5#approvals");
             existingReview.setSubmittedAt(Instant.now());
             existingReview.setAuthor(approver);
@@ -991,19 +993,9 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             PullRequest result = processor.processUnapproved(event, createContext());
 
             assertThat(result).isNotNull();
-            // Already CHANGES_REQUESTED — save() should NOT be called for the review
+            // Already DISMISSED — save() should NOT be called
             verify(reviewRepository, never()).save(any(PullRequestReview.class));
-            // State should remain CHANGES_REQUESTED
-            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
-
-            // No ReviewSubmitted event for idempotent unapproval
-            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
-            verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
-            boolean hasReviewSubmitted = eventCaptor
-                .getAllValues()
-                .stream()
-                .anyMatch(e -> e instanceof DomainEvent.ReviewSubmitted);
-            assertThat(hasReviewSubmitted).isFalse();
+            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.DISMISSED);
         }
 
         @Test
@@ -1758,11 +1750,11 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             processor.processFromSync(syncData, testRepo, 1L);
 
             // Verify new approval was created (save called for new review)
-            // and stale review was updated to CHANGES_REQUESTED (save called for stale review)
+            // and stale review was dismissed (save called for stale review)
             verify(reviewRepository, org.mockito.Mockito.atLeast(2)).save(any(PullRequestReview.class));
 
-            // Verify stale approval was transitioned to CHANGES_REQUESTED
-            assertThat(staleReview.getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
+            // Verify stale approval was dismissed (not CHANGES_REQUESTED — unapproval is distinct)
+            assertThat(staleReview.getState()).isEqualTo(PullRequestReview.State.DISMISSED);
         }
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessorTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessorTest.java
@@ -1073,8 +1073,9 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             existingReview.setPullRequest(pr);
 
             long approvalNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_USER_ID);
-            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID))
-                .thenReturn(Optional.of(existingReview));
+            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID)).thenReturn(
+                Optional.of(existingReview)
+            );
 
             processor.processRequestedChangesFromNote(pr, reviewer, createContext());
 
@@ -1096,8 +1097,9 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             existingReview.setState(PullRequestReview.State.CHANGES_REQUESTED);
 
             long approvalNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_USER_ID);
-            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID))
-                .thenReturn(Optional.of(existingReview));
+            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID)).thenReturn(
+                Optional.of(existingReview)
+            );
 
             processor.processRequestedChangesFromNote(pr, reviewer, createContext());
 
@@ -1114,8 +1116,9 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             reviewer.setNativeId(RAW_USER_ID);
 
             long approvalNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_USER_ID);
-            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID))
-                .thenReturn(Optional.empty());
+            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID)).thenReturn(
+                Optional.empty()
+            );
 
             processor.processRequestedChangesFromNote(pr, reviewer, createContext());
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessorTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/gitprovider/pullrequest/gitlab/GitLabMergeRequestProcessorTest.java
@@ -690,8 +690,8 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("processUnapproved() deletes review for actor and publishes ReviewDismissed")
-        void processUnapprovedDeletesReview() {
+        @DisplayName("processUnapproved() updates review to CHANGES_REQUESTED and publishes ReviewSubmitted")
+        void processUnapprovedUpdatesReview() {
             PullRequest pr = createPullRequestEntity();
             pr.setNativeId(RAW_MR_ID);
             // 2 calls: stale+isNew check (process), post-upsert fetch (upsertMergeRequest)
@@ -727,20 +727,19 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
 
             assertThat(result).isNotNull();
 
-            // Verify the review was deleted
-            verify(reviewRepository).delete(existingReview);
+            // Verify the review was updated to CHANGES_REQUESTED and saved
+            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
+            verify(reviewRepository).save(existingReview);
 
-            // ReviewDismissed IS published: the production code captures ReviewData BEFORE
-            // removeReview() nullifies the back-reference. Additionally, PullRequestUpdated
-            // is emitted for existing PRs that pass the staleness check.
+            // ReviewSubmitted is published for the state change
             ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
             verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
 
-            boolean hasReviewDismissed = eventCaptor
+            boolean hasReviewSubmitted = eventCaptor
                 .getAllValues()
                 .stream()
-                .anyMatch(e -> e instanceof DomainEvent.ReviewDismissed);
-            assertThat(hasReviewDismissed).isTrue();
+                .anyMatch(e -> e instanceof DomainEvent.ReviewSubmitted);
+            assertThat(hasReviewSubmitted).isTrue();
         }
 
         @Test
@@ -806,16 +805,16 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             PullRequest result = processor.processUnapproved(event, createContext());
 
             assertThat(result).isNotNull();
-            // No deletion should happen
-            verify(reviewRepository, never()).delete(any(PullRequestReview.class));
-            // Only PullRequestUpdated from process(), no ReviewDismissed
+            // No save should happen (no review to update)
+            verify(reviewRepository, never()).save(any(PullRequestReview.class));
+            // Only PullRequestUpdated from process(), no ReviewSubmitted
             ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
             verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
-            boolean hasReviewDismissed = eventCaptor
+            boolean hasReviewSubmitted = eventCaptor
                 .getAllValues()
                 .stream()
-                .anyMatch(e -> e instanceof DomainEvent.ReviewDismissed);
-            assertThat(hasReviewDismissed).isFalse();
+                .anyMatch(e -> e instanceof DomainEvent.ReviewSubmitted);
+            assertThat(hasReviewSubmitted).isFalse();
         }
 
         @Test
@@ -953,6 +952,189 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             assertThat(result).isNotNull();
             // No review should be saved when user is null
             verify(reviewRepository, never()).save(any(PullRequestReview.class));
+        }
+
+        @Test
+        @DisplayName("processUnapproved() is idempotent when review is already CHANGES_REQUESTED")
+        void processUnapproved_alreadyChangesRequested_isIdempotent() {
+            PullRequest pr = createPullRequestEntity();
+            pr.setNativeId(RAW_MR_ID);
+            when(pullRequestRepository.findByRepositoryIdAndNumber(REPO_ID, MR_IID))
+                .thenReturn(Optional.of(pr))
+                .thenReturn(Optional.of(pr))
+                .thenReturn(Optional.of(pr));
+
+            User author = createUserEntity();
+            when(userRepository.findByNativeIdAndProviderId(RAW_USER_ID, PROVIDER_ID)).thenReturn(Optional.of(author));
+
+            User approver = createApproverEntity();
+            when(gitLabUserService.findOrCreateUser(any(GitLabWebhookUser.class), eq(PROVIDER_ID))).thenReturn(
+                approver
+            );
+
+            // Review already in CHANGES_REQUESTED state
+            long expectedNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_APPROVER_ID);
+            PullRequestReview existingReview = new PullRequestReview();
+            existingReview.setNativeId(expectedNativeId);
+            existingReview.setState(PullRequestReview.State.CHANGES_REQUESTED);
+            existingReview.setHtmlUrl("https://gitlab.com/gitlab-org/gitlab/-/merge_requests/5#approvals");
+            existingReview.setSubmittedAt(Instant.now());
+            existingReview.setAuthor(approver);
+            existingReview.setPullRequest(pr);
+            pr.getReviews().add(existingReview);
+
+            when(reviewRepository.findByNativeIdAndProviderId(expectedNativeId, PROVIDER_ID)).thenReturn(
+                Optional.of(existingReview)
+            );
+
+            GitLabMergeRequestEventDTO event = createApprovalEvent("unapproved", "opened");
+            PullRequest result = processor.processUnapproved(event, createContext());
+
+            assertThat(result).isNotNull();
+            // Already CHANGES_REQUESTED — save() should NOT be called for the review
+            verify(reviewRepository, never()).save(any(PullRequestReview.class));
+            // State should remain CHANGES_REQUESTED
+            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
+
+            // No ReviewSubmitted event for idempotent unapproval
+            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
+            boolean hasReviewSubmitted = eventCaptor
+                .getAllValues()
+                .stream()
+                .anyMatch(e -> e instanceof DomainEvent.ReviewSubmitted);
+            assertThat(hasReviewSubmitted).isFalse();
+        }
+
+        @Test
+        @DisplayName("processApproved() re-approval from CHANGES_REQUESTED updates to APPROVED")
+        void processApproved_reApproval_fromChangesRequested_updatesToApproved() {
+            PullRequest pr = createPullRequestEntity();
+            pr.setNativeId(RAW_MR_ID);
+            when(pullRequestRepository.findByRepositoryIdAndNumber(REPO_ID, MR_IID))
+                .thenReturn(Optional.of(pr))
+                .thenReturn(Optional.of(pr))
+                .thenReturn(Optional.of(pr));
+
+            User author = createUserEntity();
+            when(userRepository.findByNativeIdAndProviderId(RAW_USER_ID, PROVIDER_ID)).thenReturn(Optional.of(author));
+
+            User approver = createApproverEntity();
+            when(gitLabUserService.findOrCreateUser(any(GitLabWebhookUser.class), eq(PROVIDER_ID))).thenReturn(
+                approver
+            );
+
+            // Existing review in CHANGES_REQUESTED state (from a prior unapproval)
+            long expectedNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_APPROVER_ID);
+            PullRequestReview existingReview = new PullRequestReview();
+            existingReview.setNativeId(expectedNativeId);
+            existingReview.setState(PullRequestReview.State.CHANGES_REQUESTED);
+            existingReview.setHtmlUrl("https://gitlab.com/gitlab-org/gitlab/-/merge_requests/5#approvals");
+            existingReview.setSubmittedAt(Instant.now().minusSeconds(3600));
+            existingReview.setAuthor(approver);
+            existingReview.setPullRequest(pr);
+            pr.getReviews().add(existingReview);
+
+            when(reviewRepository.findByNativeIdAndProviderId(expectedNativeId, PROVIDER_ID)).thenReturn(
+                Optional.of(existingReview)
+            );
+
+            GitLabMergeRequestEventDTO event = createApprovalEvent("approved", "opened");
+            PullRequest result = processor.processApproved(event, createContext());
+
+            assertThat(result).isNotNull();
+
+            // Review should be updated to APPROVED and saved
+            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.APPROVED);
+            verify(reviewRepository).save(existingReview);
+
+            // ReviewSubmitted event should be emitted for the state change
+            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
+            boolean hasReviewSubmitted = eventCaptor
+                .getAllValues()
+                .stream()
+                .anyMatch(e -> e instanceof DomainEvent.ReviewSubmitted);
+            assertThat(hasReviewSubmitted).isTrue();
+        }
+
+        @Test
+        @DisplayName("processRequestedChangesFromNote() updates existing APPROVED review to CHANGES_REQUESTED")
+        void processRequestedChangesFromNote_updatesExistingApproval() {
+            PullRequest pr = createPullRequestEntity();
+            pr.setNativeId(RAW_MR_ID);
+
+            User reviewer = createUserEntity();
+            reviewer.setNativeId(RAW_USER_ID);
+
+            PullRequestReview existingReview = new PullRequestReview();
+            existingReview.setState(PullRequestReview.State.APPROVED);
+            existingReview.setAuthor(reviewer);
+            existingReview.setPullRequest(pr);
+
+            long approvalNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_USER_ID);
+            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID))
+                .thenReturn(Optional.of(existingReview));
+
+            processor.processRequestedChangesFromNote(pr, reviewer, createContext());
+
+            assertThat(existingReview.getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
+            verify(reviewRepository).save(existingReview);
+            verify(eventPublisher, atLeastOnce()).publishEvent(any(DomainEvent.ReviewSubmitted.class));
+        }
+
+        @Test
+        @DisplayName("processRequestedChangesFromNote() is idempotent when already CHANGES_REQUESTED")
+        void processRequestedChangesFromNote_idempotent() {
+            PullRequest pr = createPullRequestEntity();
+            pr.setNativeId(RAW_MR_ID);
+
+            User reviewer = createUserEntity();
+            reviewer.setNativeId(RAW_USER_ID);
+
+            PullRequestReview existingReview = new PullRequestReview();
+            existingReview.setState(PullRequestReview.State.CHANGES_REQUESTED);
+
+            long approvalNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_USER_ID);
+            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID))
+                .thenReturn(Optional.of(existingReview));
+
+            processor.processRequestedChangesFromNote(pr, reviewer, createContext());
+
+            verify(reviewRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("processRequestedChangesFromNote() skips when no existing review (prevents false positives)")
+        void processRequestedChangesFromNote_noExistingReview_skips() {
+            PullRequest pr = createPullRequestEntity();
+            pr.setNativeId(RAW_MR_ID);
+
+            User reviewer = createUserEntity();
+            reviewer.setNativeId(RAW_USER_ID);
+
+            long approvalNativeId = GitLabMergeRequestProcessor.generateApprovalNativeId(RAW_MR_ID, RAW_USER_ID);
+            when(reviewRepository.findByNativeIdAndProviderId(approvalNativeId, PROVIDER_ID))
+                .thenReturn(Optional.empty());
+
+            processor.processRequestedChangesFromNote(pr, reviewer, createContext());
+
+            verify(reviewRepository, never()).save(any());
+            verify(eventPublisher, never()).publishEvent(any(DomainEvent.ReviewSubmitted.class));
+        }
+
+        @Test
+        @DisplayName("processRequestedChangesFromNote() skips when reviewer nativeId is null")
+        void processRequestedChangesFromNote_nullNativeId_skips() {
+            PullRequest pr = createPullRequestEntity();
+            pr.setNativeId(RAW_MR_ID);
+
+            User reviewer = createUserEntity();
+            reviewer.setNativeId(null);
+
+            processor.processRequestedChangesFromNote(pr, reviewer, createContext());
+
+            verify(reviewRepository, never()).findByNativeIdAndProviderId(anyLong(), anyLong());
         }
 
         @Test
@@ -1572,11 +1754,12 @@ class GitLabMergeRequestProcessorTest extends BaseUnitTest {
             );
             processor.processFromSync(syncData, testRepo, 1L);
 
-            // Verify new approval was created
-            verify(reviewRepository).save(any(PullRequestReview.class));
+            // Verify new approval was created (save called for new review)
+            // and stale review was updated to CHANGES_REQUESTED (save called for stale review)
+            verify(reviewRepository, org.mockito.Mockito.atLeast(2)).save(any(PullRequestReview.class));
 
-            // Verify stale approval was removed
-            verify(reviewRepository).delete(staleReview);
+            // Verify stale approval was transitioned to CHANGES_REQUESTED
+            assertThat(staleReview.getState()).isEqualTo(PullRequestReview.State.CHANGES_REQUESTED);
         }
     }
 


### PR DESCRIPTION
## Description

Audits and fixes GitLab workspace event scoring to close gaps in code review comment XP, change request handling, and diff note thread grouping. Validated end-to-end against real NATS data from staging.

### Changes

**Scoring**
- Add standalone review comment XP for GitLab diff notes (flat-rate: 0.50 for >50 chars, 0.25 for ≤50) with self-review detection
- Map GitLab unapproval → CHANGES_REQUESTED instead of deleting reviews
- Support re-approval flow (CHANGES_REQUESTED → APPROVED)

**Request Changes Detection**
- Detect "Request changes" from note webhook `detailed_merge_status` signal (workaround for GitLab bug [#517909](https://gitlab.com/gitlab-org/gitlab/-/work_items/517909): no dedicated webhook fires)
- Only updates existing reviews to prevent false positives from MR-level status persisting on all subsequent notes

**Thread Grouping**
- Parse `discussion_id` from note webhooks for correct thread grouping (fixes incorrect assumption that webhooks don't carry this field)
- Use same `deterministicNativeId()` hash as GraphQL sync path for consistent nativeIds

**Other**
- Add `detailed_merge_status` to embedded MR in note webhook DTO
- Add `requested_changes` to merge status mapping (→ BLOCKED)
- Create stub PRs from diff note webhooks when MR not yet in DB

## How to Test

1. Request changes on a GitLab MR → check server logs for `Updated review to CHANGES_REQUESTED (from note signal)`
2. Approve → unapprove → re-approve on a GitLab MR → verify review state transitions in DB
3. Post a diff note on a GitLab MR → verify `discussion_id` is used (not note ID) as thread nativeId
4. Verify all 2212 unit + 112 architecture tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone review comments now award XP based on comment length; self-comments receive no XP.
  * Merge request notes can mark a review as "changes requested" when indicated by provider status.

* **Bug Fixes**
  * Improved diff-note thread grouping to align webhook and sync grouping.
  * Creates/retries minimal parent PR when missing; avoids deleting reviews by dismissing and making approval transitions idempotent.

* **Tests**
  * Expanded coverage for XP rules, note-driven requested-changes, thread grouping, and review state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->