### PR TITLE
fix(docker+server): add git CLI to app server, fix agent retry when write tool skipped

### DIFF
--- a/server/application-server/Dockerfile
+++ b/server/application-server/Dockerfile
@@ -18,6 +18,9 @@ RUN --mount=type=cache,target=/root/.m2 \
 
 FROM eclipse-temurin:21
 
+# git CLI required by PullRequestReviewHandler.runGit() for diff computation
+RUN apt-get update -qq && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=build /app/target/*.jar /app/server.jar


### PR DESCRIPTION
## Problems

### 1. No git CLI in app server container
The \`eclipse-temurin:21\` base image has no \`git\` binary. \`PullRequestReviewHandler.runGit()\` spawns git CLI for diff computation. Without it, all reviews fail.

**Fix**: Install git in the Dockerfile.

### 2. Agent produces text instead of writing result.json
The agent (gpt-5.4-mini) sometimes outputs findings as text instead of calling the write tool. The old continuation prompt said "you ran out of time" even when the agent completed normally — it lied, and was too generic to fix the problem.

**Fix**:
- **PI-AGENTS.md**: Explicit instruction: "Your final action MUST be a write tool call. Do NOT output JSON as text."
- **pi-runner.mjs**: Retry prompt is now specific to what went wrong:
  - Agent produced text with "findings" → "you didn't write the file, use the write tool NOW"
  - Agent timed out → "write what you have"
  - Agent completed without output → "call the write tool with the JSON"
- Text rescue scans all assistant messages (not just last) and persists raw text for debugging

## Test plan
- [x] Docker image builds, \`git --version\` works
- [x] Unit + architecture tests pass
- [ ] Deploy and verify agent writes result.json on retry