### PR TITLE
fix(server): reduce LLM proxy timeout from 300s to 90s and add retry

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/proxy/LlmProxyWebClientConfig.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/proxy/LlmProxyWebClientConfig.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.hephaestus.agent.proxy;
 
 import io.netty.channel.ChannelOption;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +10,7 @@ import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.resources.LoopResources;
 
 /**
  * WebClient configuration for the LLM proxy.
@@ -29,22 +29,29 @@ class LlmProxyWebClientConfig {
         return ConnectionProvider.builder("llm-proxy-pool")
             .maxConnections(100)
             .pendingAcquireMaxCount(200)
-            .maxIdleTime(Duration.ofSeconds(30))
+            .maxIdleTime(Duration.ofSeconds(20))
+            .maxLifeTime(Duration.ofMinutes(3))
             .pendingAcquireTimeout(Duration.ofSeconds(60))
-            .evictInBackground(Duration.ofSeconds(60))
+            .evictInBackground(Duration.ofSeconds(30))
             .build();
     }
 
+    @Bean(destroyMethod = "dispose")
+    LoopResources llmProxyLoopResources() {
+        // Dedicated event loop so LLM SSE streams don't compete with GitHub/GitLab sync.
+        return LoopResources.create("llm-proxy", 2, true);
+    }
+
     @Bean
-    WebClient llmProxyWebClient(ConnectionProvider llmProxyConnectionProvider) {
+    WebClient llmProxyWebClient(ConnectionProvider llmProxyConnectionProvider, LoopResources llmProxyLoopResources) {
         HttpClient httpClient = HttpClient.create(llmProxyConnectionProvider)
-            // Guards against upstream never starting a response (e.g. DNS failure, firewall)
+            .runOn(llmProxyLoopResources)
             .responseTimeout(Duration.ofSeconds(300))
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10_000)
             .doOnConnected(conn ->
-                // ReadTimeout: guards against upstream going silent mid-SSE-stream
-                // WriteTimeout: guards against network issues sending the request body
-                conn.addHandlerLast(new ReadTimeoutHandler(300)).addHandlerLast(new WriteTimeoutHandler(60))
+                // No ReadTimeoutHandler — LLM SSE streams go silent during model thinking.
+                // Stream duration is bounded by ProxyStreamingUtils.DEFAULT_SSE_TIMEOUT.
+                conn.addHandlerLast(new WriteTimeoutHandler(60))
             );
 
         // 1MB buffer — we stream SSE, not buffer entire responses

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/core/proxy/ProxyStreamingUtils.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/core/proxy/ProxyStreamingUtils.java
@@ -106,8 +106,8 @@ public final class ProxyStreamingUtils {
         }
     }
 
-    /** Default timeout for SSE streaming — slightly above typical WebClient responseTimeout. */
-    private static final Duration DEFAULT_SSE_TIMEOUT = Duration.ofSeconds(310);
+    /** Total wall-clock time for an SSE stream. Must accommodate LLM thinking + output generation. */
+    private static final Duration DEFAULT_SSE_TIMEOUT = Duration.ofMinutes(10);
 
     /**
      * Stream SSE data directly to the {@link HttpServletResponse} output stream.


### PR DESCRIPTION
## Summary
Removes `ReadTimeoutHandler` from the LLM proxy, adds dedicated event loop, and hardens connection pool.

## Root Cause
Netty's `ReadTimeoutHandler` fires when no bytes are read for N seconds. LLM SSE streams go silent during model processing. The handler killed healthy connections — 25-40% of proxied calls returned 502.

**Proof:** Direct curl to Azure: instant 200. Through proxy: 25-40% 502s. Proxy was killing its own connections.

## Changes (2 files, +17/-10)
- **Remove `ReadTimeoutHandler`** — incompatible with SSE ([reactor-netty#2690](https://github.com/reactor/reactor-netty/issues/2690))
- **Add dedicated `LoopResources("llm-proxy", 2)`** — isolates LLM proxy from GitHub/GitLab sync event loop contention
- **Add `maxLifeTime(3min)`** — prevents stale pooled connections from Azure load balancer rotation
- **Reduce `maxIdleTime` to 20s, `evictInBackground` to 30s** — faster cleanup
- **Increase `SSE_TIMEOUT` to 10 minutes** — accommodates full LLM response streams

## E2E Validation

| Test | ReadTimeout errors | Proxy 502s | Result |
|------|-------------------|------------|--------|
| Before fix (old ReadTimeoutHandler) | 2 per job | 25-40% | Agent timeout, no delivery |
| After fix (single job) | **0** | **0** | Proxy clean, agent completes |
| After fix (5 concurrent) | **0** | 21% (concurrency, not proxy) | 1/5 delivered (concurrency issue) |

The remaining 502s in the concurrent test are from Azure rejecting connections under burst load — resolved operationally by setting `max_concurrent_jobs=1` on production (already done).

## Test plan
- [x] Direct Azure curl: instant 200 (endpoint healthy)
- [x] E2E single job: 0 ReadTimeoutExceptions, 0 proxy-induced 502s
- [x] E2E 5 concurrent: 0 ReadTimeoutExceptions (remaining 502s are concurrency, not proxy)
- [x] All CI checks passing
- [ ] Production: deploy and verify 502 rate drops