### PR TITLE
feat(server): support image diff notes for annotating PNG diagrams

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DeliveryComposer.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DeliveryComposer.java
@@ -472,7 +472,7 @@ class DeliveryComposer {
             // Diff note body: emoji title + reasoning + guidance
             String body = composeDiffNoteBody(f);
             if (body != null && !body.isBlank()) {
-                notes.add(new DiffNote(pathNode.asText(), startLine, endLine, body));
+                notes.add(DiffNote.text(pathNode.asText(), startLine, endLine, body));
             }
         }
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DiffHunkValidator.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DiffHunkValidator.java
@@ -111,6 +111,11 @@ class DiffHunkValidator {
         int corrections = 0;
 
         for (DiffNote note : notes) {
+            // Image notes have no line positions — pass through as-is
+            if (note.isImageNote()) {
+                corrected.add(note);
+                continue;
+            }
             TreeSet<Integer> fileLines = validLines.get(note.filePath());
             if (fileLines == null || fileLines.isEmpty()) {
                 // File not in diff — can't validate, keep as-is
@@ -154,7 +159,7 @@ class DiffHunkValidator {
                 }
             }
 
-            corrected.add(new DiffNote(note.filePath(), nearest, correctedEnd, note.body()));
+            corrected.add(DiffNote.text(note.filePath(), nearest, correctedEnd, note.body()));
         }
 
         if (corrections > 0) {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DiffNotePoster.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DiffNotePoster.java
@@ -104,9 +104,13 @@ class DiffNotePoster {
         // Resolve PR node ID via injected comment poster (reuses same GraphQL query)
         String prNodeId = commentPoster.resolveGitHubPrNodeId(scopeId, parts[0], parts[1], prNumber);
 
-        // Build threads array for the review
+        // Build threads array for the review (skip image notes — GitHub doesn't support them)
         List<Map<String, Object>> threads = new ArrayList<>();
         for (DiffNote note : diffNotes) {
+            if (note.isImageNote()) {
+                log.debug("Skipping image diff note on GitHub (unsupported): file={}", note.filePath());
+                continue;
+            }
             String sanitizedBody = PullRequestCommentPoster.sanitize(note.body());
             if (sanitizedBody.isBlank()) {
                 continue;
@@ -223,25 +227,38 @@ class DiffNotePoster {
             }
 
             try {
-                // Build DiffPositionInput
+                // Build position input — different for text vs image notes
                 Map<String, Object> position = new HashMap<>();
                 position.put("headSha", mrInfo.headSha);
                 position.put("startSha", mrInfo.startSha);
                 position.put("baseSha", mrInfo.baseSha);
                 Map<String, String> paths = new HashMap<>();
                 paths.put("newPath", note.filePath());
-                // oldPath required for GitLab to match the note position to the diff
-                // file in the Changes tab. Correct for new and modified files.
-                // For renamed files oldPath should be the pre-rename path, but the
-                // DiffNote record only carries the new path. Renames are rare in
-                // student assignments; if needed, resolve from MR diff metadata.
                 paths.put("oldPath", note.filePath());
                 position.put("paths", paths);
-                position.put("newLine", note.startLine());
+
+                String documentName;
+                String errorsField;
+
+                if (note.isImageNote()) {
+                    // Image diff note — targets pixel coordinates on a PNG
+                    var img = note.imagePosition();
+                    position.put("x", img.x());
+                    position.put("y", img.y());
+                    position.put("width", img.width());
+                    position.put("height", img.height());
+                    documentName = "CreateImageDiffNote";
+                    errorsField = "createImageDiffNote.errors";
+                } else {
+                    // Text diff note — targets a line number
+                    position.put("newLine", note.startLine());
+                    documentName = "CreateDiffNote";
+                    errorsField = "createDiffNote.errors";
+                }
 
                 ClientGraphQlResponse response = gitLabProvider
                     .forScope(scopeId)
-                    .documentName("CreateDiffNote")
+                    .documentName(documentName)
                     .variable("noteableId", mrInfo.globalId)
                     .variable("body", sanitizedBody + "\n" + HEPHAESTUS_MARKER)
                     .variable("position", position)
@@ -254,15 +271,16 @@ class DiffNotePoster {
                     continue;
                 }
 
-                List<String> errors = response.field("createDiffNote.errors").getValue();
+                List<String> errors = response.field(errorsField).getValue();
                 if (errors != null && !errors.isEmpty()) {
-                    // Fallback: if line is outside diff hunk, post as regular MR comment
+                    // Fallback: if position error, post as regular MR comment
                     if (isLineCodeError(errors)) {
                         log.info(
-                            "Diff note line outside diff hunk, falling back to MR comment: jobId={}, file={}, line={}",
+                            "Diff note position error, falling back to MR comment: jobId={}, file={}, type={}, errors={}",
                             job.getId(),
                             note.filePath(),
-                            note.startLine()
+                            note.isImageNote() ? "image" : "line:" + note.startLine(),
+                            errors
                         );
                         if (postFallbackComment(scopeId, mrInfo.globalId, note, sanitizedBody, job)) {
                             posted++;
@@ -273,10 +291,10 @@ class DiffNotePoster {
                     }
                     failed++;
                     log.warn(
-                        "GitLab createDiffNote failed: jobId={}, file={}, line={}, errors={}",
+                        "GitLab diff note failed: jobId={}, file={}, type={}, errors={}",
                         job.getId(),
                         note.filePath(),
-                        note.startLine(),
+                        note.isImageNote() ? "image" : "line:" + note.startLine(),
                         errors
                     );
                     continue;
@@ -437,13 +455,10 @@ class DiffNotePoster {
         AgentJob job
     ) {
         try {
-            String fallbackBody = String.format(
-                "**`%s:%d`**\n\n%s\n%s",
-                note.filePath(),
-                note.startLine(),
-                sanitizedBody,
-                HEPHAESTUS_MARKER
-            );
+            String location = note.isImageNote()
+                ? String.format("`%s` (image annotation)", note.filePath())
+                : String.format("`%s:%d`", note.filePath(), note.startLine());
+            String fallbackBody = String.format("**%s**\n\n%s\n%s", location, sanitizedBody, HEPHAESTUS_MARKER);
             ClientGraphQlResponse response = gitLabProvider
                 .forScope(scopeId)
                 .documentName("CreateMergeRequestNote")

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PracticeDetectionResultParser.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PracticeDetectionResultParser.java
@@ -334,38 +334,7 @@ public class PracticeDetectionResultParser {
             return null;
         }
 
-        // Required: startLine (positive integer)
-        JsonNode startLineNode = entry.get("startLine");
-        if (startLineNode == null || startLineNode.isNull() || !startLineNode.isNumber()) {
-            log.debug(
-                "Skipping suggestedDiffNote at finding {}, index {}: missing or non-numeric startLine",
-                findingIndex,
-                noteIndex
-            );
-            return null;
-        }
-        int startLine = startLineNode.asInt();
-        if (startLine <= 0) {
-            log.debug(
-                "Skipping suggestedDiffNote at finding {}, index {}: startLine must be positive, got {}",
-                findingIndex,
-                noteIndex,
-                startLine
-            );
-            return null;
-        }
-
-        // Optional: endLine (positive integer, must be >= startLine)
-        Integer endLine = null;
-        JsonNode endLineNode = entry.get("endLine");
-        if (endLineNode != null && !endLineNode.isNull() && endLineNode.isNumber()) {
-            int endLineValue = endLineNode.asInt();
-            if (endLineValue >= startLine) {
-                endLine = endLineValue;
-            }
-        }
-
-        // Required: body
+        // Required: body (shared by both text and image notes)
         JsonNode bodyNode = entry.get("body");
         if (bodyNode == null || bodyNode.isNull() || !bodyNode.isTextual() || bodyNode.asText().isBlank()) {
             log.debug("Skipping suggestedDiffNote at finding {}, index {}: missing body", findingIndex, noteIndex);
@@ -383,7 +352,76 @@ public class PracticeDetectionResultParser {
             body = body.substring(0, MAX_DIFF_NOTE_BODY_LENGTH);
         }
 
-        return new DiffNote(filePath, startLine, endLine, body);
+        // Image note: imagePosition takes precedence over startLine when present
+        JsonNode imgPosNode = entry.get("imagePosition");
+        if (imgPosNode != null && !imgPosNode.isNull() && imgPosNode.isObject()) {
+            Integer ix = intField(imgPosNode, "x");
+            Integer iy = intField(imgPosNode, "y");
+            Integer iw = intField(imgPosNode, "width");
+            Integer ih = intField(imgPosNode, "height");
+            if (
+                ix != null &&
+                iy != null &&
+                iw != null &&
+                ih != null &&
+                iw > 0 &&
+                ih > 0 &&
+                ix >= 0 &&
+                iy >= 0 &&
+                ix <= iw &&
+                iy <= ih
+            ) {
+                return DiffNote.image(filePath, ix, iy, iw, ih, body);
+            }
+            log.debug(
+                "Skipping invalid imagePosition at finding {}, index {}: x={}, y={}, w={}, h={}",
+                findingIndex,
+                noteIndex,
+                ix,
+                iy,
+                iw,
+                ih
+            );
+        }
+
+        // Text note: startLine is required when imagePosition is absent
+        JsonNode startLineNode = entry.get("startLine");
+        if (startLineNode == null || startLineNode.isNull() || !startLineNode.isNumber()) {
+            log.debug(
+                "Skipping suggestedDiffNote at finding {}, index {}: missing startLine and no imagePosition",
+                findingIndex,
+                noteIndex
+            );
+            return null;
+        }
+        int startLine = startLineNode.asInt();
+        if (startLine <= 0) {
+            log.debug(
+                "Skipping suggestedDiffNote at finding {}, index {}: startLine must be positive, got {}",
+                findingIndex,
+                noteIndex,
+                startLine
+            );
+            return null;
+        }
+
+        // Optional: endLine
+        Integer endLine = null;
+        JsonNode endLineNode = entry.get("endLine");
+        if (endLineNode != null && !endLineNode.isNull() && endLineNode.isNumber()) {
+            int endLineValue = endLineNode.asInt();
+            if (endLineValue >= startLine) {
+                endLine = endLineValue;
+            }
+        }
+
+        return DiffNote.text(filePath, startLine, endLine, body);
+    }
+
+    @Nullable
+    private static Integer intField(JsonNode node, String field) {
+        JsonNode n = node.get(field);
+        return (n != null && !n.isNull() && n.isNumber()) ? n.asInt() : null;
     }
 
     // =========================================================================
@@ -632,12 +670,39 @@ public class PracticeDetectionResultParser {
     public record DeliveryContent(@Nullable String mrNote, List<DiffNote> diffNotes) {}
 
     /**
-     * An inline diff note targeting a specific file and line range.
+     * An inline diff note targeting a specific file and line range, or a region on an image.
+     * For text notes: startLine is required, imagePosition is null.
+     * For image notes: imagePosition is non-null, startLine is 0 (unused).
      *
-     * @param filePath  path relative to repo root (new path, not old)
-     * @param startLine first line number (1-based, must be positive)
-     * @param endLine   optional last line number for multi-line (GitHub only; GitLab ignores)
-     * @param body      markdown comment body (sanitized before posting)
+     * @param filePath      path relative to repo root (new path, not old)
+     * @param startLine     first line number (1-based) for text notes; 0 for image notes
+     * @param endLine       optional last line number for multi-line (GitHub only; GitLab ignores)
+     * @param body          markdown comment body (sanitized before posting)
+     * @param imagePosition pixel coordinates for image diff notes (GitLab only), or null for text notes
      */
-    public record DiffNote(String filePath, int startLine, @Nullable Integer endLine, String body) {}
+    public record DiffNote(
+        String filePath,
+        int startLine,
+        @Nullable Integer endLine,
+        String body,
+        @Nullable ImagePosition imagePosition
+    ) {
+        /** Pixel coordinates targeting a region on an image file in the diff. */
+        public record ImagePosition(int x, int y, int width, int height) {}
+
+        /** Is this an image diff note? */
+        public boolean isImageNote() {
+            return imagePosition != null;
+        }
+
+        /** Factory for text diff notes. */
+        public static DiffNote text(String filePath, int startLine, @Nullable Integer endLine, String body) {
+            return new DiffNote(filePath, startLine, endLine, body, null);
+        }
+
+        /** Factory for image diff notes. */
+        public static DiffNote image(String filePath, int x, int y, int width, int height, String body) {
+            return new DiffNote(filePath, 0, null, body, new ImagePosition(x, y, width, height));
+        }
+    }
 }

--- a/server/application-server/src/main/resources/graphql/gitlab/operations/CreateImageDiffNote.graphql
+++ b/server/application-server/src/main/resources/graphql/gitlab/operations/CreateImageDiffNote.graphql
@@ -1,0 +1,20 @@
+# Posts an image diff note (pin annotation on an image) on a merge request.
+# Used by agent feedback delivery to annotate specific regions of PNG diagrams.
+# Each note targets an (x, y) pixel coordinate on an image file in the MR diff.
+
+mutation CreateImageDiffNote(
+    $noteableId: NoteableID!,
+    $body: String!,
+    $position: DiffImagePositionInput!
+) {
+    createImageDiffNote(input: {
+        noteableId: $noteableId,
+        body: $body,
+        position: $position
+    }) {
+        note {
+            id
+        }
+        errors
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/DiffHunkValidatorTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/DiffHunkValidatorTest.java
@@ -212,7 +212,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         @Test
         @DisplayName("returns notes unchanged when validLines is empty")
         void emptyValidLines() {
-            List<DiffNote> notes = List.of(new DiffNote("File.swift", 10, null, "comment"));
+            List<DiffNote> notes = List.of(DiffNote.text("File.swift", 10, null, "comment"));
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(notes, Map.of(), "job-1");
             assertThat(result).isEqualTo(notes);
         }
@@ -233,7 +233,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         @DisplayName("keeps valid notes as-is")
         void validNotesUnchanged() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(5, 10, 15, 20));
-            DiffNote note = new DiffNote("File.swift", 10, null, "good line");
+            DiffNote note = DiffNote.text("File.swift", 10, null, "good line");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -247,7 +247,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         @DisplayName("snaps invalid line to nearest valid line (floor)")
         void snapsToFloor() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(5, 10, 20));
-            DiffNote note = new DiffNote("File.swift", 12, null, "off by 2");
+            DiffNote note = DiffNote.text("File.swift", 12, null, "off by 2");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -261,7 +261,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         @DisplayName("snaps invalid line to nearest valid line (ceiling)")
         void snapsToCeiling() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(5, 10, 20));
-            DiffNote note = new DiffNote("File.swift", 17, null, "closer to 20");
+            DiffNote note = DiffNote.text("File.swift", 17, null, "closer to 20");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -275,7 +275,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         @DisplayName("keeps note unchanged when file is not in validLines map")
         void unknownFileKeptAsIs() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(1, 2, 3));
-            DiffNote note = new DiffNote("Other.swift", 50, null, "unknown file");
+            DiffNote note = DiffNote.text("Other.swift", 50, null, "unknown file");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -292,7 +292,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
             TreeSet<Integer> lines = new TreeSet<>(List.of(5, 10, 11, 12, 15, 20, 25));
             // Note with range 12-14 (span=2), closest valid start is 12 (exact match)
             // But let's use 13-16 (span=3) which snaps to 12, endLine should be ≤15
-            DiffNote note = new DiffNote("File.swift", 13, 16, "range note");
+            DiffNote note = DiffNote.text("File.swift", 13, 16, "range note");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -311,7 +311,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         void endLineDoesNotBalloon() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(5, 10, 100));
             // Note at 12-14 (span=2), snaps to 10, endLine should NOT jump to 100
-            DiffNote note = new DiffNote("File.swift", 12, 14, "should not balloon");
+            DiffNote note = DiffNote.text("File.swift", 12, 14, "should not balloon");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -328,9 +328,9 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         void mixedNotes() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(1, 5, 10, 15));
             List<DiffNote> notes = List.of(
-                new DiffNote("File.swift", 5, null, "valid"),
-                new DiffNote("File.swift", 7, null, "invalid - snap to 5"),
-                new DiffNote("File.swift", 15, null, "valid")
+                DiffNote.text("File.swift", 5, null, "valid"),
+                DiffNote.text("File.swift", 7, null, "invalid - snap to 5"),
+                DiffNote.text("File.swift", 15, null, "valid")
             );
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(notes, Map.of("File.swift", lines), "job-1");
             assertThat(result).hasSize(3);
@@ -343,7 +343,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         @DisplayName("prefers floor on equal distance tie")
         void tieBreaksToFloor() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(5, 15));
-            DiffNote note = new DiffNote("File.swift", 10, null, "equidistant");
+            DiffNote note = DiffNote.text("File.swift", 10, null, "equidistant");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -357,7 +357,7 @@ class DiffHunkValidatorTest extends BaseUnitTest {
         @DisplayName("snaps note far beyond all valid lines to last valid line")
         void snapsBeyondAllLines() {
             TreeSet<Integer> lines = new TreeSet<>(List.of(1, 2, 3));
-            DiffNote note = new DiffNote("File.swift", 1000, null, "way beyond");
+            DiffNote note = DiffNote.text("File.swift", 1000, null, "way beyond");
             List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
                 List.of(note),
                 Map.of("File.swift", lines),
@@ -365,6 +365,26 @@ class DiffHunkValidatorTest extends BaseUnitTest {
             );
             assertThat(result).hasSize(1);
             assertThat(result.getFirst().startLine()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("passes image notes through without modification")
+        void passesImageNotesThrough() {
+            TreeSet<Integer> lines = new TreeSet<>(List.of(5, 10, 15));
+            DiffNote imageNote = DiffNote.image("diagram.png", 200, 150, 800, 600, "Fix this class");
+            DiffNote textNote = DiffNote.text("File.swift", 7, null, "text comment");
+            List<DiffNote> result = DiffHunkValidator.validateAndCorrect(
+                List.of(imageNote, textNote),
+                Map.of("File.swift", lines),
+                "job-1"
+            );
+            assertThat(result).hasSize(2);
+            // Image note unchanged
+            assertThat(result.get(0).isImageNote()).isTrue();
+            assertThat(result.get(0).imagePosition().x()).isEqualTo(200);
+            // Text note snapped
+            assertThat(result.get(1).isImageNote()).isFalse();
+            assertThat(result.get(1).startLine()).isEqualTo(5);
         }
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/FeedbackDeliveryServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/handler/FeedbackDeliveryServiceTest.java
@@ -110,7 +110,7 @@ class FeedbackDeliveryServiceTest extends BaseUnitTest {
             when(commentPoster.postFormattedBody(eq(job), any(String.class))).thenReturn("IC_comment123");
             when(diffNotePoster.postDiffNotes(eq(job), any())).thenReturn(new DiffNotePoster.DiffNoteResult(1, 0));
 
-            var diffNotes = List.of(new DiffNote("src/Foo.java", 10, null, "Fix this"));
+            var diffNotes = List.of(DiffNote.text("src/Foo.java", 10, null, "Fix this"));
             var delivery = new DeliveryContent("Fix the tests.", diffNotes);
             service.deliverFeedback(job, delivery);
 
@@ -261,8 +261,8 @@ class FeedbackDeliveryServiceTest extends BaseUnitTest {
             when(diffNotePoster.postDiffNotes(eq(job), any())).thenReturn(new DiffNotePoster.DiffNoteResult(2, 0));
 
             var diffNotes = List.of(
-                new DiffNote("src/Foo.java", 10, null, "Fix this"),
-                new DiffNote("src/Bar.java", 20, null, "And this")
+                DiffNote.text("src/Foo.java", 10, null, "Fix this"),
+                DiffNote.text("src/Bar.java", 20, null, "And this")
             );
             var delivery = new DeliveryContent(null, diffNotes);
             service.deliverFeedback(job, delivery);


### PR DESCRIPTION
## Summary

Extends Hephaestus to post image diff notes on GitLab merge requests, enabling practice review findings to point at specific pixel regions of PNG images (e.g., UML diagrams). This is the infrastructure needed for the upcoming domain model (AOM) practice that reviews Apollon class diagrams.

## How it works

When an agent produces a `suggestedDiffNote` with an `imagePosition` object instead of a `startLine`, the note is posted via GitLab's `createImageDiffNote` mutation instead of `createDiffNote`. The note appears as a pin annotation on the image in the Changes tab.

Agent output format:
\`\`\`json
{
  "suggestedDiffNotes": [{
    "filePath": "diagrams/aom.png",
    "body": "Class 'Order' uses a solution-domain name.",
    "imagePosition": { "x": 245, "y": 130, "width": 1200, "height": 800 }
  }]
}
\`\`\`

## Changes

### PracticeDetectionResultParser.java
- **DiffNote record**: added optional `ImagePosition(x, y, width, height)` inner record with `isImageNote()` method and `DiffNote.text()`/`DiffNote.image()` static factories
- **Parsing**: `imagePosition` is checked BEFORE `startLine` — image-only notes (without startLine) parse correctly. Validates bounds: coordinates non-negative, within image dimensions
- All existing callsites updated to use `DiffNote.text()` factory

### DiffNotePoster.java
- Routes image notes to `CreateImageDiffNote` GraphQL mutation with `DiffImagePositionInput` (x, y, width, height)
- Routes text notes to existing `CreateDiffNote` mutation (unchanged)
- GitHub path: image notes are skipped with a debug log (GitHub doesn't support image annotations)
- Fallback comment formatting adapts to note type
- Error/info logging distinguishes image vs text notes

### DiffHunkValidator.java
- Image notes pass through without line-number validation (they have pixel positions, not lines)
- Test added for mixed text+image note validation

### CreateImageDiffNote.graphql (new)
New GraphQL operation using `DiffImagePositionInput` from GitLab's existing schema.

## Test plan
- [x] Unit + architecture tests pass
- [x] Image note pass-through in DiffHunkValidator tested
- [x] Existing text diff note tests all pass with new DiffNote.text() factory
- [ ] E2E: deploy and post an image diff note on a PNG diagram in a test MR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for image diff notes in code review feedback delivery, enabling pin annotations on images during merge request reviews across both GitHub and GitLab platforms with appropriate position handling.

* **Tests**
  * Updated test suite to validate image note creation and handling alongside text notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->