### PR TITLE
fix(server): fetch on all branch pushes, abort on empty diff, block garbage reviews

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -21,6 +21,7 @@ import de.tum.in.www1.hephaestus.gitprovider.pullrequestreviewcomment.PullReques
 import de.tum.in.www1.hephaestus.practices.PracticeRepository;
 import de.tum.in.www1.hephaestus.practices.finding.ContributorHistoryProvider;
 import de.tum.in.www1.hephaestus.practices.model.Practice;
+import de.tum.in.www1.hephaestus.practices.model.Verdict;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -420,7 +421,29 @@ public class PullRequestReviewHandler implements JobTypeHandler {
             );
         }
 
-        // 1b. Filter findings by diff scope — remove findings whose evidence locations
+        // 1b. Quality gate: reject reviews where every finding is NOT_APPLICABLE AND the diff
+        // had actual content. This catches stale-diff bugs where the agent saw an empty workspace.
+        // Legitimate all-NA reviews (e.g., README-only changes) are allowed through because
+        // their diff_stat will be empty or contain only non-code files.
+        boolean allNotApplicable = parsed
+            .validFindings()
+            .stream()
+            .allMatch(f -> f.verdict() == Verdict.NOT_APPLICABLE);
+        if (allNotApplicable) {
+            Set<String> diffFiles = computeDiffStatFiles(job);
+            boolean hasDiffContent = !diffFiles.isEmpty();
+            if (hasDiffContent) {
+                throw new JobDeliveryException(
+                    "All findings are NOT_APPLICABLE but the diff contains " +
+                        diffFiles.size() +
+                        " files — likely a stale/empty diff was provided to the agent. " +
+                        "Refusing to deliver. jobId=" +
+                        job.getId()
+                );
+            }
+        }
+
+        // 1c. Filter findings by diff scope — remove findings whose evidence locations
         // reference files not in the diff_stat. This is a server-side safety net for
         // LLM scope contamination (flagging pre-existing code in partially-modified files).
         Set<String> diffFiles = computeDiffStatFiles(job);
@@ -526,60 +549,73 @@ public class PullRequestReviewHandler implements JobTypeHandler {
     }
 
     /**
-     * Fetch latest refs from the remote before computing the diff.
-     * Uses GitLabTokenService for GitLab workspaces to get an authenticated fetch.
-     * Falls back gracefully on failure — the diff computation will still attempt
-     * with whatever refs are locally available.
+     * Fetch latest refs from the remote and verify the headSha exists locally.
+     *
+     * <p>Returns {@code true} if the headSha was verified to exist in the local clone.
+     * Throws {@link JobPreparationException} if a fetch succeeded but the headSha
+     * is still not in the local clone (likely force-pushed away).
      */
