### PR TITLE
fix(docker): pin app-server Traefik routing to shared-network

### DIFF
--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -142,6 +142,10 @@ services:
       - shared-network
     labels:
       - "traefik.enable=true"
+      # Pin Traefik to shared-network: the app-server temporarily joins agent sandbox
+      # networks (agent-net-*) during review jobs. Without this label, Traefik can pick
+      # the sandbox network IP and route requests to an unreachable internal network.
+      - "traefik.docker.network=shared-network"
       - "traefik.http.middlewares.https-application-server-stripprefix.stripprefix.prefixes=/api"
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.routers.http-application-server.entryPoints=http"
@@ -152,6 +156,8 @@ services:
       - "traefik.http.routers.https-application-server.rule=Host(`${APP_HOSTNAME}`) && PathPrefix(`/api`)"
       - "traefik.http.routers.https-application-server.tls.certresolver=letsencrypt"
       - "traefik.http.routers.https-application-server.tls=true"
+      - "traefik.http.services.http-application-server.loadbalancer.server.port=8080"
+      - "traefik.http.services.https-application-server.loadbalancer.server.port=8080"
       - "traefik.http.routers.http-application-server.priority=5"
       - "traefik.http.routers.https-application-server.priority=10"
     healthcheck:


### PR DESCRIPTION
## Problem

Traefik intermittently loses API routing (504) during practice review jobs and after deploys.

## Root Cause

The app-server temporarily joins agent sandbox networks (\`agent-net-*\`) during review jobs so agent containers can reach the LLM proxy. These networks are \`--internal\` (no gateway to host) — multi-homing the app-server is the only way to provide proxy access in the isolation model.

While multi-homed, Traefik sees the container on two networks and can pick the sandbox network IP (e.g., 192.168.2.2) instead of the shared-network IP (192.168.1.8). Requests routed to the sandbox IP hit an unreachable internal network → 504.

## Fix

Per-container Traefik label on the application-server:

\`\`\`yaml
- "traefik.docker.network=shared-network"
\`\`\`

This is the [documented Traefik approach](https://doc.traefik.io/traefik/providers/docker/#network) for multi-homed containers. It is:
- **Precise**: only affects the app-server, not other services
- **Self-documenting**: the routing constraint lives with the service definition
- **Non-invasive**: no changes to Traefik's global config

Also added explicit \`loadbalancer.server.port=8080\` labels so Traefik doesn't auto-detect during restarts.

## Why Not Other Approaches

- **Global \`--providers.docker.network\`**: Too broad — constrains ALL future services to shared-network
- **Eliminate multi-homing**: Impossible — \`--internal\` networks have no gateway route, so the app-server MUST be on the same network for agent containers to reach the LLM proxy
- **\`host.docker.internal\`**: Only works with \`allowInternet=true\`; breaks the sandbox isolation model

## Verified

Hotfixed on production. API stable through a review job where the app-server was on both \`shared-network\` and \`agent-net-*\`.

## Test plan
- [x] Hotfix verified on production
- [ ] Deploy this PR and verify routing survives concurrent review jobs