### PR TITLE
fix(workspace): preserve hidden member flag across org syncs

### DIFF
--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceMembership.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceMembership.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.Locale;
 import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
 
 /**
  * Join entity representing a user's membership in a workspace with role-based access control.
@@ -42,6 +43,7 @@ import lombok.*;
  */
 @Entity
 @Table(name = "workspace_membership")
+@DynamicUpdate
 @Getter
 @Setter
 @NoArgsConstructor

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceMembershipService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/workspace/WorkspaceMembershipService.java
@@ -269,9 +269,22 @@ public class WorkspaceMembershipService {
 
         for (WorkspaceMembership member : existingMembers) {
             Long memberUserId = member.getUser() != null ? member.getUser().getId() : null;
-            if (memberUserId != null && !desiredUserIds.contains(memberUserId)) {
-                toDelete.add(member);
+            if (memberUserId == null || desiredUserIds.contains(memberUserId)) {
+                continue;
             }
+            // Preserve memberships an admin has explicitly hidden from the leaderboard.
+            // `hidden=true` is a sticky, admin-authored signal that must survive org-sync
+            // churn (transient API gaps, webhook reorder, remove-then-re-add). Deleting
+            // the row would lose that signal on re-creation and silently un-hide the user.
+            if (member.isHidden()) {
+                log.debug(
+                    "Preserved hidden workspace membership during sync: workspaceId={}, userId={}",
+                    workspace.getId(),
+                    memberUserId
+                );
+                continue;
+            }
+            toDelete.add(member);
         }
 
         if (!toCreate.isEmpty()) {

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/workspace/WorkspaceMembershipControllerIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/workspace/WorkspaceMembershipControllerIntegrationTest.java
@@ -10,7 +10,9 @@ import de.tum.in.www1.hephaestus.testconfig.WithMentorUser;
 import de.tum.in.www1.hephaestus.workspace.WorkspaceMembership.WorkspaceRole;
 import de.tum.in.www1.hephaestus.workspace.dto.AssignRoleRequestDTO;
 import de.tum.in.www1.hephaestus.workspace.dto.WorkspaceMembershipDTO;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,6 +102,121 @@ class WorkspaceMembershipControllerIntegrationTest extends AbstractWorkspaceInte
             .findByWorkspace_IdAndUser_Id(workspace.getId(), targetUser.getId())
             .orElseThrow();
         assertThat(updated.getRole()).isEqualTo(WorkspaceRole.ADMIN);
+    }
+
+    @Test
+    @WithAdminUser
+    void updateMemberVisibilityTogglesHiddenFlag() {
+        User owner = persistUser("visibility-owner");
+        Workspace workspace = createWorkspace(
+            "visibility-space",
+            "Visibility Space",
+            "visibility",
+            AccountType.ORG,
+            owner
+        );
+
+        User adminUser = TestUserFactory.ensureUser(userRepository, "admin", 3L, ensureGitHubProvider());
+        workspaceMembershipService.createMembership(workspace, adminUser.getId(), WorkspaceRole.ADMIN);
+
+        User target = persistUser("visibility-target");
+        workspaceMembershipService.createMembership(workspace, target.getId(), WorkspaceRole.MEMBER);
+
+        WorkspaceMembershipDTO hidden = webTestClient
+            .patch()
+            .uri("/workspaces/{slug}/members/{userId}/hidden?hidden=true", workspace.getWorkspaceSlug(), target.getId())
+            .headers(TestAuthUtils.withCurrentUser())
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(WorkspaceMembershipDTO.class)
+            .returnResult()
+            .getResponseBody();
+
+        assertThat(hidden).isNotNull();
+        assertThat(hidden.hidden()).isTrue();
+        assertThat(workspaceMembershipRepository.findByWorkspace_IdAndUser_Id(workspace.getId(), target.getId()))
+            .get()
+            .extracting(WorkspaceMembership::isHidden)
+            .isEqualTo(true);
+    }
+
+    @Test
+    @WithAdminUser
+    void hiddenFlagIsPreservedWhenOrgSyncOmitsMember() {
+        // Simulates the bug where a scheduled GitHub/GitLab org sync — or a transient
+        // webhook gap — rebuilds desiredRoles WITHOUT a user that an admin has hidden.
+        // The sync used to delete that membership row; a later re-add would re-create
+        // it with hidden=false, silently reverting the admin's decision.
+        User owner = persistUser("sync-owner");
+        Workspace workspace = createWorkspace("sync-space", "Sync Space", "syncorg", AccountType.ORG, owner);
+
+        User hiddenUser = persistUser("hidden-user");
+        workspaceMembershipService.createMembership(workspace, hiddenUser.getId(), WorkspaceRole.MEMBER);
+        workspaceMembershipService.updateMemberVisibility(workspace.getId(), hiddenUser.getId(), true);
+
+        User visibleUser = persistUser("visible-user");
+        workspaceMembershipService.createMembership(workspace, visibleUser.getId(), WorkspaceRole.MEMBER);
+
+        // Org sync runs but does NOT include hiddenUser (e.g. transient API gap, webhook
+        // reorder, member temporarily missing from organization_membership).
+        // It DOES include a non-hidden member who is also not in the org anymore.
+        Map<Long, WorkspaceRole> desiredRoles = new HashMap<>();
+        desiredRoles.put(owner.getId(), WorkspaceRole.OWNER);
+        // visibleUser and hiddenUser are both absent from desiredRoles
+
+        workspaceMembershipService.syncWorkspaceMembers(workspace, desiredRoles);
+
+        // Hidden member must survive the sync with hidden=true intact.
+        assertThat(workspaceMembershipRepository.findByWorkspace_IdAndUser_Id(workspace.getId(), hiddenUser.getId()))
+            .as("hidden membership must not be deleted by org sync")
+            .get()
+            .extracting(WorkspaceMembership::isHidden)
+            .isEqualTo(true);
+
+        // Non-hidden absent member is still cleaned up (pre-existing behavior).
+        assertThat(workspaceMembershipRepository.findByWorkspace_IdAndUser_Id(workspace.getId(), visibleUser.getId()))
+            .as("non-hidden absent member is still removed")
+            .isEmpty();
+    }
+
+    @Test
+    @WithAdminUser
+    void hiddenFlagIsPreservedWhenOrgSyncUpdatesUnrelatedMemberRole() {
+        // Defensive: ensure an unrelated role change in the same sync transaction
+        // does not write-back a stale hidden=false for the hidden member.
+        User owner = persistUser("rolechange-owner");
+        Workspace workspace = createWorkspace(
+            "rolechange-space",
+            "Role Change Space",
+            "rolechange",
+            AccountType.ORG,
+            owner
+        );
+
+        User hiddenUser = persistUser("rolechange-hidden");
+        workspaceMembershipService.createMembership(workspace, hiddenUser.getId(), WorkspaceRole.MEMBER);
+        workspaceMembershipService.updateMemberVisibility(workspace.getId(), hiddenUser.getId(), true);
+
+        User promoted = persistUser("rolechange-promoted");
+        workspaceMembershipService.createMembership(workspace, promoted.getId(), WorkspaceRole.MEMBER);
+
+        Map<Long, WorkspaceRole> desiredRoles = new HashMap<>();
+        desiredRoles.put(owner.getId(), WorkspaceRole.OWNER);
+        desiredRoles.put(hiddenUser.getId(), WorkspaceRole.MEMBER);
+        desiredRoles.put(promoted.getId(), WorkspaceRole.ADMIN);
+
+        workspaceMembershipService.syncWorkspaceMembers(workspace, desiredRoles);
+
+        assertThat(workspaceMembershipRepository.findByWorkspace_IdAndUser_Id(workspace.getId(), hiddenUser.getId()))
+            .get()
+            .extracting(WorkspaceMembership::isHidden)
+            .isEqualTo(true);
+
+        assertThat(workspaceMembershipRepository.findByWorkspace_IdAndUser_Id(workspace.getId(), promoted.getId()))
+            .get()
+            .extracting(WorkspaceMembership::getRole)
+            .isEqualTo(WorkspaceRole.ADMIN);
     }
 
     @Test


### PR DESCRIPTION
## Description

An admin's \`hidden=true\` on a workspace member was silently reverting whenever the next GitHub/GitLab org sync did not include that user in its snapshot (webhook reorder, transient API gap, remove-then-re-add, paging edge). \`WorkspaceMembershipService.syncWorkspaceMembers\` deleted the row; a later re-add recreated it with the default \`hidden=false\`, losing the admin decision.

Root-cause fix:
- Treat \`hidden=true\` as sticky admin intent — skip deletion of hidden memberships during sync so the row (and flag) survive org-sync churn.
- Add \`@DynamicUpdate\` on \`WorkspaceMembership\` so role/league-point writes only touch columns that actually changed, preventing a stale \`hidden=false\` read-modify-write from clobbering a concurrent \`setHidden(true)\`.

## How to Test

- In the admin UI, hide a workspace member, then trigger a workspace integrations re-sync (or wait for scheduled sync). Member stays hidden.
- Remove that user from the upstream org, wait for sync, then re-add them. Hidden flag is preserved (previously it was lost).
- Automated: \`WorkspaceMembershipControllerIntegrationTest\` adds \`updateMemberVisibilityTogglesHiddenFlag\`, \`hiddenFlagIsPreservedWhenOrgSyncOmitsMember\`, and \`hiddenFlagIsPreservedWhenOrgSyncUpdatesUnrelatedMemberRole\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace members can now be marked as hidden and are preserved during synchronization operations, preventing unintended removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->