-    private void fetchBeforeDiff(long repositoryId, AgentJob job) {
+    private boolean fetchAndVerifyHead(long repositoryId, AgentJob job, String headSha) {
+        if (!gitRepositoryManager.isRepositoryCloned(repositoryId)) {
+            log.debug("Repository not cloned locally, skipping fetch/verify: repoId={}", repositoryId);
+            return false;
+        }
+        Path repoPath = gitRepositoryManager.getRepositoryPath(repositoryId);
+
+        // Try fetching from remote to get latest refs
+        boolean fetched = false;
         try {
             var workspace = job.getWorkspace();
-            if (workspace == null) {
-                log.debug("No workspace on job, skipping pre-diff fetch: jobId={}", job.getId());
-                return;
-            }
-
-            String serverUrl = null;
-            String token = null;
-            Long scopeId = workspace.getId();
-
-            if (gitLabTokenService != null) {
-                try {
-                    serverUrl = gitLabTokenService.resolveServerUrl(scopeId);
-                    token = gitLabTokenService.getAccessToken(scopeId);
-                } catch (Exception e) {
-                    log.debug("GitLab token not available for fetch: scopeId={}, reason={}", scopeId, e.getMessage());
+            if (workspace != null && gitLabTokenService != null) {
+                Long scopeId = workspace.getId();
+                String serverUrl = gitLabTokenService.resolveServerUrl(scopeId);
+                String token = gitLabTokenService.getAccessToken(scopeId);
+                JsonNode metadata = job.getMetadata();
+                String repoFullName =
+                    metadata != null && metadata.has("repository_full_name")
+                        ? metadata.get("repository_full_name").asText()
+                        : null;
+                if (serverUrl != null && token != null && repoFullName != null) {
+                    String cloneUrl = serverUrl + "/" + repoFullName + ".git";
+                    gitRepositoryManager.ensureRepository(repositoryId, cloneUrl, token);
+                    fetched = true;
+                    log.debug("Fetched latest refs: repoId={}", repositoryId);
                 }
             }
-
-            // For GitHub workspaces or when GitLab token is unavailable, the repo may already
-            // be current (fetched by push webhook). The headSha validation in resolveDiffRange
-            // will catch staleness even without a fetch here.
-            if (serverUrl == null || token == null) {
-                log.debug("No token available for pre-diff fetch, relying on existing clone: repoId={}", repositoryId);
-                return;
-            }
-
-            JsonNode metadata = job.getMetadata();
-            String repoFullName =
-                metadata != null && metadata.has("repository_full_name")
-                    ? metadata.get("repository_full_name").asText()
-                    : null;
-            if (repoFullName == null) {
-                log.debug("No repository_full_name in metadata, skipping pre-diff fetch");
-                return;
-            }
-
-            String cloneUrl = serverUrl + "/" + repoFullName + ".git";
-            gitRepositoryManager.ensureRepository(repositoryId, cloneUrl, token);
-            log.debug("Fetched latest refs before diff computation: repoId={}, scopeId={}", repositoryId, scopeId);
         } catch (Exception e) {
-            log.warn(
-                "Pre-diff fetch failed (will proceed with existing clone): repoId={}, error={}",
-                repositoryId,
-                e.getMessage()
-            );
+            log.warn("Pre-diff fetch failed: repoId={}, error={}", repositoryId, e.getMessage());
         }
+
+        // Verify headSha exists locally — this is the critical check.
+        // If headSha doesn't exist, ALL diff strategies will fail and the agent gets an empty diff.
+        if (headSha != null && !headSha.isBlank()) {
+            String catFile = runGit(repoPath, "cat-file", "-t", headSha);
+            if (catFile != null && !catFile.trim().equals("commit")) {
+                // cat-file succeeded but returned non-commit type — SHA exists but is wrong type
+                log.warn("Head SHA {} is not a commit (type={}), repoId={}", headSha, catFile.trim(), repositoryId);
+            } else if (catFile == null && fetched) {
+                // Fetch succeeded but SHA still not found — this is a hard failure
+                throw new JobPreparationException(
+                    "Head commit " +
+                        headSha +
+                        " not found in local clone after successful fetch. " +
+                        "The commit may have been force-pushed away. repoId=" +
+                        repositoryId
+                );
+            } else if (catFile == null) {
+                // No fetch happened (token unavailable) and SHA not found
+                log.warn(
+                    "Head commit {} not found locally and fetch was not possible (token unavailable). " +
+                        "Diff computation will likely fail. repoId={}",
+                    headSha,
+                    repositoryId
+                );
+                return false;
+            }
+            // catFile is "commit" — head SHA is verified present
+            return catFile != null && catFile.trim().equals("commit");
+        }
+        return false;
     }
 
     /** Build and store pull request metadata and review comments as context JSON files. */
@@ -669,15 +705,31 @@ public class PullRequestReviewHandler implements JobTypeHandler {
         }
         Path repoPath = gitRepositoryManager.getRepositoryPath(repositoryId);
 
-        // Fetch latest refs from remote before computing the diff.
-        // Without this, the local clone may have stale branch refs from an earlier push,
-        // causing the diff to be computed against the wrong commit (see: stale-diff incident).
-        fetchBeforeDiff(repositoryId, job);
+        // Fetch latest refs and verify headSha exists locally.
+        // Returns true if headSha was verified present in the local clone.
+        boolean headVerified = fetchAndVerifyHead(repositoryId, job, headSha);
 
         try {
             String[] range = resolveDiffRange(repoPath, targetBranch, sourceBranch, headSha);
             if (range == null) {
-                log.warn("Could not compute diff base for headSha={}, targetBranch={}", headSha, targetBranch);
+                if (headVerified) {
+                    // Head commit exists but diff still couldn't be resolved — real bug.
+                    throw new JobPreparationException(
+                        "Cannot compute diff: all resolution strategies failed despite head commit " +
+                            headSha +
+                            " being present. targetBranch=" +
+                            targetBranch +
+                            ", sourceBranch=" +
+                            sourceBranch +
+                            ", repoId=" +
+                            repositoryId
+                    );
+                }
+                log.warn(
+                    "Diff resolution failed (head commit not verified locally), skipping diff: headSha={}, repoId={}",
+                    headSha,
+                    repositoryId
+                );
                 return;
             }
             String rangeSpec = range[0] + ".." + range[1];

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/job/AgentJobExecutor.java
@@ -564,24 +564,48 @@ public class AgentJobExecutor {
         JobTypeHandler handler,
         AgentJob job
     ) {
-        AgentJobStatus terminalStatus = determineTerminalStatus(sandboxResult);
+        AgentJobStatus terminalStatus = determineTerminalStatus(sandboxResult, agentResult);
         persistTerminalState(jobId, agentResult, sandboxResult, terminalStatus);
         deliverResults(jobId, terminalStatus, handler);
     }
 
     /**
-     * Determine the terminal status based on sandbox execution outcome.
+     * Determine the terminal status based on sandbox execution outcome and agent output.
+     *
+     * <p>If the sandbox exited with a non-zero code but the agent still produced valid output
+     * (e.g., the runner validation was stricter than the Java-side parser, or the agent wrote
+     * result.json but the process exited 1 due to an unrelated error), we treat it as COMPLETED
+     * so findings get delivered. The non-zero exit is logged for diagnostics.
      *
      * @return TIMED_OUT, FAILED, or COMPLETED
      */
-    private AgentJobStatus determineTerminalStatus(SandboxResult sandboxResult) {
+    private AgentJobStatus determineTerminalStatus(SandboxResult sandboxResult, AgentResult agentResult) {
         if (sandboxResult.timedOut()) {
             return AgentJobStatus.TIMED_OUT;
-        } else if (sandboxResult.exitCode() != 0) {
-            return AgentJobStatus.FAILED;
-        } else {
+        }
+        if (sandboxResult.exitCode() == 0) {
             return AgentJobStatus.COMPLETED;
         }
+        // Non-zero exit: check if valid output was still produced.
+        // The agent may write result.json but the runner exits 1 due to validation mismatch.
+        if (agentResult != null && agentResult.output() != null) {
+            Object rawOutput = agentResult.output().get("rawOutput");
+            if (rawOutput instanceof String raw && !raw.isBlank()) {
+                log.info(
+                    "Agent exited with code {} but produced output — treating as COMPLETED for delivery",
+                    sandboxResult.exitCode()
+                );
+                return AgentJobStatus.COMPLETED;
+            }
+            if (rawOutput != null) {
+                log.warn(
+                    "Agent exited with code {} and rawOutput is present but not a String (type={})",
+                    sandboxResult.exitCode(),
+                    rawOutput.getClass().getSimpleName()
+                );
+            }
+        }
+        return AgentJobStatus.FAILED;
     }
 
     /**

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/repository/gitlab/GitLabPushMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/gitprovider/repository/gitlab/GitLabPushMessageHandler.java
@@ -157,7 +157,9 @@ public class GitLabPushMessageHandler extends GitLabMessageHandler<GitLabPushEve
 
             // Decide between local git enrichment and webhook-only processing.
             // Local git provides line-level diff stats (additions/deletions per file).
-            // Only use for default branch pushes in active scopes (same as GitHub).
+            // Full enrichment (clone + commit walk) only for default branch pushes.
+            // But we ALWAYS fetch on any branch push if the repo is already cloned,
+            // so the practice review pipeline has fresh refs for diff computation.
             if (event.isDefaultBranch() && gitRepositoryManager.isEnabled()) {
                 Long scopeId = resolveScopeId(repository);
                 boolean scopeActive = scopeId != null && syncTargetProvider.isScopeActiveForSync(scopeId);
@@ -169,10 +171,44 @@ public class GitLabPushMessageHandler extends GitLabMessageHandler<GitLabPushEve
                     processCommitsViaWebhook(event, repository, false);
                 }
             } else {
+                // Non-default branch push: still fetch if the repo is already cloned
+                // so practice reviews have fresh refs for diff computation.
+                if (gitRepositoryManager.isEnabled() && gitRepositoryManager.isRepositoryCloned(repository.getId())) {
+                    fetchForNonDefaultBranch(event, repository);
+                }
                 processCommitsViaWebhook(event, repository, false);
             }
         } else {
             log.warn("Failed to upsert project from push event: projectPath={}", safeProjectPath);
+        }
+    }
+
+    /**
+     * Fetch latest refs for non-default branch pushes. This keeps the local clone
+     * current for practice review diff computation. Does not walk commits or
+     * enrich file stats — that's only needed for default branch pushes.
+     */
+    private void fetchForNonDefaultBranch(GitLabPushEventDTO event, Repository repository) {
+        try {
+            Long scopeId = resolveScopeId(repository);
+            if (scopeId == null || !syncTargetProvider.isScopeActiveForSync(scopeId)) {
+                return;
+            }
+            String serverUrl = tokenService.resolveServerUrl(scopeId);
+            String token = tokenService.getAccessToken(scopeId);
+            String cloneUrl = serverUrl + "/" + repository.getNameWithOwner() + ".git";
+            gitRepositoryManager.ensureRepository(repository.getId(), cloneUrl, token);
+            log.debug(
+                "Fetched non-default branch push: ref={}, repo={}",
+                sanitizeForLog(event.ref()),
+                sanitizeForLog(repository.getNameWithOwner())
+            );
+        } catch (Exception e) {
+            log.warn(
+                "Non-default branch fetch failed: repo={}, error={}",
+                sanitizeForLog(repository.getNameWithOwner()),
+                e.getMessage()
+            );
         }
     }
 

--- a/server/application-server/src/main/resources/agent/pi-runner.mjs
+++ b/server/application-server/src/main/resources/agent/pi-runner.mjs
@@ -53,9 +53,16 @@ function redact(text) {
 // ── Validation ───────────────────────────────────────────────────
 
 function isValidFinding(f) {
-    return Boolean(f && typeof f === "object" && typeof f.practiceSlug === "string" && f.practiceSlug.trim() &&
-        typeof f.title === "string" && f.title.trim() && typeof f.verdict === "string" &&
-        typeof f.severity === "string" && typeof f.confidence === "number");
+    if (!f || typeof f !== "object") return false;
+    if (typeof f.practiceSlug !== "string" || !f.practiceSlug.trim()) return false;
+    if (typeof f.title !== "string" || !f.title.trim()) return false;
+    if (typeof f.verdict !== "string") return false;
+    if (typeof f.severity !== "string") return false;
+    // Tolerate confidence as string (LLMs sometimes write "0.85" instead of 0.85)
+    // Guard: Number(null)=0 and Number("")=0 would pass isNaN, so reject nullish/empty first.
+    if (f.confidence == null || f.confidence === "") return false;
+    if (Number.isNaN(Number(f.confidence))) return false;
+    return true;
 }
 
 function isValidFindingsPayload(p) {
@@ -66,7 +73,20 @@ function isValidFindingsPayload(p) {
 function checkResultFile() {
     const path = `${OUTPUT}/result.json`;
     if (!existsSync(path)) return false;
-    try { return isValidFindingsPayload(JSON.parse(readFileSync(path, "utf-8"))); } catch { return false; }
+    try {
+        const data = JSON.parse(readFileSync(path, "utf-8"));
+        const valid = isValidFindingsPayload(data);
+        if (!valid) {
+            const hasFindings = Array.isArray(data?.findings);
+            const count = hasFindings ? data.findings.length : 0;
+            const validCount = hasFindings ? data.findings.filter(isValidFinding).length : 0;
+            console.error(`[pi-runner] result.json validation failed: findings=${count}, valid=${validCount}`);
+        }
+        return valid;
+    } catch (e) {
+        console.error(`[pi-runner] result.json parse error: ${e.message}`);
+        return false;
+    }
 }
 
 // ── Session usage extraction ─────────────────────────────────────


### PR DESCRIPTION
## Problem

5 out of 8 delivered practice reviews told students "nothing to review" on MRs with hundreds of lines of real code. The agent received an empty diff, correctly reported all NOT_APPLICABLE, and the system delivered this garbage to students.

Additionally, 2 jobs ($0.36 LLM spend) produced excellent findings but were marked FAILED because the runner exited with code 1 due to strict validation, and the Java executor only checked exit code.

## Root Cause

The kill chain had 5 links, all of which needed to fail for garbage to reach students:

1. **Push webhook only fetched on default branch** — `GitLabPushMessageHandler` checked `event.isDefaultBranch()` before calling `ensureRepository()`. Feature branch commits were never fetched into the local clone.

2. **`fetchBeforeDiff` failed silently** — when the GitLab token lookup failed or no fetch was possible, it logged at debug and returned. No error signal to the caller.

3. **`resolveDiffRange` returned null** — without the headSha in the local clone, all 3 resolution strategies failed. `computeAndStoreDiff` silently returned without adding any diff files.

4. **Agent analyzed an empty workspace** — no diff.patch, no diff_stat.txt, no diff_summary.md. The agent correctly reported "0 additions and 0 deletions" for everything.

5. **No quality gate** — all-NOT_APPLICABLE findings were delivered to students without question.

## Fixes

### `GitLabPushMessageHandler.java` — Fetch on ALL branch pushes

Added `fetchForNonDefaultBranch()`: when a non-default branch push arrives and the repo is already cloned, fetch latest refs. This keeps local clones current for practice review diff computation. Failures logged at warn level.

### `PullRequestReviewHandler.java` — Abort on bad diff, block garbage delivery

- **`fetchAndVerifyHead` returns boolean**: fetches latest refs, then runs `git cat-file -t {headSha}` to verify the commit exists locally. Returns true if verified, false if not. Throws `JobPreparationException` if fetch succeeded but SHA still missing (force-pushed away).
- **Null diff range = hard failure**: when `resolveDiffRange` returns null AND head was verified present, throws `JobPreparationException`. When head was NOT verified (test env, no fetch possible), warns and skips gracefully.
- **Quality gate**: after parsing findings, checks if ALL are NOT_APPLICABLE. If so, checks `computeDiffStatFiles` — if the diff actually had files, throws `JobDeliveryException` refusing to deliver. Legitimate all-NA reviews (README-only changes with empty diff stat) pass through.
- Removed duplicate stale Javadoc from the `fetchBeforeDiff` → `fetchAndVerifyHead` rename.

### `AgentJobExecutor.java` — Deliver findings on non-zero exit

`determineTerminalStatus` now checks if `rawOutput` contains valid content when exit code is non-zero. If so, treats as COMPLETED for delivery. Logs unexpected rawOutput types.

### `pi-runner.mjs` — Tolerant validation with null guards

`isValidFinding` uses `Number(f.confidence)` to tolerate string confidence values. Added explicit `null`/empty guards since `Number(null)=0` and `Number("")=0` would silently pass `isNaN`. Added diagnostic logging to `checkResultFile` showing findings count and valid count when validation fails.

## Test plan

- [x] Unit + architecture tests pass
- [x] Formatting passes
- [ ] Deploy and verify: trigger reviews on MRs with real code, confirm diff is present and findings are substantive
- [ ] Verify quality gate: a stale-diff scenario should now fail the job instead of delivering garbage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve timeout status; mark non-zero sandbox exits as completed when valid agent output exists (logs added for treated-as-completed and type-mismatch cases).
  * Prevent delivery of reviews when all findings are NOT_APPLICABLE and a diff contains files.

* **Improvements**
  * Accept numeric-string confidences and emit clearer diagnostics distinguishing JSON parse errors from schema/field validation failures.
  * Limit heavy local enrichment to default-branch pushes; for other branches, perform a lightweight fetch-if-cloned to refresh refs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->