### PR TITLE
fix(server): run initial workspace sync synchronously on installation

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/adapter/WorkspaceProvisioningAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/adapter/WorkspaceProvisioningAdapter.java
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 public class WorkspaceProvisioningAdapter implements ProvisioningListener {
@@ -238,36 +240,24 @@ public class WorkspaceProvisioningAdapter implements ProvisioningListener {
         // Update status first
         workspaceInstallationService.updateWorkspaceStatus(installationId, Workspace.WorkspaceStatus.ACTIVE);
 
-        // Trigger initial sync asynchronously before starting NATS consumer
-        // This ensures all entities exist before NATS starts processing webhook events
+        // Sync after the outer transaction commits so RepositoryToMonitor rows are visible.
         workspaceRepository
             .findByInstallationId(installationId)
             .ifPresent(workspace -> {
-                log.info(
-                    "Triggering initial sync for activated installation: installationId={}, workspaceId={}",
-                    installationId,
-                    workspace.getId()
-                );
-
-                // Run sync asynchronously to avoid blocking webhook processing
                 Long workspaceId = workspace.getId();
-                monitoringExecutor.execute(() -> {
-                    try {
-                        getGitHubDataSyncService().syncAllRepositories(workspaceId);
-                        log.info(
-                            "Completed initial sync for activated installation: installationId={}, workspaceId={}",
-                            installationId,
-                            workspaceId
-                        );
-                    } catch (Exception e) {
-                        log.error(
-                            "Failed initial sync for activated installation: installationId={}, workspaceId={}",
-                            installationId,
-                            workspaceId,
-                            e
-                        );
-                    }
-                });
+
+                if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                    TransactionSynchronizationManager.registerSynchronization(
+                        new TransactionSynchronization() {
+                            @Override
+                            public void afterCommit() {
+                                triggerInitialSync(installationId, workspaceId);
+                            }
+                        }
+                    );
+                } else {
+                    triggerInitialSync(installationId, workspaceId);
+                }
             });
 
         // Start NATS consumer to resume webhook processing
@@ -285,6 +275,32 @@ public class WorkspaceProvisioningAdapter implements ProvisioningListener {
         RepositorySelection repoSelection = parseRepositorySelection(selection);
         workspaceInstallationService.updateRepositorySelection(installationId, repoSelection);
         log.debug("Updated repository selection: installationId={}, selection={}", installationId, repoSelection);
+    }
+
+    private void triggerInitialSync(Long installationId, Long workspaceId) {
+        log.info(
+            "Starting initial sync for activated installation: installationId={}, workspaceId={}",
+            installationId,
+            workspaceId
+        );
+
+        monitoringExecutor.execute(() -> {
+            try {
+                getGitHubDataSyncService().syncAllRepositories(workspaceId);
+                log.info(
+                    "Completed initial sync for activated installation: installationId={}, workspaceId={}",
+                    installationId,
+                    workspaceId
+                );
+            } catch (Exception e) {
+                log.error(
+                    "Failed initial sync for activated installation: installationId={}, workspaceId={}",
+                    installationId,
+                    workspaceId,
+                    e
+                );
+            }
+        });
     }
 
     private RepositorySelection parseRepositorySelection(String selection) {


### PR DESCRIPTION
## Summary
Fixes a race condition where newly installed GitHub App workspaces have repos but zero synced data. Users had to wait until the 3 AM cron job.

## Root Cause
The entire installation webhook handler runs inside a `TransactionTemplate` (in `GitHubMessageHandler.onMessage()`). This means:

1. `onInstallationCreated` creates `RepositoryToMonitor` entities — but they **join the outer transaction** via `@Transactional(propagation = REQUIRED)` and are NOT committed yet
2. `onInstallationActivated` dispatches the sync to `monitoringExecutor` (async thread pool)
3. The async thread calls `getSyncTargetsForScope()` in a NEW `@Transactional(readOnly = true)` transaction
4. This new transaction uses READ_COMMITTED isolation — it **cannot see the uncommitted repos** from the outer transaction
5. The sync finds zero targets and returns in 1ms

## Fix
Use `TransactionSynchronizationManager.registerSynchronization()` to schedule the async sync in the `afterCommit()` callback. This guarantees:
- All `RepositoryToMonitor` entities are persisted and visible before the sync reads them
- The sync still runs async on the monitoring executor (no NATS ack-wait risk)
- Falls back to direct sync when no transaction is active (e.g., unsuspend path)

## Test plan
- [ ] Install GitHub App on a new org → verify repos + data sync immediately (not after 3 AM)
- [ ] Unsuspend an existing workspace → verify sync still works (fallback path)
- [ ] Verify existing workspaces continue to sync normally on the cron schedule