### PR TITLE
fix(server): consolidate Pi runner config staging

### DIFF
--- a/docker/agents/pi/Dockerfile
+++ b/docker/agents/pi/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends git finduti
 ARG PI_VERSION=0.74.0
 RUN npm install -g @earendil-works/pi-coding-agent@${PI_VERSION} && \
     npm cache clean --force && \
-    mkdir -p /home/agent/.pi /workspace && \
+    mkdir -p /home/agent /workspace && \
     chown -R 1000:1000 /home/agent /workspace
 
 # Bun runtime for precomputation scripts (static analysis before agent runs)

--- a/docs/contributor/agent/workspace-abi.mdx
+++ b/docs/contributor/agent/workspace-abi.mdx
@@ -24,8 +24,10 @@ lands (#1071) and beyond.
 ├── scratch/               # RESERVED (#1071). AI-writable scratch area. Survives Pi turns,
 │                          # ephemeral across runs. Never read by the server.
 ├── task.json              # TaskEnvelope<…> — runtime contract between handler and runner.
-├── .pi/                   # Pi SDK orchestrator + agent state (AGENTS.md, sessions…).
-├── .pi-runtime/           # settings.json bundle (copied to ~/.pi/settings.json at boot).
+├── .pi/                   # Pi SDK agent dir — $PI_CODING_AGENT_DIR resolves here.
+│   ├── AGENTS.md          #   Orchestrator instructions
+│   ├── settings.json      #   Pi SDK config (provider, model, compaction)
+│   └── extensions/        #   Custom provider extensions (auto-discovered)
 ├── .run-pi.mjs            # Runner script entry point.
 ├── .practices/            # Practice catalog (index.json, {slug}.md, all-criteria.md).
 ├── .precompute/           # Per-practice precompute scripts injected by the server.

--- a/docs/contributor/ai-code-review.mdx
+++ b/docs/contributor/ai-code-review.mdx
@@ -75,8 +75,10 @@ Every agent container gets this file structure (agent-specific files noted):
   .precompute/practices/{slug}.ts    # Precompute scripts (from DB, if present)
   .precompute-out/                   # Precompute output (summary.md + per-practice JSON)
   task.json                          # TaskEnvelope<PracticeReviewTask> — prompt, jobId, workspaceId
-  .pi/AGENTS.md                      # Pi orchestrator instructions
-  .pi-runtime/settings.json          # Pi SDK configuration (provider, model, compaction)
+  .pi/                               # Pi SDK agent dir ($PI_CODING_AGENT_DIR)
+    AGENTS.md                        #   Pi orchestrator instructions
+    settings.json                    #   Pi SDK configuration (provider, model, compaction)
+    extensions/                      #   Custom provider extensions (auto-discovered)
   .run-pi.mjs                        # Runner script
   .analysis/practices/.gitkeep       # Directory for intermediate findings
   .output/                           # Agent writes final results here

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DeliveryComposer.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/DeliveryComposer.java
@@ -1,5 +1,12 @@
 package de.tum.in.www1.hephaestus.agent.handler;
 
+import static de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.ANALYSIS_PREFIX;
+import static de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.CONTEXT_TARGET_PREFIX;
+import static de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PI_AGENT_PREFIX;
+import static de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PRACTICES_PREFIX;
+import static de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PRECOMPUTE_OUT_PREFIX;
+import static de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PRECOMPUTE_PREFIX;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import de.tum.in.www1.hephaestus.agent.handler.PracticeDetectionResultParser.DeliveryContent;
 import de.tum.in.www1.hephaestus.agent.handler.PracticeDetectionResultParser.DiffNote;
@@ -45,13 +52,12 @@ class DeliveryComposer {
 
     /** Paths that are internal workspace artifacts, not student code. */
     private static final List<String> INTERNAL_PATH_PREFIXES = List.of(
-        de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.CONTEXT_TARGET_PREFIX,
-        de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PRACTICES_PREFIX,
-        de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.ANALYSIS_PREFIX,
-        de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PI_AGENT_PREFIX,
-        de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PI_RUNTIME_PREFIX,
-        de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PRECOMPUTE_PREFIX,
-        de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi.PRECOMPUTE_OUT_PREFIX
+        CONTEXT_TARGET_PREFIX,
+        PRACTICES_PREFIX,
+        ANALYSIS_PREFIX,
+        PI_AGENT_PREFIX,
+        PRECOMPUTE_PREFIX,
+        PRECOMPUTE_OUT_PREFIX
     );
 
     /**

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -59,7 +59,8 @@ import org.slf4j.LoggerFactory;
  * ├── .practices/{index.json, {slug}.md, all-criteria.md}
  * ├── .precompute/practices/{slug}.ts
  * ├── .precompute-out/
- * ├── .pi/AGENTS.md, .pi-runtime/settings.json, .run-pi.mjs
+ * ├── .pi/{AGENTS.md, settings.json, extensions/} # Pi SDK agent dir ($PI_CODING_AGENT_DIR)
+ * ├── .run-pi.mjs                          # runner entry point
  * └── .output/
  * </pre>
  */

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorAgentProperties.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorAgentProperties.java
@@ -13,10 +13,6 @@ import org.springframework.validation.annotation.Validated;
 /**
  * When llmProvider + credentialMode + modelName are all set, mentor uses them directly and
  * skips the workspace-scoped AgentConfig table. Omit any one to fall back to AgentConfig.
- *
- * <p>The runner script name is owned by {@link MentorRunnerProfile} — operator overrides for it
- * were never used in practice and risked drifting from the V8 flags / per-process env that the
- * kernel pairs with the script. Bumping the runner is a code change.
  */
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.mentor.agent")

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorAgentProperties.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorAgentProperties.java
@@ -13,12 +13,15 @@ import org.springframework.validation.annotation.Validated;
 /**
  * When llmProvider + credentialMode + modelName are all set, mentor uses them directly and
  * skips the workspace-scoped AgentConfig table. Omit any one to fall back to AgentConfig.
+ *
+ * <p>The runner script name is owned by {@link MentorRunnerProfile} — operator overrides for it
+ * were never used in practice and risked drifting from the V8 flags / per-process env that the
+ * kernel pairs with the script. Bumping the runner is a code change.
  */
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.mentor.agent")
 public record MentorAgentProperties(
     @DefaultValue("ghcr.io/ls1intum/hephaestus/agent-pi:latest") @NotBlank String image,
-    @DefaultValue("pi-mentor-runner.mjs") @NotBlank String runnerScript,
     @DefaultValue("100000") @Min(1) int maxPromptChars,
     @DefaultValue("") String baseUrl,
     @Nullable LlmProvider llmProvider,

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorPiAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorPiAdapter.java
@@ -24,17 +24,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MentorPiAdapter {
 
-    /**
-     * Workspace-relative path of the system prompt file the runner loads. Routed through
-     * {@link WorkspaceAbi#MENTOR_SYSTEM_PROMPT_PATH} so the Java materialiser and JS runner
-     * share one source of truth — see {@code WorkspaceAbiSyncTest}.
-     */
     public static final String SYSTEM_PROMPT_PATH = WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH;
-
-    /** Workspace-relative directory the aspect JSON files land in (matches {@link WorkspaceAbi#CONTEXT_TARGET_PREFIX}). */
     public static final String ASPECT_INPUT_PREFIX = WorkspaceAbi.CONTEXT_TARGET_PREFIX;
-
-    /** Workspace-relative directory for restored Pi SDK session JSONL files (matches the runner's {@code SESSIONS_DIR}). */
     public static final String SESSIONS_DIR_PREFIX = WorkspaceAbi.SESSIONS_DIR_PREFIX;
 
     private static final MentorRunnerProfile PROFILE = new MentorRunnerProfile();
@@ -79,7 +70,7 @@ public class MentorPiAdapter {
             llmConfig.timeoutSeconds(),
             PROFILE,
             extraInputs,
-            "" /* no precompute step — mentor analytics arrive as aspect JSON */
+            ""
         );
 
         PiPlan plan = runtimeFactory.build(planSpec);

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorPiAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorPiAdapter.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.hephaestus.agent.mentor;
 import de.tum.in.www1.hephaestus.agent.runtime.PiPlanSpec;
 import de.tum.in.www1.hephaestus.agent.runtime.PiRuntimeFactory;
 import de.tum.in.www1.hephaestus.agent.runtime.PiRuntimeFactory.PiPlan;
+import de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxSpec;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.ResourceLimits;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.SecurityProfile;
@@ -23,14 +24,20 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MentorPiAdapter {
 
-    /** Workspace-relative path of the system prompt file the runner loads. */
-    public static final String SYSTEM_PROMPT_PATH = "agent/mentor/system.md";
+    /**
+     * Workspace-relative path of the system prompt file the runner loads. Routed through
+     * {@link WorkspaceAbi#MENTOR_SYSTEM_PROMPT_PATH} so the Java materialiser and JS runner
+     * share one source of truth — see {@code WorkspaceAbiSyncTest}.
+     */
+    public static final String SYSTEM_PROMPT_PATH = WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH;
 
-    /** Workspace-relative directory the aspect JSON files land in (matches {@code ContentProvider.OUTPUT_PREFIX}). */
-    public static final String ASPECT_INPUT_PREFIX = "context/target/";
+    /** Workspace-relative directory the aspect JSON files land in (matches {@link WorkspaceAbi#CONTEXT_TARGET_PREFIX}). */
+    public static final String ASPECT_INPUT_PREFIX = WorkspaceAbi.CONTEXT_TARGET_PREFIX;
 
     /** Workspace-relative directory for restored Pi SDK session JSONL files (matches the runner's {@code SESSIONS_DIR}). */
-    public static final String SESSIONS_DIR_PREFIX = ".sessions/";
+    public static final String SESSIONS_DIR_PREFIX = WorkspaceAbi.SESSIONS_DIR_PREFIX;
+
+    private static final MentorRunnerProfile PROFILE = new MentorRunnerProfile();
 
     private final PiRuntimeFactory runtimeFactory;
     private final MentorAgentProperties mentorProperties;
@@ -70,7 +77,7 @@ public class MentorPiAdapter {
             null,
             true,
             llmConfig.timeoutSeconds(),
-            mentorProperties.runnerScript(),
+            PROFILE,
             extraInputs,
             "" /* no precompute step — mentor analytics arrive as aspect JSON */
         );

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorRunnerProfile.java
@@ -1,0 +1,74 @@
+package de.tum.in.www1.hephaestus.agent.mentor;
+
+import de.tum.in.www1.hephaestus.agent.runtime.PiRunnerProfile;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runner profile for the long-lived mentor chat agent.
+ *
+ * <p><b>V8 flags:</b>
+ * <ul>
+ *   <li>{@code --max-old-space-size=256} — cap V8 old-gen at 256 MB. Empirically the mentor
+ *       runtime sits at ~100 MB V8 heap; 2.5× headroom defends against a leaky session OOM-ing
+ *       the host instead of itself. Default ~1.4 GB on 64-bit lets one bad runner take the host
+ *       down.</li>
+ *   <li>{@code --no-warnings} — keeps stderr clean for ops grep against our own log prefix.</li>
+ *   <li>{@code --expose-gc} — exposes {@code global.gc()} so the runner can force a post-turn
+ *       compaction in {@code pi-mentor-runner.mjs:forwardEvent}. The flag costs nothing on its
+ *       own and is only effective when {@code global.gc()} is actually called.</li>
+ * </ul>
+ *
+ * <p>Note: {@code --disable-source-maps} was removed in Node 22 (source maps are off by default;
+ * the flag itself no longer exists and causes {@code bad option} exit 9). Do not re-add.
+ *
+ * <p>We deliberately removed {@code --max-semi-space-size=16} and {@code UV_THREADPOOL_SIZE=2}
+ * from prior revisions: the former matches the Node 22 default on 64-bit (so it was a no-op),
+ * and the latter risks serialising libuv fs/crypto bursts.
+ *
+ * <p><b>Per-process env:</b> {@code LD_PRELOAD=libjemalloc.so.2} +
+ * {@code MALLOC_CONF=background_thread:true,narenas:2,dirty_decay_ms:30000,muzzy_decay_ms:30000}.
+ * Mentor's long-lived heap benefits from jemalloc's page-decay tuning; precompute's bursty
+ * allocations don't. {@code background_thread:true} runs jemalloc's page-decay sweep on a
+ * dedicated thread — without it the mutator must re-enter the allocator to trigger decay, which
+ * a long-idle Node loop rarely does (cf. jemalloc TUNING.md). Decay window 30 s matches
+ * jemalloc upstream's "long-lived process" recommendation.
+ *
+ * <p>The path matches the {@code /usr/local/lib/libjemalloc.so.2} symlink created by the Pi
+ * Dockerfile ({@code docker/agents/pi/Dockerfile}). The symlink is per-arch by design; the env
+ * literal here is arch-independent.
+ */
+public final class MentorRunnerProfile implements PiRunnerProfile {
+
+    /** Filename of the mentor runner under {@code resources/agent/}. */
+    public static final String SCRIPT = "pi-mentor-runner.mjs";
+
+    private static final List<String> FLAGS = List.of("--max-old-space-size=256", "--no-warnings", "--expose-gc");
+
+    private static final Map<String, String> ENV;
+
+    static {
+        // LinkedHashMap preserves declaration order — the assembled command line is the same
+        // every build, which simplifies cross-build diff inspection.
+        LinkedHashMap<String, String> env = new LinkedHashMap<>();
+        env.put("LD_PRELOAD", "/usr/local/lib/libjemalloc.so.2");
+        env.put("MALLOC_CONF", "background_thread:true,narenas:2,dirty_decay_ms:30000,muzzy_decay_ms:30000");
+        ENV = Map.copyOf(env);
+    }
+
+    @Override
+    public String runnerScript() {
+        return SCRIPT;
+    }
+
+    @Override
+    public List<String> nodeFlags() {
+        return FLAGS;
+    }
+
+    @Override
+    public Map<String, String> additionalEnv() {
+        return ENV;
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorRunnerProfile.java
@@ -1,43 +1,24 @@
 package de.tum.in.www1.hephaestus.agent.mentor;
 
 import de.tum.in.www1.hephaestus.agent.runtime.PiRunnerProfile;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Runner profile for the long-lived mentor chat agent.
+ * Runner profile for the long-lived mentor chat agent. Tuning is set for ~100 MB V8 heap floor
+ * and predictable page-decay over hours-long sessions.
  *
- * <p><b>V8 flags:</b>
- * <ul>
- *   <li>{@code --max-old-space-size=256} — cap V8 old-gen at 256 MB. Empirically the mentor
- *       runtime sits at ~100 MB V8 heap; 2.5× headroom defends against a leaky session OOM-ing
- *       the host instead of itself. Default ~1.4 GB on 64-bit lets one bad runner take the host
- *       down.</li>
- *   <li>{@code --no-warnings} — keeps stderr clean for ops grep against our own log prefix.</li>
- *   <li>{@code --expose-gc} — exposes {@code global.gc()} so the runner can force a post-turn
- *       compaction in {@code pi-mentor-runner.mjs:forwardEvent}. The flag costs nothing on its
- *       own and is only effective when {@code global.gc()} is actually called.</li>
- * </ul>
+ * <p>V8 flags: {@code --max-old-space-size=256} caps the heap so a leaky session OOMs itself
+ * (default ~1.4 GB lets one bad runner take the host); {@code --expose-gc} backs
+ * {@code pi-mentor-runner.mjs}'s post-turn compaction call to {@code global.gc()}.
  *
- * <p>Note: {@code --disable-source-maps} was removed in Node 22 (source maps are off by default;
- * the flag itself no longer exists and causes {@code bad option} exit 9). Do not re-add.
- *
- * <p>We deliberately removed {@code --max-semi-space-size=16} and {@code UV_THREADPOOL_SIZE=2}
- * from prior revisions: the former matches the Node 22 default on 64-bit (so it was a no-op),
- * and the latter risks serialising libuv fs/crypto bursts.
- *
- * <p><b>Per-process env:</b> {@code LD_PRELOAD=libjemalloc.so.2} +
- * {@code MALLOC_CONF=background_thread:true,narenas:2,dirty_decay_ms:30000,muzzy_decay_ms:30000}.
- * Mentor's long-lived heap benefits from jemalloc's page-decay tuning; precompute's bursty
- * allocations don't. {@code background_thread:true} runs jemalloc's page-decay sweep on a
- * dedicated thread — without it the mutator must re-enter the allocator to trigger decay, which
- * a long-idle Node loop rarely does (cf. jemalloc TUNING.md). Decay window 30 s matches
- * jemalloc upstream's "long-lived process" recommendation.
- *
- * <p>The path matches the {@code /usr/local/lib/libjemalloc.so.2} symlink created by the Pi
- * Dockerfile ({@code docker/agents/pi/Dockerfile}). The symlink is per-arch by design; the env
- * literal here is arch-independent.
+ * <p>Per-process env preloads jemalloc and tunes page decay because mentor's long-lived heap
+ * benefits from background-thread decay sweeps (cf. jemalloc TUNING.md "long-lived process");
+ * practice's bursty allocations don't, hence kernel-scoped LD_PRELOAD on the node invocation
+ * only. {@code /usr/local/lib/libjemalloc.so.2} is the per-arch symlink the Pi Dockerfile
+ * creates so this literal stays arch-independent.
  */
 public final class MentorRunnerProfile implements PiRunnerProfile {
 
@@ -46,15 +27,15 @@ public final class MentorRunnerProfile implements PiRunnerProfile {
 
     private static final List<String> FLAGS = List.of("--max-old-space-size=256", "--no-warnings", "--expose-gc");
 
+    // Iteration order is load-bearing: renderNodeEnv emits `KEY=value` pairs in iteration order,
+    // so a non-deterministic Map yields a non-deterministic command line across builds.
     private static final Map<String, String> ENV;
 
     static {
-        // LinkedHashMap preserves declaration order — the assembled command line is the same
-        // every build, which simplifies cross-build diff inspection.
         LinkedHashMap<String, String> env = new LinkedHashMap<>();
         env.put("LD_PRELOAD", "/usr/local/lib/libjemalloc.so.2");
         env.put("MALLOC_CONF", "background_thread:true,narenas:2,dirty_decay_ms:30000,muzzy_decay_ms:30000");
-        ENV = Map.copyOf(env);
+        ENV = Collections.unmodifiableMap(env);
     }
 
     @Override

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/MentorRunnerProfile.java
@@ -22,7 +22,6 @@ import java.util.Map;
  */
 public final class MentorRunnerProfile implements PiRunnerProfile {
 
-    /** Filename of the mentor runner under {@code resources/agent/}. */
     public static final String SCRIPT = "pi-mentor-runner.mjs";
 
     private static final List<String> FLAGS = List.of("--max-old-space-size=256", "--no-warnings", "--expose-gc");

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticePiAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticePiAdapter.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class PracticePiAdapter {
 
+    private static final PracticeRunnerProfile PROFILE = new PracticeRunnerProfile();
+
     private final PiRuntimeFactory runtimeFactory;
     private final PiResultParser resultParser;
     private final PiAgentProperties properties;
@@ -43,7 +45,7 @@ public class PracticePiAdapter {
                 request.jobToken(),
                 request.allowInternet(),
                 request.timeoutSeconds(),
-                properties.runnerScript(),
+                PROFILE,
                 Map.of(),
                 buildPrecomputeStep()
             )

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -11,7 +11,6 @@ import java.util.Map;
  */
 public final class PracticeRunnerProfile implements PiRunnerProfile {
 
-    /** Filename of the practice runner under {@code resources/agent/}. */
     public static final String SCRIPT = "pi-runner.mjs";
 
     private static final List<String> FLAGS = List.of("--no-warnings");

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -5,16 +5,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Runner profile for the one-shot practice-review agent.
- *
- * <p><b>V8 flags:</b> only {@code --no-warnings}. We do NOT cap the heap because practice
- * routinely parses 30-file diff patches that allocate transiently; a 256 MB cap would convert
- * worst-case-input OOMs from "rare" to "regular." We do NOT {@code --expose-gc} because the
- * practice runner never calls {@code global.gc()} and exposing the global is a foot-gun.
- *
- * <p><b>Per-process env:</b> empty. Practice's bursty allocations don't benefit from jemalloc's
- * page-decay tuning, and forcing {@code LD_PRELOAD} on a short-lived process is unmeasured
- * overhead.
+ * Runner profile for the one-shot practice-review agent. Conservative tuning: no heap cap (30-file
+ * diff patches allocate transiently and 256 MB would convert worst-case OOMs from rare to regular)
+ * and no jemalloc LD_PRELOAD (page-decay tuning helps long-lived heaps, not bursty one-shots).
  */
 public final class PracticeRunnerProfile implements PiRunnerProfile {
 

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -1,0 +1,40 @@
+package de.tum.in.www1.hephaestus.agent.practice;
+
+import de.tum.in.www1.hephaestus.agent.runtime.PiRunnerProfile;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runner profile for the one-shot practice-review agent.
+ *
+ * <p><b>V8 flags:</b> only {@code --no-warnings}. We do NOT cap the heap because practice
+ * routinely parses 30-file diff patches that allocate transiently; a 256 MB cap would convert
+ * worst-case-input OOMs from "rare" to "regular." We do NOT {@code --expose-gc} because the
+ * practice runner never calls {@code global.gc()} and exposing the global is a foot-gun.
+ *
+ * <p><b>Per-process env:</b> empty. Practice's bursty allocations don't benefit from jemalloc's
+ * page-decay tuning, and forcing {@code LD_PRELOAD} on a short-lived process is unmeasured
+ * overhead.
+ */
+public final class PracticeRunnerProfile implements PiRunnerProfile {
+
+    /** Filename of the practice runner under {@code resources/agent/}. */
+    public static final String SCRIPT = "pi-runner.mjs";
+
+    private static final List<String> FLAGS = List.of("--no-warnings");
+
+    @Override
+    public String runnerScript() {
+        return SCRIPT;
+    }
+
+    @Override
+    public List<String> nodeFlags() {
+        return FLAGS;
+    }
+
+    @Override
+    public Map<String, String> additionalEnv() {
+        return Map.of();
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiAgentProperties.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiAgentProperties.java
@@ -6,11 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;
 
-/**
- * The runner script name is owned by {@code PracticeRunnerProfile} — operator overrides for it
- * were never used in practice and risked drifting from the V8 flags / per-process env that the
- * kernel pairs with the script. Bumping the runner is a code change.
- */
+/** Configuration for the Pi agent container image and pull policy. */
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.agent.pi")
 public record PiAgentProperties(

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiAgentProperties.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiAgentProperties.java
@@ -6,10 +6,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.validation.annotation.Validated;
 
+/**
+ * The runner script name is owned by {@code PracticeRunnerProfile} — operator overrides for it
+ * were never used in practice and risked drifting from the V8 flags / per-process env that the
+ * kernel pairs with the script. Bumping the runner is a code change.
+ */
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.agent.pi")
 public record PiAgentProperties(
     @DefaultValue("ghcr.io/ls1intum/hephaestus/agent-pi:latest") @NotBlank String image,
-    @DefaultValue("pi-runner.mjs") @NotBlank String runnerScript,
     @DefaultValue("IF_NOT_PRESENT") ImagePullPolicy pullPolicy
 ) {}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpec.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpec.java
@@ -10,28 +10,14 @@ import org.springframework.lang.Nullable;
  * Inputs for {@link PiRuntimeFactory#build(PiPlanSpec)}. Validation lives in the compact
  * constructor — there is no builder; callers construct positionally.
  *
- * @param provider        LLM provider; required
- * @param credentialMode  PROXY (job-token), API_KEY, or OAUTH; required
- * @param credential      API key in API_KEY/OAUTH modes; must be non-blank in those modes
- * @param modelName       optional model override
- * @param baseUrl         optional OpenAI-compatible base URL override. Exported as
- *                        {@code OPENAI_BASE_URL} / {@code ANTHROPIC_BASE_URL} only in API_KEY/OAUTH
- *                        modes — PROXY mode resolves its base URL from the sandbox-injected
- *                        {@code $LLM_PROXY_URL}, so a baseUrl here would be silently shadowed.
- *                        Production runs leave this {@code null}; live tests use it to point Pi at
- *                        a non-default OpenAI-compatible endpoint (e.g. the TUM gateway).
- * @param jobToken        PROXY mode job token; must be non-blank in PROXY mode
- * @param allowInternet   PROXY mode internet flag; ignored otherwise (always true)
- * @param timeoutSeconds  total sandbox timeout (must be {@code > TIMEOUT_BUFFER_SECONDS})
- * @param runnerProfile   per-runner-kind strategy (script filename, V8 flags, per-process env);
- *                        the kernel reads three properties off it instead of dispatching by
- *                        filename match
+ * @param baseUrl         OpenAI-compatible base URL override. Exported as {@code OPENAI_BASE_URL}
+ *                        / {@code ANTHROPIC_BASE_URL} only in API_KEY/OAUTH modes — PROXY mode
+ *                        resolves its base URL from the sandbox-injected {@code $LLM_PROXY_URL},
+ *                        so a baseUrl here would be silently shadowed.
  * @param extraInputs     additional workspace files keyed by relative path. Each key MUST appear
  *                        in {@link WorkspaceAbi#allowedExtraInputPaths()} or be prefixed by one
- *                        of {@link WorkspaceAbi#allowedExtraInputPrefixes()} — the validation
- *                        prevents adapters from writing to arbitrary workspace paths and forces
- *                        new mount points to be declared on {@link WorkspaceAbi}
- * @param precomputeStep  shell fragment ending in {@code " && "} (or empty)
+ *                        of {@link WorkspaceAbi#allowedExtraInputPrefixes()}.
+ * @param precomputeStep  shell fragment ending in {@code " && "} (or empty).
  */
 public record PiPlanSpec(
     LlmProvider provider,
@@ -74,22 +60,12 @@ public record PiPlanSpec(
             }
         }
         extraInputs = extraInputs != null ? Map.copyOf(extraInputs) : Map.of();
-        // Fail-fast at construction: every extraInputs key must be a recognised workspace path.
-        // Adapters caught writing to arbitrary paths surface here at boot/test time instead of
-        // silently overwriting a future workspace mount-point.
+        // Fail-fast: adapters writing to undeclared workspace paths surface here at test/boot time
+        // instead of silently overwriting a future mount-point.
         for (String path : extraInputs.keySet()) {
-            if (path == null) {
-                throw new IllegalArgumentException("extraInputs keys must not be null");
-            }
-            boolean ok = WorkspaceAbi.allowedExtraInputPaths().contains(path);
-            if (!ok) {
-                for (String prefix : WorkspaceAbi.allowedExtraInputPrefixes()) {
-                    if (path.startsWith(prefix)) {
-                        ok = true;
-                        break;
-                    }
-                }
-            }
+            boolean ok =
+                WorkspaceAbi.allowedExtraInputPaths().contains(path) ||
+                WorkspaceAbi.allowedExtraInputPrefixes().stream().anyMatch(path::startsWith);
             if (!ok) {
                 throw new IllegalArgumentException(
                     "extraInputs path '" +

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpec.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpec.java
@@ -8,16 +8,11 @@ import org.springframework.lang.Nullable;
 
 /**
  * Inputs for {@link PiRuntimeFactory#build(PiPlanSpec)}. Validation lives in the compact
- * constructor — there is no builder; callers construct positionally.
+ * constructor; callers construct positionally.
  *
- * @param baseUrl         OpenAI-compatible base URL override. Exported as {@code OPENAI_BASE_URL}
- *                        / {@code ANTHROPIC_BASE_URL} only in API_KEY/OAUTH modes — PROXY mode
- *                        resolves its base URL from the sandbox-injected {@code $LLM_PROXY_URL},
- *                        so a baseUrl here would be silently shadowed.
- * @param extraInputs     additional workspace files keyed by relative path. Each key MUST appear
- *                        in {@link WorkspaceAbi#allowedExtraInputPaths()} or be prefixed by one
- *                        of {@link WorkspaceAbi#allowedExtraInputPrefixes()}.
- * @param precomputeStep  shell fragment ending in {@code " && "} (or empty).
+ * <p><b>baseUrl trap:</b> exported as {@code OPENAI_BASE_URL} / {@code ANTHROPIC_BASE_URL} only in
+ * API_KEY/OAUTH modes — PROXY mode resolves its base URL from the sandbox-injected
+ * {@code $LLM_PROXY_URL}, so a baseUrl here would be silently shadowed.
  */
 public record PiPlanSpec(
     LlmProvider provider,
@@ -60,8 +55,6 @@ public record PiPlanSpec(
             }
         }
         extraInputs = extraInputs != null ? Map.copyOf(extraInputs) : Map.of();
-        // Fail-fast: adapters writing to undeclared workspace paths surface here at test/boot time
-        // instead of silently overwriting a future mount-point.
         for (String path : extraInputs.keySet()) {
             boolean ok =
                 WorkspaceAbi.allowedExtraInputPaths().contains(path) ||

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpec.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpec.java
@@ -23,8 +23,14 @@ import org.springframework.lang.Nullable;
  * @param jobToken        PROXY mode job token; must be non-blank in PROXY mode
  * @param allowInternet   PROXY mode internet flag; ignored otherwise (always true)
  * @param timeoutSeconds  total sandbox timeout (must be {@code > TIMEOUT_BUFFER_SECONDS})
- * @param runnerScript    filename of the Pi runner under {@code resources/agent/}; required
- * @param extraInputs     additional workspace files keyed by relative path (e.g. {@code task.json})
+ * @param runnerProfile   per-runner-kind strategy (script filename, V8 flags, per-process env);
+ *                        the kernel reads three properties off it instead of dispatching by
+ *                        filename match
+ * @param extraInputs     additional workspace files keyed by relative path. Each key MUST appear
+ *                        in {@link WorkspaceAbi#allowedExtraInputPaths()} or be prefixed by one
+ *                        of {@link WorkspaceAbi#allowedExtraInputPrefixes()} — the validation
+ *                        prevents adapters from writing to arbitrary workspace paths and forces
+ *                        new mount points to be declared on {@link WorkspaceAbi}
  * @param precomputeStep  shell fragment ending in {@code " && "} (or empty)
  */
 public record PiPlanSpec(
@@ -36,16 +42,16 @@ public record PiPlanSpec(
     @Nullable String jobToken,
     boolean allowInternet,
     int timeoutSeconds,
-    String runnerScript,
+    PiRunnerProfile runnerProfile,
     Map<String, byte[]> extraInputs,
     String precomputeStep
 ) {
     public PiPlanSpec {
         Objects.requireNonNull(provider, "provider");
         Objects.requireNonNull(credentialMode, "credentialMode");
-        Objects.requireNonNull(runnerScript, "runnerScript");
-        if (runnerScript.isBlank()) {
-            throw new IllegalArgumentException("runnerScript must not be blank");
+        Objects.requireNonNull(runnerProfile, "runnerProfile");
+        if (runnerProfile.runnerScript() == null || runnerProfile.runnerScript().isBlank()) {
+            throw new IllegalArgumentException("runnerProfile.runnerScript() must not be blank");
         }
         if (timeoutSeconds <= PiRuntimeFactory.TIMEOUT_BUFFER_SECONDS) {
             throw new IllegalArgumentException(
@@ -68,6 +74,32 @@ public record PiPlanSpec(
             }
         }
         extraInputs = extraInputs != null ? Map.copyOf(extraInputs) : Map.of();
+        // Fail-fast at construction: every extraInputs key must be a recognised workspace path.
+        // Adapters caught writing to arbitrary paths surface here at boot/test time instead of
+        // silently overwriting a future workspace mount-point.
+        for (String path : extraInputs.keySet()) {
+            if (path == null) {
+                throw new IllegalArgumentException("extraInputs keys must not be null");
+            }
+            boolean ok = WorkspaceAbi.allowedExtraInputPaths().contains(path);
+            if (!ok) {
+                for (String prefix : WorkspaceAbi.allowedExtraInputPrefixes()) {
+                    if (path.startsWith(prefix)) {
+                        ok = true;
+                        break;
+                    }
+                }
+            }
+            if (!ok) {
+                throw new IllegalArgumentException(
+                    "extraInputs path '" +
+                        path +
+                        "' is not a recognised workspace path: must appear in " +
+                        "WorkspaceAbi.allowedExtraInputPaths() or be prefixed by one of " +
+                        WorkspaceAbi.allowedExtraInputPrefixes()
+                );
+            }
+        }
         precomputeStep = precomputeStep != null ? precomputeStep : "";
     }
 }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRunnerProfile.java
@@ -1,0 +1,51 @@
+package de.tum.in.www1.hephaestus.agent.runtime;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Per-runner-kind strategy resolved at {@link PiPlanSpec} construction time.
+ *
+ * <p>Each adapter (practice, mentor) owns its own implementation in the adjacent domain package
+ * and passes it to {@link PiRuntimeFactory#build(PiPlanSpec)}. This replaces the dispatch
+ * branches that previously lived inside the kernel ({@code MENTOR_RUNNER_SCRIPT} filename match,
+ * {@code nodeFlagsFor}, {@code nodeEnvFor}). The kernel reads three properties off the profile;
+ * adding a third runner kind no longer requires editing the kernel.
+ *
+ * <p><b>Note on sealing:</b> not declared {@code sealed}. A {@code sealed} interface with
+ * {@code permits PracticeRunnerProfile, MentorRunnerProfile} would force this kernel type to
+ * import its domain implementations — exactly the {@code agent.runtime ↛ agent.practice /
+ * agent.mentor} dependency the architecture test forbids. The boundary is instead enforced by a
+ * dedicated arch rule (see {@code AgentRuntimeBoundaryTest}), mirroring the established
+ * {@code ContentProvider} pattern.
+ *
+ * <p><b>Note on {@code shouldRegisterHephaestusProvider}:</b> stayed a kernel-side spec helper —
+ * it's a function of {@link PiPlanSpec#credentialMode()} / {@link PiPlanSpec#provider()} /
+ * {@link PiPlanSpec#baseUrl()}, not the runner kind. Both practice and mentor compute it
+ * identically today. Pushing it into the profile would force domain modules to import
+ * {@code CredentialMode} + {@code LlmProvider} only to defer to the kernel logic.
+ *
+ * <p>Profiles are pure value objects. They MUST NOT capture spec-level state (provider,
+ * credentials, baseUrl). Spec-dependent decisions stay in the kernel and read from the spec.
+ */
+public interface PiRunnerProfile {
+    /**
+     * Filename of the runner script under {@code resources/agent/} the kernel copies into the
+     * container workspace at {@link WorkspaceAbi#RUNNER_SCRIPT_FILENAME}.
+     */
+    String runnerScript();
+
+    /**
+     * V8 CLI flags applied to the {@code node} invocation. Returned without a trailing space; the
+     * kernel joins entries with {@code " "} and appends a trailing {@code " "} when non-empty.
+     */
+    List<String> nodeFlags();
+
+    /**
+     * Per-process env fragment scoped to the {@code node} invocation only — the kernel emits
+     * these as {@code KEY=value} pairs immediately preceding the {@code node} keyword. NOT
+     * applied to other binaries in the same shell ({@code bun}, {@code git}, {@code jq}) and
+     * NOT injected into the image-wide container environment.
+     */
+    Map<String, String> additionalEnv();
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRunnerProfile.java
@@ -4,28 +4,16 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Per-runner-kind strategy resolved at {@link PiPlanSpec} construction time.
+ * Per-runner-kind strategy resolved at {@link PiPlanSpec} construction time. Each adapter owns
+ * its implementation in the adjacent domain package and passes it to
+ * {@link PiRuntimeFactory#build(PiPlanSpec)}.
  *
- * <p>Each adapter (practice, mentor) owns its own implementation in the adjacent domain package
- * and passes it to {@link PiRuntimeFactory#build(PiPlanSpec)}. This replaces the dispatch
- * branches that previously lived inside the kernel ({@code MENTOR_RUNNER_SCRIPT} filename match,
- * {@code nodeFlagsFor}, {@code nodeEnvFor}). The kernel reads three properties off the profile;
- * adding a third runner kind no longer requires editing the kernel.
+ * <p>Not declared {@code sealed}: a {@code permits} list would force this kernel type to import
+ * its domain implementations, violating the {@code agent.runtime ↛ agent.{practice,mentor}}
+ * boundary. The boundary is enforced by {@code AgentRuntimeBoundaryTest} instead — same pattern
+ * as the existing {@code ContentProvider} SPI.
  *
- * <p><b>Note on sealing:</b> not declared {@code sealed}. A {@code sealed} interface with
- * {@code permits PracticeRunnerProfile, MentorRunnerProfile} would force this kernel type to
- * import its domain implementations — exactly the {@code agent.runtime ↛ agent.practice /
- * agent.mentor} dependency the architecture test forbids. The boundary is instead enforced by a
- * dedicated arch rule (see {@code AgentRuntimeBoundaryTest}), mirroring the established
- * {@code ContentProvider} pattern.
- *
- * <p><b>Note on {@code shouldRegisterHephaestusProvider}:</b> stayed a kernel-side spec helper —
- * it's a function of {@link PiPlanSpec#credentialMode()} / {@link PiPlanSpec#provider()} /
- * {@link PiPlanSpec#baseUrl()}, not the runner kind. Both practice and mentor compute it
- * identically today. Pushing it into the profile would force domain modules to import
- * {@code CredentialMode} + {@code LlmProvider} only to defer to the kernel logic.
- *
- * <p>Profiles are pure value objects. They MUST NOT capture spec-level state (provider,
+ * <p>Profiles are pure value objects: they MUST NOT capture spec-level state (provider,
  * credentials, baseUrl). Spec-dependent decisions stay in the kernel and read from the spec.
  */
 public interface PiRunnerProfile {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRunnerProfile.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRunnerProfile.java
@@ -4,36 +4,17 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Per-runner-kind strategy resolved at {@link PiPlanSpec} construction time. Each adapter owns
- * its implementation in the adjacent domain package and passes it to
- * {@link PiRuntimeFactory#build(PiPlanSpec)}.
- *
- * <p>Not declared {@code sealed}: a {@code permits} list would force this kernel type to import
- * its domain implementations, violating the {@code agent.runtime ↛ agent.{practice,mentor}}
- * boundary. The boundary is enforced by {@code AgentRuntimeBoundaryTest} instead — same pattern
- * as the existing {@code ContentProvider} SPI.
- *
- * <p>Profiles are pure value objects: they MUST NOT capture spec-level state (provider,
- * credentials, baseUrl). Spec-dependent decisions stay in the kernel and read from the spec.
+ * Per-runner-kind strategy. Each adapter owns its implementation in the adjacent domain package
+ * and passes it to {@link PiRuntimeFactory#build(PiPlanSpec)}. Profiles are pure value objects —
+ * they MUST NOT capture spec-level state (provider, credentials, baseUrl).
  */
 public interface PiRunnerProfile {
-    /**
-     * Filename of the runner script under {@code resources/agent/} the kernel copies into the
-     * container workspace at {@link WorkspaceAbi#RUNNER_SCRIPT_FILENAME}.
-     */
+    /** Runner script filename under {@code resources/agent/}. */
     String runnerScript();
 
-    /**
-     * V8 CLI flags applied to the {@code node} invocation. Returned without a trailing space; the
-     * kernel joins entries with {@code " "} and appends a trailing {@code " "} when non-empty.
-     */
+    /** V8 flags for the {@code node} invocation. */
     List<String> nodeFlags();
 
-    /**
-     * Per-process env fragment scoped to the {@code node} invocation only — the kernel emits
-     * these as {@code KEY=value} pairs immediately preceding the {@code node} keyword. NOT
-     * applied to other binaries in the same shell ({@code bun}, {@code git}, {@code jq}) and
-     * NOT injected into the image-wide container environment.
-     */
+    /** {@code KEY=value} pairs scoped to the {@code node} invocation only — not image-wide ENV. */
     Map<String, String> additionalEnv();
 }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -75,7 +75,7 @@ public class PiRuntimeFactory {
             buildPiSettingsJson(spec.provider(), spec.modelName(), useCustomProvider)
         );
         inputFiles.put(WorkspaceAbi.ORCHESTRATOR_PATH, loadClasspathResource("pi-orchestrator.md"));
-        inputFiles.put(WorkspaceAbi.RUNNER_SCRIPT_FILENAME, loadClasspathResource(spec.runnerScript()));
+        inputFiles.put(WorkspaceAbi.RUNNER_SCRIPT_FILENAME, loadClasspathResource(spec.runnerProfile().runnerScript()));
         inputFiles.putAll(spec.extraInputs());
 
         long agentTimeoutMs = Math.max(60_000L, (long) (spec.timeoutSeconds() - TIMEOUT_BUFFER_SECONDS) * 1000);
@@ -100,6 +100,15 @@ public class PiRuntimeFactory {
         }
 
         String workspaceRoot = WorkspaceAbi.WORKSPACE_ROOT;
+
+        // Per-agent Node flags + envs come from the spec's runner profile. The kernel knows
+        // nothing about practice vs mentor — the profile knows nothing about the spec. This was
+        // previously a runner-script filename dispatch inside the kernel, forcing every new
+        // runner kind to edit four switches in this file.
+        PiRunnerProfile profile = spec.runnerProfile();
+        String nodeFlagsFragment = renderNodeFlags(profile.nodeFlags());
+        String nodeEnvFragment = renderNodeEnv(profile.additionalEnv());
+
         String command =
             authSetup +
             "mkdir -p " +
@@ -110,12 +119,9 @@ public class PiRuntimeFactory {
             workspaceRoot +
             "/node_modules && " +
             spec.precomputeStep() +
-            // Per-agent Node flags + envs. We deliberately do NOT apply the same flags to both
-            // the long-lived mentor runner and the one-shot practice runner — see the rationale
-            // in {@link #nodeFlagsFor(String)} and {@link #nodeEnvFor(String)}.
-            nodeEnvFor(spec.runnerScript()) +
+            nodeEnvFragment +
             "node " +
-            nodeFlagsFor(spec.runnerScript()) +
+            nodeFlagsFragment +
             workspaceRoot +
             "/" +
             WorkspaceAbi.RUNNER_SCRIPT_FILENAME;
@@ -137,70 +143,36 @@ public class PiRuntimeFactory {
         return new PiPlan(List.of("sh", "-c", command), Map.copyOf(env), Map.copyOf(inputFiles), networkPolicy);
     }
 
-    /** Mentor uses a long-lived runner; the script filename is the dispatch key. */
-    static final String MENTOR_RUNNER_SCRIPT = "pi-mentor-runner.mjs";
-
     /**
-     * Per-runner Node CLI flags. We split mentor (long-lived JSONL pump, 50+ concurrent containers
-     * on a single host) from practice (one-shot review, reads large diffs, runs precompute).
-     *
-     * <p><b>Mentor flags:</b>
-     * <ul>
-     *   <li>{@code --max-old-space-size=256} — cap V8 old-gen at 256 MB. Empirically the mentor
-     *       runtime sits at ~100 MB V8 heap; 2.5× headroom defends against a leaky session OOM-ing
-     *       the host instead of itself. Default ~1.4 GB on 64-bit lets one bad runner take the
-     *       host down.</li>
-     *   <li>{@code --no-warnings} — keeps stderr clean for ops grep against our own log prefix.</li>
-     *   <li>{@code --expose-gc} — exposes {@code global.gc()} so the runner can force a post-turn
-     *       compaction in {@code pi-mentor-runner.mjs:forwardEvent}. The flag costs nothing on its
-     *       own and is only effective when {@code global.gc()} is actually called.</li>
-     * </ul>
-     *
-     * <p><b>Practice flags:</b> only {@code --no-warnings}. We do NOT cap the heap because practice
-     * routinely parses 30-file diff patches that allocate transiently; a 256 MB cap would convert
-     * worst-case-input OOMs from "rare" to "regular." We do NOT {@code --expose-gc} because the
-     * practice runner never calls {@code global.gc()} and exposing the global is a foot-gun.
-     *
-     * <p>Note: {@code --disable-source-maps} was removed — the flag was dropped in Node 22 (source
-     * maps are off by default; the flag itself no longer exists and causes {@code bad option} exit 9).
-     *
-     * <p>We deliberately removed {@code --max-semi-space-size=16} and {@code UV_THREADPOOL_SIZE=2}
-     * from prior revisions: the former matches the Node 22 default on 64-bit (so it was a no-op),
-     * and the latter risks serialising libuv fs/crypto bursts (notably the practice runner's
-     * git tool calls) for an unmeasured ~MB-scale RSS reservation reduction.
+     * Render the profile's node flags as a trailing-space-terminated fragment so the kernel can
+     * interpolate without conditional whitespace. Empty profiles render to the empty string.
      */
-    private static String nodeFlagsFor(String runnerScript) {
-        if (MENTOR_RUNNER_SCRIPT.equals(runnerScript)) {
-            return "--max-old-space-size=256 --no-warnings --expose-gc ";
+    private static String renderNodeFlags(List<String> flags) {
+        if (flags == null || flags.isEmpty()) {
+            return "";
         }
-        return "--no-warnings ";
+        return String.join(" ", flags) + " ";
     }
 
     /**
-     * Per-runner environment fragments injected as {@code VAR=value} pairs into the shell
-     * {@code node …} invocation. This scopes {@code LD_PRELOAD=libjemalloc.so.2} +
-     * {@code MALLOC_CONF=…} to the Node process only — NOT image-wide ENV — so the precompute
-     * runner ({@code bun}), {@code git}, {@code jq}, and short-lived tool invocations all keep
-     * their default glibc allocators. Mentor's long-lived heap benefits from jemalloc's
-     * page-decay tuning; precompute's bursty allocations don't.
+     * Render the profile's per-process env fragment as {@code KEY=value} pairs. Each pair is
+     * trailing-space terminated; the assembled fragment is emitted IMMEDIATELY preceding the
+     * {@code node} keyword so the shell scopes the env to the node invocation only — NOT image-
+     * wide ENV. Other binaries in the same shell ({@code bun}, {@code git}) keep their default
+     * environment.
      *
-     * <p>The path matches the {@code /usr/local/lib/libjemalloc.so.2} symlink created by the Pi
-     * Dockerfile (see {@code docker/agents/pi/Dockerfile}). The symlink is per-arch by design;
-     * the env literal here is arch-independent.
+     * <p>Values are NOT shell-quoted because no profile today emits values containing whitespace
+     * or shell metacharacters; a future profile that needs to MUST add quoting here.
      */
-    private static String nodeEnvFor(String runnerScript) {
-        if (MENTOR_RUNNER_SCRIPT.equals(runnerScript)) {
-            // `background_thread:true` runs jemalloc's page-decay sweep on a dedicated thread —
-            // without it the mutator must re-enter the allocator to trigger decay, which a
-            // long-idle Node loop rarely does (cf. jemalloc TUNING.md). Decay window 30s
-            // matches jemalloc upstream's "long-lived process" recommendation; 10s was
-            // aggressive without buying anything once background_thread is on.
-            return (
-                "LD_PRELOAD=/usr/local/lib/libjemalloc.so.2 " +
-                "MALLOC_CONF=background_thread:true,narenas:2,dirty_decay_ms:30000,muzzy_decay_ms:30000 "
-            );
+    private static String renderNodeEnv(Map<String, String> env) {
+        if (env == null || env.isEmpty()) {
+            return "";
         }
-        return "";
+        StringBuilder b = new StringBuilder();
+        for (Map.Entry<String, String> e : env.entrySet()) {
+            b.append(e.getKey()).append('=').append(e.getValue()).append(' ');
+        }
+        return b.toString();
     }
 
     /**

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -30,13 +30,11 @@ public class PiRuntimeFactory {
 
     private static final Logger log = LoggerFactory.getLogger(PiRuntimeFactory.class);
 
-    /** Default workspace output directory inside the container — see {@link WorkspaceAbi#OUTPUT_PATH}. */
     public static final String OUTPUT_PATH = WorkspaceAbi.OUTPUT_PATH;
 
-    /** Reserved for retries + container cleanup before the sandbox kills the runner. */
+    /** Grace window before the sandbox hard-kills the runner — must fire before that deadline. */
     public static final int TIMEOUT_BUFFER_SECONDS = 60;
 
-    /** Classpath prefix for all Pi-related resources ({@code pi-runner.mjs}, {@code pi-orchestrator.md}). */
     static final String AGENT_RESOURCE_PREFIX = "agent/";
 
     private final ObjectMapper objectMapper;
@@ -58,10 +56,6 @@ public class PiRuntimeFactory {
             env
         );
 
-        // The custom-provider extension is only emitted when the caller pinned a baseUrl on a
-        // non-Azure provider in API_KEY/OAUTH mode (production keeps baseUrl null → built-in
-        // provider; live tests set it → custom hephaestus provider). PROXY mode never needs the
-        // extension because the proxy is already on the standard OPENAI_BASE_URL.
         boolean useCustomProvider = shouldRegisterHephaestusProvider(spec);
         if (useCustomProvider) {
             inputFiles.put(
@@ -81,21 +75,17 @@ public class PiRuntimeFactory {
         long agentTimeoutMs = Math.max(60_000L, (long) (spec.timeoutSeconds() - TIMEOUT_BUFFER_SECONDS) * 1000);
         env.put("AGENT_BUDGET_MS", Long.toString(agentTimeoutMs));
 
-        // TMPDIR resolves under the mandatory /home/agent/.local tmpfs (see ContainerSecurityPolicy);
-        // Pi runs as uid 1000 and the Dockerfile pre-creates and chowns /home/agent so $HOME writes work.
         env.put("HOME", "/home/agent");
         env.put("XDG_CONFIG_HOME", "/home/agent/.config");
         env.put("TMPDIR", "/home/agent/.local/tmp");
         env.put("PI_CODING_AGENT_DIR", WorkspaceAbi.PI_AGENT_DIR);
 
-        // Pi's azure-openai-responses provider hard-defaults the model to "gpt-5.2" — the deployment
-        // map routes both that and the configured model to the correct Azure deployment.
+        // Azure's `azure-openai-responses` provider hard-defaults the model id to "gpt-5.2"; route
+        // both that and the configured model to the same Azure deployment.
         if (spec.provider() == LlmProvider.AZURE_OPENAI) {
             String deployment = (spec.modelName() != null && !spec.modelName().isBlank())
                 ? spec.modelName()
                 : "gpt-5.4-mini";
-            // Model name flows to the shell via the env map (not interpolated into a shell string),
-            // so docker-java handles the quoting. The map *value* is then read by the agent.
             env.put("AZURE_OPENAI_DEPLOYMENT_NAME_MAP", deployment + "=" + deployment + ",gpt-5.2=" + deployment);
         }
 
@@ -138,10 +128,6 @@ public class PiRuntimeFactory {
         return new PiPlan(List.of("sh", "-c", command), Map.copyOf(env), Map.copyOf(inputFiles), networkPolicy);
     }
 
-    /**
-     * Render the profile's node flags as a trailing-space-terminated fragment so the kernel can
-     * interpolate without conditional whitespace. Empty profiles render to the empty string.
-     */
     private static String renderNodeFlags(List<String> flags) {
         if (flags == null || flags.isEmpty()) {
             return "";
@@ -149,16 +135,7 @@ public class PiRuntimeFactory {
         return String.join(" ", flags) + " ";
     }
 
-    /**
-     * Render the profile's per-process env fragment as {@code KEY=value} pairs. Each pair is
-     * trailing-space terminated; the assembled fragment is emitted IMMEDIATELY preceding the
-     * {@code node} keyword so the shell scopes the env to the node invocation only — NOT image-
-     * wide ENV. Other binaries in the same shell ({@code bun}, {@code git}) keep their default
-     * environment.
-     *
-     * <p>Values are NOT shell-quoted because no profile today emits values containing whitespace
-     * or shell metacharacters; a future profile that needs to MUST add quoting here.
-     */
+    /** Renders env as {@code KEY=value} pairs. Values are NOT shell-quoted — add quoting here if a profile ever needs whitespace/metachars. */
     private static String renderNodeEnv(Map<String, String> env) {
         if (env == null || env.isEmpty()) {
             return "";
@@ -170,11 +147,7 @@ public class PiRuntimeFactory {
         return b.toString();
     }
 
-    /**
-     * Map the Hephaestus {@link LlmProvider} enum to its Pi provider token.
-     * Identical across all known agent roles today; when mentor introduces different
-     * provider mappings, extract this into a strategy.
-     */
+    /** Map {@link LlmProvider} to its Pi provider token. */
     static String providerToken(LlmProvider provider) {
         return switch (provider) {
             case AZURE_OPENAI -> "azure-openai-responses";
@@ -183,21 +156,15 @@ public class PiRuntimeFactory {
         };
     }
 
-    /**
-     * Build settings JSON shared by every Pi-based agent (practice review and mentor chat alike).
-     * Two-arg overload kept for the test surface that doesn't care about custom provider routing.
-     */
+    /** Two-arg overload for tests that don't exercise custom-provider routing. */
     byte[] buildPiSettingsJson(LlmProvider provider, @Nullable String modelName) {
         return buildPiSettingsJson(provider, modelName, false);
     }
 
     /**
-     * When {@code useCustomProvider} is true, {@code defaultProvider} routes to the
-     * hephaestus extension (see {@link #buildExtensionFile}). The {@code defaultModel} is then
-     * the configured model id — the extension is registered with exactly that model.
-     *
-     * <p>Public so live tests in {@code agent.mentor.live} can reuse the production bytes
-     * verbatim instead of duplicating the JSON shape.
+     * Build the settings JSON Pi loads at session start. When {@code useCustomProvider} is true,
+     * {@code defaultProvider} routes through the {@code hephaestus} extension (see
+     * {@link #buildExtensionFile}).
      */
     public byte[] buildPiSettingsJson(LlmProvider provider, @Nullable String modelName, boolean useCustomProvider) {
         Map<String, Object> settings = new LinkedHashMap<>();
@@ -233,20 +200,13 @@ public class PiRuntimeFactory {
     }
 
     /**
-     * Emit a Pi extension that registers a custom provider named {@code hephaestus}. The
-     * provider reads its base URL, API key, and model id from the env (set by
-     * {@link LlmProxyAuthShell}). Pi auto-discovers extensions in {@code ~/.pi/extensions/} via
-     * jiti at session start — no TypeScript compile step needed.
-     *
-     * <p>{@code api: "openai-completions"} routes to Pi's chat-completions implementation for
-     * OpenAI; {@code anthropic-messages} routes to the Anthropic Messages API. {@code authHeader:
-     * true} attaches {@code Authorization: Bearer $PI_HEPHAESTUS_API_KEY}.
+     * Emit the Pi extension that registers the {@code hephaestus} custom provider. The provider
+     * reads its base URL, API key, and model id from env vars set by {@link LlmProxyAuthShell};
+     * Pi auto-discovers extensions in the agent dir via jiti at session start.
      */
     public byte[] buildExtensionFile(PiPlanSpec spec) {
-        // The TS source lives at server/application-server/src/main/resources/agent/extensions/.
-        // It is typechecked at CI time against @earendil-works/pi-coding-agent@0.74.0 via the
-        // sibling npm workspace `agent-extensions` (npm -w server/application-server/agent-extensions
-        // run typecheck). Bump in lockstep with MentorLiveLlmTest.PI_SDK_VERSION.
+        // TS source typechecked at CI time via the agent-extensions npm workspace; bump in
+        // lockstep with MentorLiveLlmTest.PI_SDK_VERSION.
         String resource =
             spec.provider() == LlmProvider.ANTHROPIC
                 ? "extensions/provider-anthropic.ts"
@@ -254,10 +214,7 @@ public class PiRuntimeFactory {
         return loadClasspathResource(resource);
     }
 
-    /**
-     * Network policy: PROXY mode forwards {@code allowInternet} + {@code jobToken}; direct modes
-     * always allow internet. The sandbox layer fills in {@code llmProxyUrl} during PREPARE.
-     */
+    /** Sandbox-layer fills in {@code llmProxyUrl} during PREPARE; this only emits the policy shape. */
     static NetworkPolicy buildNetworkPolicy(
         CredentialMode mode,
         LlmProvider provider,

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -100,11 +100,6 @@ public class PiRuntimeFactory {
         }
 
         String workspaceRoot = WorkspaceAbi.WORKSPACE_ROOT;
-
-        // Per-agent Node flags + envs come from the spec's runner profile. The kernel knows
-        // nothing about practice vs mentor — the profile knows nothing about the spec. This was
-        // previously a runner-script filename dispatch inside the kernel, forcing every new
-        // runner kind to edit four switches in this file.
         PiRunnerProfile profile = spec.runnerProfile();
         String nodeFlagsFragment = renderNodeFlags(profile.nodeFlags());
         String nodeEnvFragment = renderNodeEnv(profile.additionalEnv());

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactory.java
@@ -65,14 +65,13 @@ public class PiRuntimeFactory {
         boolean useCustomProvider = shouldRegisterHephaestusProvider(spec);
         if (useCustomProvider) {
             inputFiles.put(
-                WorkspaceAbi.PI_RUNTIME_PREFIX + "extensions/hephaestus-provider.ts",
+                WorkspaceAbi.PI_AGENT_PREFIX + "extensions/hephaestus-provider.ts",
                 buildExtensionFile(spec)
             );
         }
 
-        // Settings live outside .pi/ so Pi's settings lock file lands on a writable mount.
         inputFiles.put(
-            WorkspaceAbi.PI_RUNTIME_PREFIX + "settings.json",
+            WorkspaceAbi.PI_AGENT_PREFIX + "settings.json",
             buildPiSettingsJson(spec.provider(), spec.modelName(), useCustomProvider)
         );
         inputFiles.put(WorkspaceAbi.ORCHESTRATOR_PATH, loadClasspathResource("pi-orchestrator.md"));
@@ -82,11 +81,12 @@ public class PiRuntimeFactory {
         long agentTimeoutMs = Math.max(60_000L, (long) (spec.timeoutSeconds() - TIMEOUT_BUFFER_SECONDS) * 1000);
         env.put("AGENT_BUDGET_MS", Long.toString(agentTimeoutMs));
 
-        // Redirect writable runtime state away from the read-only /workspace mount.
+        // TMPDIR resolves under the mandatory /home/agent/.local tmpfs (see ContainerSecurityPolicy);
+        // Pi runs as uid 1000 and the Dockerfile pre-creates and chowns /home/agent so $HOME writes work.
         env.put("HOME", "/home/agent");
         env.put("XDG_CONFIG_HOME", "/home/agent/.config");
         env.put("TMPDIR", "/home/agent/.local/tmp");
-        env.put("PI_CODING_AGENT_DIR", "/home/agent/.pi");
+        env.put("PI_CODING_AGENT_DIR", WorkspaceAbi.PI_AGENT_DIR);
 
         // Pi's azure-openai-responses provider hard-defaults the model to "gpt-5.2" — the deployment
         // map routes both that and the configured model to the correct Azure deployment.
@@ -100,35 +100,15 @@ public class PiRuntimeFactory {
         }
 
         String workspaceRoot = WorkspaceAbi.WORKSPACE_ROOT;
-        String extensionCopyStep = useCustomProvider
-            ? "mkdir -p /home/agent/.pi/extensions && cp " +
-              workspaceRoot +
-              "/" +
-              WorkspaceAbi.PI_RUNTIME_PREFIX +
-              "extensions/hephaestus-provider.ts /home/agent/.pi/extensions/hephaestus-provider.ts && "
-            : "";
         String command =
             authSetup +
             "mkdir -p " +
             WorkspaceAbi.OUTPUT_PATH +
-            " /home/agent/.pi /home/agent/.config /home/agent/.local/tmp && " +
+            " /home/agent/.config /home/agent/.local/tmp && " +
             // Pi SDK ESM imports require a workspace-local node_modules.
             "ln -sf /usr/local/lib/node_modules " +
             workspaceRoot +
             "/node_modules && " +
-            "cp " +
-            workspaceRoot +
-            "/" +
-            WorkspaceAbi.PI_RUNTIME_PREFIX +
-            "settings.json /home/agent/.pi/settings.json && " +
-            "cp " +
-            workspaceRoot +
-            "/" +
-            WorkspaceAbi.ORCHESTRATOR_PATH +
-            " /home/agent/.pi/" +
-            WorkspaceAbi.ORCHESTRATOR_FILENAME +
-            " && " +
-            extensionCopyStep +
             spec.precomputeStep() +
             // Per-agent Node flags + envs. We deliberately do NOT apply the same flags to both
             // the long-lived mentor runner and the one-shot practice runner — see the rationale

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbi.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbi.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.hephaestus.agent.runtime;
 
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -60,9 +61,43 @@ public final class WorkspaceAbi {
     /** Workspace-relative path of the orchestrator instructions (combination of prefix + filename). */
     public static final String ORCHESTRATOR_PATH = PI_AGENT_PREFIX + ORCHESTRATOR_FILENAME;
 
+    /**
+     * Workspace-relative path of the mentor runner's system prompt file. Single-sourced so the
+     * Java materialiser (writing the bytes) and the JavaScript runner (reading them) cannot drift.
+     */
+    public static final String MENTOR_SYSTEM_PROMPT_PATH = "agent/mentor/system.md";
+
+    /** Workspace-relative directory for restored Pi SDK session JSONL files (matches the mentor runner's {@code SESSIONS_DIR}). */
+    public static final String SESSIONS_DIR_PREFIX = ".sessions/";
+
     /** Exit code emitted by the Pi runner on envelope/image drift (unsupported {@code schemaVersion} or {@code kind}). */
     public static final int EXIT_ENVELOPE_MISMATCH = 42;
 
     /** Practice slug pattern enforced at the handler boundary as defense-in-depth against FS-path injection. */
     public static final Pattern PRACTICE_SLUG = Pattern.compile("[a-z0-9][a-z0-9-]{0,63}");
+
+    /**
+     * Allowlist of {@link PiPlanSpec#extraInputs()} workspace paths that do NOT live under
+     * {@link #CONTEXT_TARGET_PREFIX}. Every adapter writing one of these paths must declare it
+     * here, so the next reader sees the complete set of mount points an adapter can plant in the
+     * workspace.
+     *
+     * <p>The set is the wire contract between {@code PiPlanSpec}'s compact-constructor validator
+     * (which rejects unknown paths fail-fast at boot/test time) and the {@code MentorPiAdapter}
+     * (which writes {@link #MENTOR_SYSTEM_PROMPT_PATH}). A future adapter adding a new path will
+     * fail validation until the path is added here — forcing the architectural review.
+     */
+    public static Set<String> allowedExtraInputPaths() {
+        return Set.of(MENTOR_SYSTEM_PROMPT_PATH);
+    }
+
+    /**
+     * Returns workspace-path prefixes accepted by {@code PiPlanSpec.extraInputs} for dynamic-suffix
+     * paths. Mentor's per-thread session JSONL restores ({@code .sessions/&lt;threadId&gt;.jsonl})
+     * are accepted via {@link #SESSIONS_DIR_PREFIX}; provider-emitted aspect JSON via
+     * {@link #CONTEXT_TARGET_PREFIX}.
+     */
+    public static Set<String> allowedExtraInputPrefixes() {
+        return Set.of(CONTEXT_TARGET_PREFIX, SESSIONS_DIR_PREFIX);
+    }
 }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbi.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbi.java
@@ -42,11 +42,14 @@ public final class WorkspaceAbi {
     /** Workspace-relative path of the practices-analysis marker directory. */
     public static final String ANALYSIS_PRACTICES_PREFIX = ANALYSIS_PREFIX + "practices/";
 
-    /** Workspace-relative path the Pi runtime config (settings.json) is staged into. */
-    public static final String PI_RUNTIME_PREFIX = ".pi-runtime/";
+    /** Workspace-relative directory name of the Pi SDK agent dir. */
+    private static final String PI_AGENT_NAME = ".pi";
 
-    /** Workspace-relative path the orchestrator instructions ({@code .pi/AGENTS.md}) live under. */
-    public static final String PI_AGENT_PREFIX = ".pi/";
+    /** Workspace-relative path of the Pi SDK agent dir — settings.json, AGENTS.md, extensions/. */
+    public static final String PI_AGENT_PREFIX = PI_AGENT_NAME + "/";
+
+    /** Absolute container path of the Pi SDK agent dir — value of {@code PI_CODING_AGENT_DIR}. */
+    public static final String PI_AGENT_DIR = WORKSPACE_ROOT + "/" + PI_AGENT_NAME;
 
     /** Workspace-relative filename of the runner script copied from the classpath. */
     public static final String RUNNER_SCRIPT_FILENAME = ".run-pi.mjs";

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbi.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbi.java
@@ -61,10 +61,7 @@ public final class WorkspaceAbi {
     /** Workspace-relative path of the orchestrator instructions (combination of prefix + filename). */
     public static final String ORCHESTRATOR_PATH = PI_AGENT_PREFIX + ORCHESTRATOR_FILENAME;
 
-    /**
-     * Workspace-relative path of the mentor runner's system prompt file. Single-sourced so the
-     * Java materialiser (writing the bytes) and the JavaScript runner (reading them) cannot drift.
-     */
+    /** Mentor system prompt path — pinned by {@code WorkspaceAbiSyncTest} against pi-mentor-runner.mjs. */
     public static final String MENTOR_SYSTEM_PROMPT_PATH = "agent/mentor/system.md";
 
     /** Workspace-relative directory for restored Pi SDK session JSONL files (matches the mentor runner's {@code SESSIONS_DIR}). */
@@ -76,27 +73,12 @@ public final class WorkspaceAbi {
     /** Practice slug pattern enforced at the handler boundary as defense-in-depth against FS-path injection. */
     public static final Pattern PRACTICE_SLUG = Pattern.compile("[a-z0-9][a-z0-9-]{0,63}");
 
-    /**
-     * Allowlist of {@link PiPlanSpec#extraInputs()} workspace paths that do NOT live under
-     * {@link #CONTEXT_TARGET_PREFIX}. Every adapter writing one of these paths must declare it
-     * here, so the next reader sees the complete set of mount points an adapter can plant in the
-     * workspace.
-     *
-     * <p>The set is the wire contract between {@code PiPlanSpec}'s compact-constructor validator
-     * (which rejects unknown paths fail-fast at boot/test time) and the {@code MentorPiAdapter}
-     * (which writes {@link #MENTOR_SYSTEM_PROMPT_PATH}). A future adapter adding a new path will
-     * fail validation until the path is added here — forcing the architectural review.
-     */
+    /** Exact workspace paths an adapter may pass in {@link PiPlanSpec#extraInputs()}. */
     public static Set<String> allowedExtraInputPaths() {
         return Set.of(MENTOR_SYSTEM_PROMPT_PATH);
     }
 
-    /**
-     * Returns workspace-path prefixes accepted by {@code PiPlanSpec.extraInputs} for dynamic-suffix
-     * paths. Mentor's per-thread session JSONL restores ({@code .sessions/&lt;threadId&gt;.jsonl})
-     * are accepted via {@link #SESSIONS_DIR_PREFIX}; provider-emitted aspect JSON via
-     * {@link #CONTEXT_TARGET_PREFIX}.
-     */
+    /** Workspace-path prefixes accepted by {@link PiPlanSpec#extraInputs()} for dynamic-suffix paths. */
     public static Set<String> allowedExtraInputPrefixes() {
         return Set.of(CONTEXT_TARGET_PREFIX, SESSIONS_DIR_PREFIX);
     }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/task/Task.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/task/Task.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.hephaestus.agent.task;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Objects;
 
 /**
@@ -17,6 +18,7 @@ public sealed interface Task {
      * files materialised by the content providers — this record only carries the prompt and
      * routing hints needed by the runner.
      */
+    @JsonTypeName(Task.PracticeReview.KIND)
     record PracticeReview(String prompt, int pullRequestNumber, String repositoryFullName) implements Task {
         public static final String KIND = "practice_review";
 

--- a/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
+++ b/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
@@ -46,25 +46,15 @@ async function loadSdk() {
     return sdk;
 }
 
-// Production paths are pinned to the container layout (/workspace/...). PROTOCOL_ONLY tests
-// and CI smoke-test invocations run the runner as a plain Node process where /workspace is
-// unwritable; MENTOR_RUNNER_SESSIONS_DIR / MENTOR_RUNNER_SYSTEM_PROMPT_PATH let callers point
-// at a tmpdir without forking the runner code.
-//
-// Workspace ABI: these literals are pinned by `WorkspaceAbiSyncTest` against
-// `de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi`. Don't introduce a string template
-// that hides the constant value — the test grep is exact.
+// PROTOCOL_ONLY tests / CI smoke-test invocations run the runner as a plain Node process where
+// /workspace is unwritable; MENTOR_RUNNER_* env overrides let callers point at a tmpdir without
+// forking the runner code. The workspace literals below are pinned by `WorkspaceAbiSyncTest` —
+// keep them quoted strings, not template expressions, so the grep stays exact.
 const WORKSPACE_ROOT = "/workspace";
-const CONTEXT_TARGET_PREFIX = "context/target/"; // WorkspaceAbi.CONTEXT_TARGET_PREFIX
 const MENTOR_SYSTEM_PROMPT_PATH = "agent/mentor/system.md"; // WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH
 const CWD = process.env.MENTOR_RUNNER_CWD ?? WORKSPACE_ROOT;
 const SESSIONS_DIR = process.env.MENTOR_RUNNER_SESSIONS_DIR ?? `${WORKSPACE_ROOT}/.sessions`;
 const SYSTEM_PROMPT_PATH = process.env.MENTOR_RUNNER_SYSTEM_PROMPT_PATH ?? `${WORKSPACE_ROOT}/${MENTOR_SYSTEM_PROMPT_PATH}`;
-// Aspect JSON inputs (workspace.json, user.json, ...) are materialised under this prefix by
-// the Java content providers. The runner never reads them directly — they arrive via the
-// `fetch_context` callback — but pinning the prefix here keeps the ABI contract documented.
-const ASPECT_INPUT_DIR = `${WORKSPACE_ROOT}/${CONTEXT_TARGET_PREFIX}`;
-void ASPECT_INPUT_DIR; // intentionally referenced for ABI documentation
 // The SDK's `getAgentDir()` is the canonical default ("~/.pi/agent"). We resolve it lazily
 // inside `ensureRuntime()` so the module loads without the SDK in protocol-only test mode.
 const AGENT_DIR_OVERRIDE = process.env.PI_CODING_AGENT_DIR ?? null;

--- a/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
+++ b/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
@@ -50,13 +50,47 @@ async function loadSdk() {
 // and CI smoke-test invocations run the runner as a plain Node process where /workspace is
 // unwritable; MENTOR_RUNNER_SESSIONS_DIR / MENTOR_RUNNER_SYSTEM_PROMPT_PATH let callers point
 // at a tmpdir without forking the runner code.
-const CWD = process.env.MENTOR_RUNNER_CWD ?? "/workspace";
-const SESSIONS_DIR = process.env.MENTOR_RUNNER_SESSIONS_DIR ?? "/workspace/.sessions";
-const SYSTEM_PROMPT_PATH = process.env.MENTOR_RUNNER_SYSTEM_PROMPT_PATH ?? "/workspace/agent/mentor/system.md";
+//
+// Workspace ABI: these literals are pinned by `WorkspaceAbiSyncTest` against
+// `de.tum.in.www1.hephaestus.agent.runtime.WorkspaceAbi`. Don't introduce a string template
+// that hides the constant value — the test grep is exact.
+const WORKSPACE_ROOT = "/workspace";
+const CONTEXT_TARGET_PREFIX = "context/target/"; // WorkspaceAbi.CONTEXT_TARGET_PREFIX
+const MENTOR_SYSTEM_PROMPT_PATH = "agent/mentor/system.md"; // WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH
+const CWD = process.env.MENTOR_RUNNER_CWD ?? WORKSPACE_ROOT;
+const SESSIONS_DIR = process.env.MENTOR_RUNNER_SESSIONS_DIR ?? `${WORKSPACE_ROOT}/.sessions`;
+const SYSTEM_PROMPT_PATH = process.env.MENTOR_RUNNER_SYSTEM_PROMPT_PATH ?? `${WORKSPACE_ROOT}/${MENTOR_SYSTEM_PROMPT_PATH}`;
+// Aspect JSON inputs (workspace.json, user.json, ...) are materialised under this prefix by
+// the Java content providers. The runner never reads them directly — they arrive via the
+// `fetch_context` callback — but pinning the prefix here keeps the ABI contract documented.
+const ASPECT_INPUT_DIR = `${WORKSPACE_ROOT}/${CONTEXT_TARGET_PREFIX}`;
+void ASPECT_INPUT_DIR; // intentionally referenced for ABI documentation
 // The SDK's `getAgentDir()` is the canonical default ("~/.pi/agent"). We resolve it lazily
 // inside `ensureRuntime()` so the module loads without the SDK in protocol-only test mode.
 const AGENT_DIR_OVERRIDE = process.env.PI_CODING_AGENT_DIR ?? null;
 const PROTOCOL_VERSION = 1;
+
+// WorkspaceAbi.EXIT_ENVELOPE_MISMATCH — exit code on protocol-version / image / config drift
+// that makes this runner incompatible with the calling Java side. Java's launcher distinguishes
+// this exit from a generic crash so deploy regressions surface as a structured failure.
+const ENVELOPE_MISMATCH_EXIT = 42;
+
+// Startup envelope check: if the Java launcher pins an expected protocol version via env,
+// fail-fast with a structured exit so the deploy doesn't silently downgrade to a stub.
+{
+    const expectedRaw = process.env.MENTOR_RUNNER_EXPECTED_PROTOCOL_VERSION;
+    if (expectedRaw !== undefined && expectedRaw !== "") {
+        const expected = Number(expectedRaw);
+        if (!Number.isFinite(expected) || expected !== PROTOCOL_VERSION) {
+            process.stderr.write(
+                `[pi-mentor-runner] FATAL envelope mismatch: ` +
+                    `MENTOR_RUNNER_EXPECTED_PROTOCOL_VERSION=${expectedRaw}, runner PROTOCOL_VERSION=${PROTOCOL_VERSION}. ` +
+                    `Exiting ${ENVELOPE_MISMATCH_EXIT}.\n`,
+            );
+            process.exit(ENVELOPE_MISMATCH_EXIT);
+        }
+    }
+}
 
 const FETCH_CONTEXT_TIMEOUT_MS = 10_000;
 const TURN_BUDGET_MS = (() => {
@@ -969,15 +1003,18 @@ function start() {
     });
     process.stdin.on("error", (e) => {
         log("stdin error:", e);
-        process.exit(2);
+        // Distinct from ENVELOPE_MISMATCH_EXIT (42): this is a transport-layer failure, not a
+        // structured protocol/image drift. Node default fatal exit code is 1.
+        process.exit(1);
     });
 
     process.on("uncaughtException", (e) => {
         log("uncaughtException:", e);
         try {
-            process.stdout.write("", () => process.exit(2));
+            // Same rationale: uncaught is a runtime crash, not an envelope mismatch.
+            process.stdout.write("", () => process.exit(1));
         } catch {
-            process.exit(2);
+            process.exit(1);
         }
     });
     process.on("unhandledRejection", (e) => {

--- a/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
+++ b/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
@@ -225,7 +225,7 @@ async function ensureRuntime() {
             DefaultResourceLoader,
             getAgentDir,
         } = await loadSdk();
-        const agentDir = AGENT_DIR_OVERRIDE ?? (typeof getAgentDir === "function" ? getAgentDir() : "/home/agent/.pi");
+        const agentDir = AGENT_DIR_OVERRIDE ?? getAgentDir();
 
         // System prompt is optional in v1 — the Java caller may inject it later. If the
         // resource exists we load it once and reuse via ResourceLoader override.

--- a/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
+++ b/server/application-server/src/main/resources/agent/pi-mentor-runner.mjs
@@ -225,7 +225,10 @@ async function ensureRuntime() {
             DefaultResourceLoader,
             getAgentDir,
         } = await loadSdk();
-        const agentDir = AGENT_DIR_OVERRIDE ?? getAgentDir();
+        // `typeof getAgentDir === "function"` guard accommodates MENTOR_RUNNER_PROTOCOL_ONLY=1 mode,
+        // where the stub SDK (see buildStubSdk) does not export getAgentDir. Tests then fall through
+        // to the workspace-relative default that matches production's PI_CODING_AGENT_DIR.
+        const agentDir = AGENT_DIR_OVERRIDE ?? (typeof getAgentDir === "function" ? getAgentDir() : "/workspace/.pi");
 
         // System prompt is optional in v1 — the Java caller may inject it later. If the
         // resource exists we load it once and reuse via ResourceLoader override.

--- a/server/application-server/src/main/resources/agent/pi-runner.mjs
+++ b/server/application-server/src/main/resources/agent/pi-runner.mjs
@@ -17,6 +17,10 @@ const AGENT_BUDGET_MS = Number(process.env.AGENT_BUDGET_MS);
 if (!Number.isFinite(AGENT_BUDGET_MS) || AGENT_BUDGET_MS <= 0) {
     throw new Error(`AGENT_BUDGET_MS env var is required and must be a positive number, got: ${process.env.AGENT_BUDGET_MS}`);
 }
+const AGENT_DIR = process.env.PI_CODING_AGENT_DIR;
+if (!AGENT_DIR) {
+    throw new Error("PI_CODING_AGENT_DIR env var is required");
+}
 // 85% initial / 15% retry; soft nudge at 50% of initial.
 const INITIAL_TIMEOUT_MS = Math.max(60_000, Math.floor(AGENT_BUDGET_MS * 0.85));
 const RETRY_TIMEOUT_MS = Math.max(30_000, AGENT_BUDGET_MS - INITIAL_TIMEOUT_MS);
@@ -564,12 +568,12 @@ async function main() {
     // edit/write — findings are persisted only via the customTools below. Pi 0.74+
     // filters customTools through the same allowlist (see agent-session.js:1796), so
     // the custom tool names must be listed here too or they won't be exposed to the LLM.
-    const settingsManager = SettingsManager.create(CWD, process.env.PI_CODING_AGENT_DIR || "/home/agent/.pi");
+    const settingsManager = SettingsManager.create(CWD, AGENT_DIR);
     const sessionManager = SessionManager.inMemory();
 
     const { session } = await createAgentSession({
         cwd: CWD,
-        agentDir: process.env.PI_CODING_AGENT_DIR || "/home/agent/.pi",
+        agentDir: AGENT_DIR,
         tools: ["read", "bash", "grep", "report_finding", "set_review_summary"],
         customTools: [reportFindingTool, setReviewSummaryTool],
         sessionManager,

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatControllerTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatControllerTest.java
@@ -33,7 +33,6 @@ class MentorChatControllerTest extends BaseUnitTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final MentorAgentProperties TEST_PROPERTIES = new MentorAgentProperties(
         "ghcr.io/ls1intum/hephaestus/agent-pi:latest",
-        "pi-mentor-runner.mjs",
         100_000,
         "",
         null,

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
@@ -133,7 +133,6 @@ class MentorChatServiceTest extends BaseUnitTest {
         // the instance path and does not need the agentConfigRepository.
         MentorAgentProperties mentorProps = new MentorAgentProperties(
             "test-image",
-            "pi-mentor-runner.mjs",
             100_000,
             "",
             LlmProvider.OPENAI,

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/live/MentorLiveLlmTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/live/MentorLiveLlmTest.java
@@ -606,9 +606,7 @@ class MentorLiveLlmTest {
         Files.createDirectories(piHome);
         Files.write(piHome.resolve("settings.json"), settingsBytes);
 
-        // Extensions go under PI_CODING_AGENT_DIR/extensions/ (the SDK auto-discovers them via
-        // jiti during session start). The production container path is /home/agent/.pi/extensions/
-        // — same shape, different root.
+        // Pi SDK auto-discovers extensions in $PI_CODING_AGENT_DIR/extensions/ via jiti.
         Path extDir = piHome.resolve("extensions");
         Files.createDirectories(extDir);
         Files.write(extDir.resolve("hephaestus-provider.ts"), extensionBytes);

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/live/MentorLiveLlmTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/live/MentorLiveLlmTest.java
@@ -593,7 +593,7 @@ class MentorLiveLlmTest {
             null,
             true,
             300,
-            "pi-mentor-runner.mjs",
+            new de.tum.in.www1.hephaestus.agent.mentor.MentorRunnerProfile(),
             Map.of(),
             ""
         );

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/live/MentorSandboxStressTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/live/MentorSandboxStressTest.java
@@ -768,7 +768,7 @@ class MentorSandboxStressTest {
             null,
             true,
             300,
-            "pi-mentor-runner.mjs",
+            new de.tum.in.www1.hephaestus.agent.mentor.MentorRunnerProfile(),
             Map.of(),
             ""
         );

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/practice/PracticePiAdapterTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/practice/PracticePiAdapterTest.java
@@ -29,7 +29,7 @@ class PracticePiAdapterTest extends BaseUnitTest {
         adapter = new PracticePiAdapter(
             new PiRuntimeFactory(mapper),
             new PiResultParser(mapper, metrics),
-            new PiAgentProperties(IMAGE, "pi-runner.mjs", ImagePullPolicy.IF_NOT_PRESENT)
+            new PiAgentProperties(IMAGE, ImagePullPolicy.IF_NOT_PRESENT)
         );
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/practice/live/PracticeRunnerLiveLlmTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/practice/live/PracticeRunnerLiveLlmTest.java
@@ -290,9 +290,8 @@ class PracticeRunnerLiveLlmTest {
         // Copy the production runner verbatim — same bytes that ship to the agent container.
         Files.copy(RUNNER, WORKSPACE.resolve("pi-runner.mjs"), StandardCopyOption.REPLACE_EXISTING);
 
-        // Orchestrator instructions: the runner expects /workspace/.pi/AGENTS.md on disk (production
-        // PiRuntimeFactory copies it into ~/.pi). We stage both locations so either lookup path
-        // works.
+        // Orchestrator instructions live at WORKSPACE/.pi/AGENTS.md — same layout production uses
+        // now that PI_CODING_AGENT_DIR points inside the workspace.
         Path piDir = WORKSPACE.resolve(WorkspaceAbi.PI_AGENT_PREFIX);
         Files.createDirectories(piDir);
         Files.copy(

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/AgentRuntimeBoundaryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/AgentRuntimeBoundaryTest.java
@@ -34,28 +34,15 @@ class AgentRuntimeBoundaryTest extends HephaestusArchitectureTest {
     class RuntimeBoundary {
 
         @Test
-        @DisplayName("agent.runtime must not depend on agent.practice")
-        void runtimeIndependentOfPractice() {
+        @DisplayName("agent.runtime must not depend on agent.practice or agent.mentor")
+        void runtimeIndependentOfDomains() {
             ArchRule rule = noClasses()
                 .that()
                 .resideInAPackage(RUNTIME)
                 .should()
                 .dependOnClassesThat()
-                .resideInAPackage(PRACTICE)
-                .because("agent.runtime is the shared Pi kernel reused by mentor — it must stay practice-agnostic");
-            rule.check(classes);
-        }
-
-        @Test
-        @DisplayName("agent.runtime must not depend on agent.mentor")
-        void runtimeIndependentOfMentor() {
-            ArchRule rule = noClasses()
-                .that()
-                .resideInAPackage(RUNTIME)
-                .should()
-                .dependOnClassesThat()
-                .resideInAPackage(MENTOR)
-                .because("agent.runtime is the shared Pi kernel reused by practice — it must stay mentor-agnostic");
+                .resideInAnyPackage(PRACTICE, MENTOR)
+                .because("agent.runtime is the shared Pi kernel reused by both domains — it must stay role-agnostic");
             rule.check(classes);
         }
     }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/AgentRuntimeBoundaryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/AgentRuntimeBoundaryTest.java
@@ -102,10 +102,6 @@ class AgentRuntimeBoundaryTest extends HephaestusArchitectureTest {
         @Test
         @DisplayName("PiRunnerProfile implementations reside in agent.practice or agent.mentor")
         void profilesInDomainPackages() {
-            // The profile interface is intentionally NOT sealed (a sealed interface with
-            // `permits PracticeRunnerProfile, MentorRunnerProfile` would force agent.runtime to
-            // import its domain implementations — exactly the dependency the boundary rules
-            // above forbid). Enforce the same constraint architecturally instead.
             ArchRule rule = classes()
                 .that()
                 .implement("de.tum.in.www1.hephaestus.agent.runtime.PiRunnerProfile")

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/AgentRuntimeBoundaryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/AgentRuntimeBoundaryTest.java
@@ -96,6 +96,27 @@ class AgentRuntimeBoundaryTest extends HephaestusArchitectureTest {
     }
 
     @Nested
+    @DisplayName("PiRunnerProfile placement")
+    class PiRunnerProfilePlacement {
+
+        @Test
+        @DisplayName("PiRunnerProfile implementations reside in agent.practice or agent.mentor")
+        void profilesInDomainPackages() {
+            // The profile interface is intentionally NOT sealed (a sealed interface with
+            // `permits PracticeRunnerProfile, MentorRunnerProfile` would force agent.runtime to
+            // import its domain implementations — exactly the dependency the boundary rules
+            // above forbid). Enforce the same constraint architecturally instead.
+            ArchRule rule = classes()
+                .that()
+                .implement("de.tum.in.www1.hephaestus.agent.runtime.PiRunnerProfile")
+                .should()
+                .resideInAnyPackage(PRACTICE, MENTOR)
+                .because("Each runner kind owns its profile next to its adapter; the kernel sees only the interface");
+            rule.check(classes);
+        }
+    }
+
+    @Nested
     @DisplayName("context module boundary")
     class ContextBoundary {
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpecValidationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpecValidationTest.java
@@ -1,31 +1,23 @@
 package de.tum.in.www1.hephaestus.agent.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.tum.in.www1.hephaestus.agent.CredentialMode;
 import de.tum.in.www1.hephaestus.agent.LlmProvider;
 import de.tum.in.www1.hephaestus.agent.practice.PracticeRunnerProfile;
 import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-/**
- * Fail-fast validation contract for {@link PiPlanSpec#extraInputs}.
- *
- * <p>Every workspace-relative path an adapter puts in {@code extraInputs} must be either
- * prefixed by a known dynamic-suffix prefix from {@link WorkspaceAbi#allowedExtraInputPrefixes}
- * (e.g. {@link WorkspaceAbi#CONTEXT_TARGET_PREFIX}, {@link WorkspaceAbi#SESSIONS_DIR_PREFIX}),
- * OR equal to one of the static allowlisted paths in {@link WorkspaceAbi#allowedExtraInputPaths}.
- * Adapters caught writing to undeclared paths fail at construction time — surfaced at boot or
- * the first unit test, not at runtime in front of a user.
- */
-@DisplayName("PiPlanSpec.extraInputs path validation")
+@DisplayName("PiPlanSpec validation contract")
 class PiPlanSpecValidationTest extends BaseUnitTest {
 
     private static final PiRunnerProfile PROFILE = new PracticeRunnerProfile();
+    private static final byte[] BYTES = new byte[] { 0x01 };
 
     private static PiPlanSpec specWith(Map<String, byte[]> extraInputs) {
         return new PiPlanSpec(
@@ -43,46 +35,23 @@ class PiPlanSpecValidationTest extends BaseUnitTest {
         );
     }
 
-    @Test
-    @DisplayName("CONTEXT_TARGET_PREFIX paths are accepted")
-    void contextTargetPathAccepted() {
-        Map<String, byte[]> inputs = Map.of(
-            WorkspaceAbi.CONTEXT_TARGET_PREFIX + "diff.patch",
-            "x".getBytes(StandardCharsets.UTF_8)
-        );
-        // No throw — happy path.
-        PiPlanSpec spec = specWith(inputs);
-        assertThat(spec.extraInputs()).containsKey(WorkspaceAbi.CONTEXT_TARGET_PREFIX + "diff.patch");
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "context/target/diff.patch", // CONTEXT_TARGET_PREFIX
+            "agent/mentor/system.md", // MENTOR_SYSTEM_PROMPT_PATH
+            ".sessions/abc-123.jsonl", // SESSIONS_DIR_PREFIX
+        }
+    )
+    @DisplayName("Allowlisted workspace paths are accepted")
+    void allowlistedPathsAccepted(String path) {
+        assertThatNoException().isThrownBy(() -> specWith(Map.of(path, BYTES)));
     }
 
     @Test
-    @DisplayName("Static allowlist (MENTOR_SYSTEM_PROMPT_PATH) accepted")
-    void mentorSystemPromptPathAccepted() {
-        Map<String, byte[]> inputs = Map.of(
-            WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH,
-            "# prompt".getBytes(StandardCharsets.UTF_8)
-        );
-        // No throw.
-        PiPlanSpec spec = specWith(inputs);
-        assertThat(spec.extraInputs()).containsKey(WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH);
-    }
-
-    @Test
-    @DisplayName("Dynamic-suffix prefix (SESSIONS_DIR_PREFIX) accepted for mentor session restores")
-    void sessionsPrefixAccepted() {
-        Map<String, byte[]> inputs = Map.of(
-            WorkspaceAbi.SESSIONS_DIR_PREFIX + "abc-123.jsonl",
-            "{}".getBytes(StandardCharsets.UTF_8)
-        );
-        // No throw.
-        specWith(inputs);
-    }
-
-    @Test
-    @DisplayName("Arbitrary workspace path is REJECTED with a message naming the path")
+    @DisplayName("Undeclared workspace paths are rejected with a message naming the path")
     void undeclaredPathRejected() {
-        Map<String, byte[]> inputs = Map.of("evil/../etc/passwd", "x".getBytes(StandardCharsets.UTF_8));
-        assertThatThrownBy(() -> specWith(inputs))
+        assertThatThrownBy(() -> specWith(Map.of("evil/../etc/passwd", BYTES)))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("evil/../etc/passwd")
             .hasMessageContaining("allowedExtraInputPaths");
@@ -152,27 +121,5 @@ class PiPlanSpecValidationTest extends BaseUnitTest {
         )
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("TIMEOUT_BUFFER_SECONDS");
-    }
-
-    @Test
-    @DisplayName("runnerProfile must not be null")
-    void runnerProfileNotNull() {
-        assertThatThrownBy(() ->
-            new PiPlanSpec(
-                LlmProvider.OPENAI,
-                CredentialMode.API_KEY,
-                "sk",
-                null,
-                null,
-                null,
-                true,
-                600,
-                null,
-                Map.of(),
-                ""
-            )
-        )
-            .isInstanceOf(NullPointerException.class)
-            .hasMessageContaining("runnerProfile");
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpecValidationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpecValidationTest.java
@@ -89,23 +89,90 @@ class PiPlanSpecValidationTest extends BaseUnitTest {
     }
 
     @Test
-    @DisplayName("Even a 'plausible' path under .pi/ is rejected unless declared")
-    void plausibleButUndeclaredPathRejected() {
-        Map<String, byte[]> inputs = Map.of(
-            ".pi/AGENTS.md", // collides with the kernel-written orchestrator path
-            "rogue".getBytes(StandardCharsets.UTF_8)
-        );
-        assertThatThrownBy(() -> specWith(inputs))
+    @DisplayName("PROXY mode requires jobToken")
+    void proxyRequiresToken() {
+        assertThatThrownBy(() ->
+            new PiPlanSpec(
+                LlmProvider.OPENAI,
+                CredentialMode.PROXY,
+                null,
+                null,
+                null,
+                null,
+                false,
+                600,
+                PROFILE,
+                Map.of(),
+                ""
+            )
+        )
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining(".pi/AGENTS.md");
+            .hasMessageContaining("jobToken");
     }
 
     @Test
-    @DisplayName("Null keys are rejected with a useful message")
-    void nullKeyRejected() {
-        java.util.Map<String, byte[]> withNullKey = new java.util.HashMap<>();
-        withNullKey.put(null, "x".getBytes(StandardCharsets.UTF_8));
-        // Map.copyOf throws on null keys; the validation message names that condition.
-        assertThatThrownBy(() -> specWith(withNullKey)).isInstanceOf(NullPointerException.class);
+    @DisplayName("API_KEY mode requires credential")
+    void apiKeyRequiresCredential() {
+        assertThatThrownBy(() ->
+            new PiPlanSpec(
+                LlmProvider.OPENAI,
+                CredentialMode.API_KEY,
+                null,
+                null,
+                null,
+                null,
+                false,
+                600,
+                PROFILE,
+                Map.of(),
+                ""
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("credential");
+    }
+
+    @Test
+    @DisplayName("timeoutSeconds must exceed TIMEOUT_BUFFER_SECONDS")
+    void timeoutMustExceedBuffer() {
+        assertThatThrownBy(() ->
+            new PiPlanSpec(
+                LlmProvider.OPENAI,
+                CredentialMode.API_KEY,
+                "sk",
+                null,
+                null,
+                null,
+                true,
+                PiRuntimeFactory.TIMEOUT_BUFFER_SECONDS,
+                PROFILE,
+                Map.of(),
+                ""
+            )
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("TIMEOUT_BUFFER_SECONDS");
+    }
+
+    @Test
+    @DisplayName("runnerProfile must not be null")
+    void runnerProfileNotNull() {
+        assertThatThrownBy(() ->
+            new PiPlanSpec(
+                LlmProvider.OPENAI,
+                CredentialMode.API_KEY,
+                "sk",
+                null,
+                null,
+                null,
+                true,
+                600,
+                null,
+                Map.of(),
+                ""
+            )
+        )
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("runnerProfile");
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpecValidationTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiPlanSpecValidationTest.java
@@ -1,0 +1,111 @@
+package de.tum.in.www1.hephaestus.agent.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.tum.in.www1.hephaestus.agent.CredentialMode;
+import de.tum.in.www1.hephaestus.agent.LlmProvider;
+import de.tum.in.www1.hephaestus.agent.practice.PracticeRunnerProfile;
+import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fail-fast validation contract for {@link PiPlanSpec#extraInputs}.
+ *
+ * <p>Every workspace-relative path an adapter puts in {@code extraInputs} must be either
+ * prefixed by a known dynamic-suffix prefix from {@link WorkspaceAbi#allowedExtraInputPrefixes}
+ * (e.g. {@link WorkspaceAbi#CONTEXT_TARGET_PREFIX}, {@link WorkspaceAbi#SESSIONS_DIR_PREFIX}),
+ * OR equal to one of the static allowlisted paths in {@link WorkspaceAbi#allowedExtraInputPaths}.
+ * Adapters caught writing to undeclared paths fail at construction time — surfaced at boot or
+ * the first unit test, not at runtime in front of a user.
+ */
+@DisplayName("PiPlanSpec.extraInputs path validation")
+class PiPlanSpecValidationTest extends BaseUnitTest {
+
+    private static final PiRunnerProfile PROFILE = new PracticeRunnerProfile();
+
+    private static PiPlanSpec specWith(Map<String, byte[]> extraInputs) {
+        return new PiPlanSpec(
+            LlmProvider.OPENAI,
+            CredentialMode.API_KEY,
+            "sk",
+            null,
+            null,
+            null,
+            true,
+            600,
+            PROFILE,
+            extraInputs,
+            ""
+        );
+    }
+
+    @Test
+    @DisplayName("CONTEXT_TARGET_PREFIX paths are accepted")
+    void contextTargetPathAccepted() {
+        Map<String, byte[]> inputs = Map.of(
+            WorkspaceAbi.CONTEXT_TARGET_PREFIX + "diff.patch",
+            "x".getBytes(StandardCharsets.UTF_8)
+        );
+        // No throw — happy path.
+        PiPlanSpec spec = specWith(inputs);
+        assertThat(spec.extraInputs()).containsKey(WorkspaceAbi.CONTEXT_TARGET_PREFIX + "diff.patch");
+    }
+
+    @Test
+    @DisplayName("Static allowlist (MENTOR_SYSTEM_PROMPT_PATH) accepted")
+    void mentorSystemPromptPathAccepted() {
+        Map<String, byte[]> inputs = Map.of(
+            WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH,
+            "# prompt".getBytes(StandardCharsets.UTF_8)
+        );
+        // No throw.
+        PiPlanSpec spec = specWith(inputs);
+        assertThat(spec.extraInputs()).containsKey(WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH);
+    }
+
+    @Test
+    @DisplayName("Dynamic-suffix prefix (SESSIONS_DIR_PREFIX) accepted for mentor session restores")
+    void sessionsPrefixAccepted() {
+        Map<String, byte[]> inputs = Map.of(
+            WorkspaceAbi.SESSIONS_DIR_PREFIX + "abc-123.jsonl",
+            "{}".getBytes(StandardCharsets.UTF_8)
+        );
+        // No throw.
+        specWith(inputs);
+    }
+
+    @Test
+    @DisplayName("Arbitrary workspace path is REJECTED with a message naming the path")
+    void undeclaredPathRejected() {
+        Map<String, byte[]> inputs = Map.of("evil/../etc/passwd", "x".getBytes(StandardCharsets.UTF_8));
+        assertThatThrownBy(() -> specWith(inputs))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("evil/../etc/passwd")
+            .hasMessageContaining("allowedExtraInputPaths");
+    }
+
+    @Test
+    @DisplayName("Even a 'plausible' path under .pi/ is rejected unless declared")
+    void plausibleButUndeclaredPathRejected() {
+        Map<String, byte[]> inputs = Map.of(
+            ".pi/AGENTS.md", // collides with the kernel-written orchestrator path
+            "rogue".getBytes(StandardCharsets.UTF_8)
+        );
+        assertThatThrownBy(() -> specWith(inputs))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(".pi/AGENTS.md");
+    }
+
+    @Test
+    @DisplayName("Null keys are rejected with a useful message")
+    void nullKeyRejected() {
+        java.util.Map<String, byte[]> withNullKey = new java.util.HashMap<>();
+        withNullKey.put(null, "x".getBytes(StandardCharsets.UTF_8));
+        // Map.copyOf throws on null keys; the validation message names that condition.
+        assertThatThrownBy(() -> specWith(withNullKey)).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.in.www1.hephaestus.agent.CredentialMode;
 import de.tum.in.www1.hephaestus.agent.LlmProvider;
+import de.tum.in.www1.hephaestus.agent.mentor.MentorRunnerProfile;
+import de.tum.in.www1.hephaestus.agent.practice.PracticeRunnerProfile;
 import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -20,6 +22,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 @DisplayName("PiRuntimeFactory")
 class PiRuntimeFactoryTest extends BaseUnitTest {
+
+    private static final PracticeRunnerProfile PRACTICE = new PracticeRunnerProfile();
+    private static final MentorRunnerProfile MENTOR = new MentorRunnerProfile();
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private PiRuntimeFactory factory;
@@ -39,7 +44,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             "job-token-123",
             false,
             600,
-            "pi-runner.mjs",
+            PRACTICE,
             Map.of(),
             ""
         );
@@ -55,7 +60,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             null,
             true,
             600,
-            "pi-runner.mjs",
+            PRACTICE,
             Map.of(),
             ""
         );
@@ -96,8 +101,9 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("extra inputs merge into the input-files map")
+        @DisplayName("extra inputs merge into the input-files map when path is whitelisted")
         void extraInputsMerge() {
+            byte[] payload = "deadbeef".getBytes(StandardCharsets.UTF_8);
             PiPlanSpec spec = new PiPlanSpec(
                 LlmProvider.OPENAI,
                 CredentialMode.API_KEY,
@@ -107,11 +113,13 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
-                Map.of("task.json", "{\"schemaVersion\":1}".getBytes(StandardCharsets.UTF_8)),
+                PRACTICE,
+                Map.of(WorkspaceAbi.CONTEXT_TARGET_PREFIX + "metadata.json", payload),
                 ""
             );
-            assertThat(factory.build(spec).inputFiles()).containsKey("task.json");
+            assertThat(factory.build(spec).inputFiles()).containsKey(
+                WorkspaceAbi.CONTEXT_TARGET_PREFIX + "metadata.json"
+            );
         }
     }
 
@@ -211,7 +219,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -235,7 +243,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 "job-token-123",
                 false,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -261,7 +269,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -288,7 +296,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -314,7 +322,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -340,7 +348,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -364,7 +372,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -412,37 +420,8 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("MENTOR_RUNNER_SCRIPT constant tracks MentorAgentProperties.runnerScript default")
-        void mentorRunnerScriptConstantAgreesWithProperties() {
-            // PiRuntimeFactory dispatches V8 flags by filename match against MENTOR_RUNNER_SCRIPT.
-            // If MentorAgentProperties' default runnerScript ever drifts (rename, version bump,
-            // operator override) the mentor silently reverts to the practice V8 profile —
-            // no heap cap, no --expose-gc, no jemalloc preload.
-            //
-            // The previous version of this test constructed MentorAgentProperties manually with
-            // the literal "pi-mentor-runner.mjs" and asserted that literal equalled the constant.
-            // It would have passed even if @DefaultValue on MentorAgentProperties was renamed to
-            // "pi-mentor-runner-v2.mjs" — the very drift it claimed to defend against. Fixed by
-            // round-tripping through Spring's Binder against an empty source, which actually
-            // exercises the @DefaultValue resolution.
-            org.springframework.boot.context.properties.bind.Binder binder =
-                new org.springframework.boot.context.properties.bind.Binder(
-                    org.springframework.boot.context.properties.source.ConfigurationPropertySources.from(
-                        new org.springframework.core.env.MapPropertySource("empty", Map.of())
-                    )
-                );
-            de.tum.in.www1.hephaestus.agent.mentor.MentorAgentProperties bound = binder.bindOrCreate(
-                "hephaestus.mentor.agent",
-                de.tum.in.www1.hephaestus.agent.mentor.MentorAgentProperties.class
-            );
-            assertThat(bound.runnerScript())
-                .as("MENTOR_RUNNER_SCRIPT must equal MentorAgentProperties.@DefaultValue('runnerScript')")
-                .isEqualTo(PiRuntimeFactory.MENTOR_RUNNER_SCRIPT);
-        }
-
-        @Test
-        @DisplayName("Mentor runner: heap cap + --expose-gc + jemalloc preload scoped to node")
-        void nodeFlagsForMentor() {
+        @DisplayName("Mentor profile: heap cap + --expose-gc + jemalloc preload scoped to node")
+        void mentorProfileContributesMentorFlagsAndEnv() {
             PiPlanSpec spec = new PiPlanSpec(
                 LlmProvider.OPENAI,
                 CredentialMode.API_KEY,
@@ -452,7 +431,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-mentor-runner.mjs",
+                MENTOR,
                 Map.of(),
                 ""
             );
@@ -465,7 +444,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 .contains("--no-warnings")
                 .contains("--expose-gc")
                 // --disable-source-maps is an unrecognised Node 22 CLI flag and crashes the
-                // runner at startup (exit 9). Must NOT be present for either runner.
+                // runner at startup (exit 9). Must NOT be present for either profile.
                 .doesNotContain("--disable-source-maps");
             // LD_PRELOAD + MALLOC_CONF appear in the shell env BEFORE `node `, scoped to that
             // invocation only — they do NOT leak to bun (precompute) or other tools.
@@ -473,6 +452,33 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             assertThat(beforeNode)
                 .contains("LD_PRELOAD=/usr/local/lib/libjemalloc.so.2")
                 .contains("MALLOC_CONF=background_thread:true,narenas:2,dirty_decay_ms:30000,muzzy_decay_ms:30000");
+        }
+
+        @Test
+        @DisplayName("Mentor profile loads the mentor runner script from classpath")
+        void mentorProfileResolvesCorrectScript() {
+            PiPlanSpec spec = new PiPlanSpec(
+                LlmProvider.OPENAI,
+                CredentialMode.API_KEY,
+                "sk-test",
+                null,
+                null,
+                null,
+                true,
+                600,
+                MENTOR,
+                Map.of(),
+                ""
+            );
+            // The bytes copied to the workspace script slot must come from the mentor runner
+            // resource — distinct from the practice runner. We don't pin the exact bytes (they
+            // change every Pi-SDK bump), but the mentor runner header is stable.
+            String runner = new String(
+                factory.build(spec).inputFiles().get(WorkspaceAbi.RUNNER_SCRIPT_FILENAME),
+                StandardCharsets.UTF_8
+            );
+            // Practice runner does NOT speak the JSON-RPC mentor protocol; mentor does.
+            assertThat(runner).contains("jsonrpc");
         }
 
         @Test
@@ -487,7 +493,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 "echo precompute && "
             );
@@ -515,7 +521,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 null,
                 true,
                 600,
-                "pi-runner.mjs",
+                PRACTICE,
                 Map.of(),
                 ""
             );
@@ -540,7 +546,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     null,
                     false,
                     600,
-                    "pi-runner.mjs",
+                    PRACTICE,
                     Map.of(),
                     ""
                 )
@@ -562,7 +568,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     null,
                     false,
                     600,
-                    "pi-runner.mjs",
+                    PRACTICE,
                     Map.of(),
                     ""
                 )
@@ -584,7 +590,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     null,
                     true,
                     PiRuntimeFactory.TIMEOUT_BUFFER_SECONDS,
-                    "pi-runner.mjs",
+                    PRACTICE,
                     Map.of(),
                     ""
                 )
@@ -594,8 +600,8 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("runnerScript must not be blank")
-        void runnerScriptNotBlank() {
+        @DisplayName("runnerProfile must not be null")
+        void runnerProfileNotNull() {
             assertThatThrownBy(() ->
                 new PiPlanSpec(
                     LlmProvider.OPENAI,
@@ -606,13 +612,13 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                     null,
                     true,
                     600,
-                    "  ",
+                    null,
                     Map.of(),
                     ""
                 )
             )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("runnerScript");
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("runnerProfile");
         }
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.hephaestus.agent.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -455,9 +454,11 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("Mentor profile loads the mentor runner script from classpath")
-        void mentorProfileResolvesCorrectScript() {
-            PiPlanSpec spec = new PiPlanSpec(
+        @DisplayName("Mentor and practice profiles resolve to distinct runner scripts")
+        void profilesResolveToDistinctScripts() {
+            PiPlanSpec base = proxySpec(LlmProvider.AZURE_OPENAI, null);
+            byte[] practiceBytes = factory.build(base).inputFiles().get(WorkspaceAbi.RUNNER_SCRIPT_FILENAME);
+            PiPlanSpec mentorSpec = new PiPlanSpec(
                 LlmProvider.OPENAI,
                 CredentialMode.API_KEY,
                 "sk-test",
@@ -470,15 +471,8 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 Map.of(),
                 ""
             );
-            // The bytes copied to the workspace script slot must come from the mentor runner
-            // resource — distinct from the practice runner. We don't pin the exact bytes (they
-            // change every Pi-SDK bump), but the mentor runner header is stable.
-            String runner = new String(
-                factory.build(spec).inputFiles().get(WorkspaceAbi.RUNNER_SCRIPT_FILENAME),
-                StandardCharsets.UTF_8
-            );
-            // Practice runner does NOT speak the JSON-RPC mentor protocol; mentor does.
-            assertThat(runner).contains("jsonrpc");
+            byte[] mentorBytes = factory.build(mentorSpec).inputFiles().get(WorkspaceAbi.RUNNER_SCRIPT_FILENAME);
+            assertThat(mentorBytes).isNotEqualTo(practiceBytes);
         }
 
         @Test
@@ -526,99 +520,6 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 ""
             );
             assertThat(factory.build(spec).command().get(2)).doesNotContain(" cp ");
-        }
-    }
-
-    @Nested
-    @DisplayName("spec validation")
-    class SpecValidation {
-
-        @Test
-        @DisplayName("PROXY mode requires jobToken")
-        void proxyRequiresToken() {
-            assertThatThrownBy(() ->
-                new PiPlanSpec(
-                    LlmProvider.OPENAI,
-                    CredentialMode.PROXY,
-                    null,
-                    null,
-                    null,
-                    null,
-                    false,
-                    600,
-                    PRACTICE,
-                    Map.of(),
-                    ""
-                )
-            )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("jobToken");
-        }
-
-        @Test
-        @DisplayName("API_KEY mode requires credential")
-        void apiKeyRequiresCredential() {
-            assertThatThrownBy(() ->
-                new PiPlanSpec(
-                    LlmProvider.OPENAI,
-                    CredentialMode.API_KEY,
-                    null,
-                    null,
-                    null,
-                    null,
-                    false,
-                    600,
-                    PRACTICE,
-                    Map.of(),
-                    ""
-                )
-            )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("credential");
-        }
-
-        @Test
-        @DisplayName("timeoutSeconds must exceed the buffer")
-        void timeoutMustExceedBuffer() {
-            assertThatThrownBy(() ->
-                new PiPlanSpec(
-                    LlmProvider.OPENAI,
-                    CredentialMode.API_KEY,
-                    "sk",
-                    null,
-                    null,
-                    null,
-                    true,
-                    PiRuntimeFactory.TIMEOUT_BUFFER_SECONDS,
-                    PRACTICE,
-                    Map.of(),
-                    ""
-                )
-            )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("TIMEOUT_BUFFER_SECONDS");
-        }
-
-        @Test
-        @DisplayName("runnerProfile must not be null")
-        void runnerProfileNotNull() {
-            assertThatThrownBy(() ->
-                new PiPlanSpec(
-                    LlmProvider.OPENAI,
-                    CredentialMode.API_KEY,
-                    "sk",
-                    null,
-                    null,
-                    null,
-                    true,
-                    600,
-                    null,
-                    Map.of(),
-                    ""
-                )
-            )
-                .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("runnerProfile");
         }
     }
 }

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -162,13 +162,13 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         }
 
         @Test
-        @DisplayName("HOME / TMPDIR redirected to writable mount")
+        @DisplayName("HOME / TMPDIR on tmpfs; PI_CODING_AGENT_DIR points into the workspace")
         void writableMounts() {
             var env = factory.build(proxySpec(LlmProvider.AZURE_OPENAI, null)).environment();
             assertThat(env)
                 .containsEntry("HOME", "/home/agent")
                 .containsEntry("TMPDIR", "/home/agent/.local/tmp")
-                .containsEntry("PI_CODING_AGENT_DIR", "/home/agent/.pi");
+                .containsEntry("PI_CODING_AGENT_DIR", WorkspaceAbi.PI_AGENT_DIR);
         }
 
         @Test
@@ -250,7 +250,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
     class CustomProvider {
 
         @Test
-        @DisplayName("baseUrl-pinned OPENAI spec emits hephaestus-provider.ts under .pi-runtime/extensions/")
+        @DisplayName("baseUrl-pinned OPENAI spec emits hephaestus-provider.ts under .pi/extensions/")
         void baseUrlOpenaiEmitsExtension() {
             PiPlanSpec spec = new PiPlanSpec(
                 LlmProvider.OPENAI,
@@ -267,7 +267,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             );
             var inputs = factory.build(spec).inputFiles();
             String ts = new String(
-                inputs.get(WorkspaceAbi.PI_RUNTIME_PREFIX + "extensions/hephaestus-provider.ts"),
+                inputs.get(WorkspaceAbi.PI_AGENT_PREFIX + "extensions/hephaestus-provider.ts"),
                 StandardCharsets.UTF_8
             );
             assertThat(ts)
@@ -296,7 +296,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 factory
                     .build(spec)
                     .inputFiles()
-                    .get(WorkspaceAbi.PI_RUNTIME_PREFIX + "extensions/hephaestus-provider.ts"),
+                    .get(WorkspaceAbi.PI_AGENT_PREFIX + "extensions/hephaestus-provider.ts"),
                 StandardCharsets.UTF_8
             );
             assertThat(ts).contains("api: \"anthropic-messages\"");
@@ -320,7 +320,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             );
             JsonNode settings = objectMapper.readTree(
                 new String(
-                    factory.build(spec).inputFiles().get(WorkspaceAbi.PI_RUNTIME_PREFIX + "settings.json"),
+                    factory.build(spec).inputFiles().get(WorkspaceAbi.PI_AGENT_PREFIX + "settings.json"),
                     StandardCharsets.UTF_8
                 )
             );
@@ -345,9 +345,9 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 ""
             );
             var inputs = factory.build(spec).inputFiles();
-            assertThat(inputs).doesNotContainKey(WorkspaceAbi.PI_RUNTIME_PREFIX + "extensions/hephaestus-provider.ts");
+            assertThat(inputs).doesNotContainKey(WorkspaceAbi.PI_AGENT_PREFIX + "extensions/hephaestus-provider.ts");
             JsonNode settings = objectMapper.readTree(
-                new String(inputs.get(WorkspaceAbi.PI_RUNTIME_PREFIX + "settings.json"), StandardCharsets.UTF_8)
+                new String(inputs.get(WorkspaceAbi.PI_AGENT_PREFIX + "settings.json"), StandardCharsets.UTF_8)
             );
             assertThat(settings.path("defaultProvider").asText()).isEqualTo("openai");
         }
@@ -369,7 +369,7 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
                 ""
             );
             assertThat(factory.build(spec).inputFiles()).doesNotContainKey(
-                WorkspaceAbi.PI_RUNTIME_PREFIX + "extensions/hephaestus-provider.ts"
+                WorkspaceAbi.PI_AGENT_PREFIX + "extensions/hephaestus-provider.ts"
             );
         }
     }
@@ -499,6 +499,27 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             // the command line may carry V8 flags (`--max-old-space-size`, `--disable-source-maps`,
             // …) between `node` and the script path. Asserting the script path alone is enough.
             assertThat(body.indexOf("echo precompute")).isLessThan(body.indexOf("/workspace/.run-pi.mjs"));
+        }
+
+        @Test
+        @DisplayName("No shell-side cp of Pi config")
+        void noCopyShim() {
+            // Asserted on the baseUrl-pinned spec because the custom-provider extension path was
+            // the last conditional `cp` the old boot script emitted.
+            PiPlanSpec spec = new PiPlanSpec(
+                LlmProvider.OPENAI,
+                CredentialMode.API_KEY,
+                "sk-test",
+                "gpt-x",
+                "https://gpu.example.com/api",
+                null,
+                true,
+                600,
+                "pi-runner.mjs",
+                Map.of(),
+                ""
+            );
+            assertThat(factory.build(spec).command().get(2)).doesNotContain(" cp ");
         }
     }
 

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/PiRuntimeFactoryTest.java
@@ -94,9 +94,11 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         @DisplayName("loads pi-orchestrator.md and the runner from classpath")
         void loadsClasspathResources() {
             var inputs = factory.build(proxySpec(LlmProvider.AZURE_OPENAI, null)).inputFiles();
-            assertThat(inputs.get(".pi/AGENTS.md")).isNotNull();
-            assertThat(new String(inputs.get(".pi/AGENTS.md"), StandardCharsets.UTF_8)).contains("findings");
-            assertThat(inputs.get(".run-pi.mjs")).isNotEmpty();
+            assertThat(inputs.get(WorkspaceAbi.ORCHESTRATOR_PATH)).isNotNull();
+            assertThat(new String(inputs.get(WorkspaceAbi.ORCHESTRATOR_PATH), StandardCharsets.UTF_8)).contains(
+                "findings"
+            );
+            assertThat(inputs.get(WorkspaceAbi.RUNNER_SCRIPT_FILENAME)).isNotEmpty();
         }
 
         @Test
@@ -154,9 +156,6 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         @Test
         @DisplayName("AGENT_BUDGET_MS stays strictly below the spec hard timeout (leaves grace)")
         void budget_leavesGraceUnderSpecTimeout() {
-            // Brittle predecessor asserted the exact constant `540000` from `(600-60)*1000` —
-            // it would break on any buffer-constant tweak even when the architectural
-            // invariant (budget < hard timeout) still held. Now assert the invariant itself.
             var spec = proxySpec(LlmProvider.AZURE_OPENAI, null);
             String budget = factory.build(spec).environment().get("AGENT_BUDGET_MS");
             assertThat(budget).as("AGENT_BUDGET_MS must be present").isNotNull();
@@ -181,9 +180,6 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
         @Test
         @DisplayName("No image-wide UV_THREADPOOL_SIZE override (would serialise libuv fs bursts)")
         void uvThreadpoolNotForced() {
-            // Previously set to 2 image-wide — removed because (a) the RSS saving was unmeasured
-            // and (b) it serialises the practice runner's git tool calls. If a workload-specific
-            // override is needed it should be set inline in nodeEnvFor.
             var env = factory.build(proxySpec(LlmProvider.OPENAI, null)).environment();
             assertThat(env).doesNotContainKey("UV_THREADPOOL_SIZE");
         }
@@ -386,40 +382,25 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
     class CommandAssembly {
 
         @Test
-        @DisplayName("Practice runner: only safe flags (no heap cap, no --expose-gc)")
+        @DisplayName("Practice profile contributes --no-warnings and no per-process env")
         void nodeFlagsForPractice() {
-            // The default test specs use `pi-runner.mjs` (practice). Practice handles large diffs
-            // and uses no global.gc() — applying a 256 MB heap cap there would be a latent OOM
-            // and exposing gc() is a foot-gun.
             String body = factory.build(apiKeySpec(LlmProvider.OPENAI)).command().get(2);
             int nodeIdx = body.indexOf("node ");
-            int scriptIdx = body.indexOf(".run-pi.mjs");
-            assertThat(nodeIdx).as("node invocation present").isGreaterThanOrEqualTo(0);
-            assertThat(scriptIdx).as("runner script present").isGreaterThan(nodeIdx);
+            int scriptIdx = body.indexOf(WorkspaceAbi.RUNNER_SCRIPT_FILENAME);
             String nodePrefix = body.substring(nodeIdx, scriptIdx);
             assertThat(nodePrefix)
                 .contains("--no-warnings")
                 .doesNotContain("--max-old-space-size")
-                .doesNotContain("--max-semi-space-size")
                 .doesNotContain("--expose-gc")
-                // --disable-source-maps is an unrecognised Node 22 CLI flag and would crash the
-                // runner at startup with exit 9. Guard the regression.
                 .doesNotContain("--disable-source-maps");
-            // The shell segment IMMEDIATELY preceding `node ` must not set LD_PRELOAD /
-            // MALLOC_CONF. The earlier auth-setup prefix never sets either; but to make the
-            // assertion meaningful (rather than tautological against a prefix that never
-            // contains them in ANY codepath), we slice from the last `&&` before `node ` —
-            // that's the same-statement scope `var=value cmd` would inject into.
+            // Per-process env immediately preceding `node ` must be empty for practice.
             int lastAmp = body.lastIndexOf("&&", nodeIdx);
             int sliceStart = lastAmp >= 0 ? lastAmp + 2 : 0;
-            assertThat(body.substring(sliceStart, nodeIdx))
-                .as("practice path: per-process env immediately preceding `node` must be empty")
-                .doesNotContain("LD_PRELOAD")
-                .doesNotContain("MALLOC_CONF");
+            assertThat(body.substring(sliceStart, nodeIdx)).doesNotContain("LD_PRELOAD").doesNotContain("MALLOC_CONF");
         }
 
         @Test
-        @DisplayName("Mentor profile: heap cap + --expose-gc + jemalloc preload scoped to node")
+        @DisplayName("Mentor profile contributes heap cap, --expose-gc, and jemalloc preload scoped to node")
         void mentorProfileContributesMentorFlagsAndEnv() {
             PiPlanSpec spec = new PiPlanSpec(
                 LlmProvider.OPENAI,
@@ -436,21 +417,15 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             );
             String body = factory.build(spec).command().get(2);
             int nodeIdx = body.indexOf("node ");
-            int scriptIdx = body.indexOf(".run-pi.mjs");
-            String nodePrefix = body.substring(nodeIdx, scriptIdx);
-            assertThat(nodePrefix)
+            int scriptIdx = body.indexOf(WorkspaceAbi.RUNNER_SCRIPT_FILENAME);
+            assertThat(body.substring(nodeIdx, scriptIdx))
                 .contains("--max-old-space-size=256")
                 .contains("--no-warnings")
                 .contains("--expose-gc")
-                // --disable-source-maps is an unrecognised Node 22 CLI flag and crashes the
-                // runner at startup (exit 9). Must NOT be present for either profile.
                 .doesNotContain("--disable-source-maps");
-            // LD_PRELOAD + MALLOC_CONF appear in the shell env BEFORE `node `, scoped to that
-            // invocation only — they do NOT leak to bun (precompute) or other tools.
-            String beforeNode = body.substring(0, nodeIdx);
-            assertThat(beforeNode)
+            assertThat(body.substring(0, nodeIdx))
                 .contains("LD_PRELOAD=/usr/local/lib/libjemalloc.so.2")
-                .contains("MALLOC_CONF=background_thread:true,narenas:2,dirty_decay_ms:30000,muzzy_decay_ms:30000");
+                .contains("MALLOC_CONF=background_thread:true");
         }
 
         @Test
@@ -495,17 +470,15 @@ class PiRuntimeFactoryTest extends BaseUnitTest {
             assertThat(plan.command()).hasSize(3);
             assertThat(plan.command().get(0)).isEqualTo("sh");
             String body = plan.command().get(2);
-            // Precompute step must run before the runner. Don't pin the exact `node` invocation —
-            // the command line may carry V8 flags (`--max-old-space-size`, `--disable-source-maps`,
-            // …) between `node` and the script path. Asserting the script path alone is enough.
-            assertThat(body.indexOf("echo precompute")).isLessThan(body.indexOf("/workspace/.run-pi.mjs"));
+            assertThat(body.indexOf("echo precompute")).isLessThan(
+                body.indexOf(WorkspaceAbi.WORKSPACE_ROOT + "/" + WorkspaceAbi.RUNNER_SCRIPT_FILENAME)
+            );
         }
 
         @Test
         @DisplayName("No shell-side cp of Pi config")
         void noCopyShim() {
-            // Asserted on the baseUrl-pinned spec because the custom-provider extension path was
-            // the last conditional `cp` the old boot script emitted.
+            // baseUrl-pinned spec exercises the custom-provider extension, the only conditional input path.
             PiPlanSpec spec = new PiPlanSpec(
                 LlmProvider.OPENAI,
                 CredentialMode.API_KEY,

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbiSyncTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbiSyncTest.java
@@ -32,20 +32,26 @@ class WorkspaceAbiSyncTest extends BaseUnitTest {
             .contains("\"" + WorkspaceAbi.WORKSPACE_ROOT + "/" + WorkspaceAbi.TASK_ENVELOPE_FILENAME + "\"");
 
         assertThat(body)
-            .as("runner pins its supported schemaVersion to the Java SCHEMA_VERSION constant")
-            .containsPattern("=\\s*" + TaskEnvelope.SCHEMA_VERSION + "\\b");
+            .as("runner pins SUPPORTED_SCHEMA_VERSION to the Java SCHEMA_VERSION constant")
+            .contains("SUPPORTED_SCHEMA_VERSION = " + TaskEnvelope.SCHEMA_VERSION);
 
         assertThat(body)
-            .as("runner exits %d on envelope mismatch", WorkspaceAbi.EXIT_ENVELOPE_MISMATCH)
-            .containsPattern("=\\s*" + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH + "\\b");
+            .as("runner pins ENVELOPE_MISMATCH_EXIT to WorkspaceAbi.EXIT_ENVELOPE_MISMATCH")
+            .contains("ENVELOPE_MISMATCH_EXIT = " + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH);
 
         assertThat(body)
             .as("runner writes its output under WorkspaceAbi.OUTPUT_PATH")
             .contains("\"" + WorkspaceAbi.OUTPUT_PATH + "\"");
+
+        assertThat(body)
+            .as("runner reads the practices index under WorkspaceAbi.PRACTICES_PREFIX")
+            .contains("/" + WorkspaceAbi.PRACTICES_PREFIX + "index.json");
     }
 
     @Test
-    @DisplayName("pi-mentor-runner.mjs pins MENTOR_SYSTEM_PROMPT_PATH and exits 42 on envelope mismatch")
+    @DisplayName(
+        "pi-mentor-runner.mjs pins MENTOR_SYSTEM_PROMPT_PATH, SESSIONS_DIR_PREFIX, PI_AGENT_DIR, and the envelope exit"
+    )
     void mentorRunnerLiteralsMatchAbi() throws IOException {
         Path runner = resolveResource("agent/pi-mentor-runner.mjs");
         assertThat(runner).isRegularFile();
@@ -56,8 +62,16 @@ class WorkspaceAbiSyncTest extends BaseUnitTest {
             .contains("\"" + WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH + "\"");
 
         assertThat(body)
-            .as("mentor runner exits %d on envelope mismatch", WorkspaceAbi.EXIT_ENVELOPE_MISMATCH)
-            .containsPattern("=\\s*" + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH + "\\b");
+            .as("mentor runner references WorkspaceAbi.SESSIONS_DIR_PREFIX dir name (.sessions)")
+            .contains("/" + WorkspaceAbi.SESSIONS_DIR_PREFIX.replaceFirst("/$", ""));
+
+        assertThat(body)
+            .as("mentor runner falls back to WorkspaceAbi.PI_AGENT_DIR when PI_CODING_AGENT_DIR is unset")
+            .contains("\"" + WorkspaceAbi.PI_AGENT_DIR + "\"");
+
+        assertThat(body)
+            .as("mentor runner pins ENVELOPE_MISMATCH_EXIT to WorkspaceAbi.EXIT_ENVELOPE_MISMATCH")
+            .contains("ENVELOPE_MISMATCH_EXIT = " + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH);
     }
 
     private static Path resolveResource(String relativePath) {

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbiSyncTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbiSyncTest.java
@@ -44,6 +44,28 @@ class WorkspaceAbiSyncTest extends BaseUnitTest {
             .contains("\"" + WorkspaceAbi.OUTPUT_PATH + "\"");
     }
 
+    @Test
+    @DisplayName(
+        "pi-mentor-runner.mjs references CONTEXT_TARGET_PREFIX, MENTOR_SYSTEM_PROMPT_PATH, and exits 42 on envelope mismatch"
+    )
+    void mentorRunnerLiteralsMatchAbi() throws IOException {
+        Path runner = resolveResource("agent/pi-mentor-runner.mjs");
+        assertThat(runner).isRegularFile();
+        String body = Files.readString(runner, StandardCharsets.UTF_8);
+
+        assertThat(body)
+            .as("mentor runner references WorkspaceAbi.CONTEXT_TARGET_PREFIX literally")
+            .contains("\"" + WorkspaceAbi.CONTEXT_TARGET_PREFIX + "\"");
+
+        assertThat(body)
+            .as("mentor runner references WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH literally")
+            .contains("\"" + WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH + "\"");
+
+        assertThat(body)
+            .as("mentor runner exits %d on envelope mismatch", WorkspaceAbi.EXIT_ENVELOPE_MISMATCH)
+            .contains("ENVELOPE_MISMATCH_EXIT = " + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH);
+    }
+
     private static Path resolveResource(String relativePath) {
         Path candidate = Path.of("src/main/resources").resolve(relativePath);
         return Files.exists(candidate)

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbiSyncTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/runtime/WorkspaceAbiSyncTest.java
@@ -32,12 +32,12 @@ class WorkspaceAbiSyncTest extends BaseUnitTest {
             .contains("\"" + WorkspaceAbi.WORKSPACE_ROOT + "/" + WorkspaceAbi.TASK_ENVELOPE_FILENAME + "\"");
 
         assertThat(body)
-            .as("runner pins SUPPORTED_SCHEMA_VERSION to the Java SCHEMA_VERSION constant")
-            .contains("SUPPORTED_SCHEMA_VERSION = " + TaskEnvelope.SCHEMA_VERSION);
+            .as("runner pins its supported schemaVersion to the Java SCHEMA_VERSION constant")
+            .containsPattern("=\\s*" + TaskEnvelope.SCHEMA_VERSION + "\\b");
 
         assertThat(body)
             .as("runner exits %d on envelope mismatch", WorkspaceAbi.EXIT_ENVELOPE_MISMATCH)
-            .contains("ENVELOPE_MISMATCH_EXIT = " + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH);
+            .containsPattern("=\\s*" + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH + "\\b");
 
         assertThat(body)
             .as("runner writes its output under WorkspaceAbi.OUTPUT_PATH")
@@ -45,17 +45,11 @@ class WorkspaceAbiSyncTest extends BaseUnitTest {
     }
 
     @Test
-    @DisplayName(
-        "pi-mentor-runner.mjs references CONTEXT_TARGET_PREFIX, MENTOR_SYSTEM_PROMPT_PATH, and exits 42 on envelope mismatch"
-    )
+    @DisplayName("pi-mentor-runner.mjs pins MENTOR_SYSTEM_PROMPT_PATH and exits 42 on envelope mismatch")
     void mentorRunnerLiteralsMatchAbi() throws IOException {
         Path runner = resolveResource("agent/pi-mentor-runner.mjs");
         assertThat(runner).isRegularFile();
         String body = Files.readString(runner, StandardCharsets.UTF_8);
-
-        assertThat(body)
-            .as("mentor runner references WorkspaceAbi.CONTEXT_TARGET_PREFIX literally")
-            .contains("\"" + WorkspaceAbi.CONTEXT_TARGET_PREFIX + "\"");
 
         assertThat(body)
             .as("mentor runner references WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH literally")
@@ -63,7 +57,7 @@ class WorkspaceAbiSyncTest extends BaseUnitTest {
 
         assertThat(body)
             .as("mentor runner exits %d on envelope mismatch", WorkspaceAbi.EXIT_ENVELOPE_MISMATCH)
-            .contains("ENVELOPE_MISMATCH_EXIT = " + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH);
+            .containsPattern("=\\s*" + WorkspaceAbi.EXIT_ENVELOPE_MISMATCH + "\\b");
     }
 
     private static Path resolveResource(String relativePath) {

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/PiImagePullBootstrapperTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/PiImagePullBootstrapperTest.java
@@ -25,11 +25,7 @@ class PiImagePullBootstrapperTest extends BaseUnitTest {
     private DockerImageOperations imageOps;
 
     private PiImagePullBootstrapper bootstrapperWith(ImagePullPolicy policy) {
-        return new PiImagePullBootstrapper(
-            imageOps,
-            new PiAgentProperties(IMAGE, "pi-runner.mjs", policy),
-            new SimpleMeterRegistry()
-        );
+        return new PiImagePullBootstrapper(imageOps, new PiAgentProperties(IMAGE, policy), new SimpleMeterRegistry());
     }
 
     // ─── ALWAYS policy ──────────────────────────────────────────────────────────
@@ -41,7 +37,7 @@ class PiImagePullBootstrapperTest extends BaseUnitTest {
         var registry = new SimpleMeterRegistry();
         var bootstrapper = new PiImagePullBootstrapper(
             imageOps,
-            new PiAgentProperties(IMAGE, "pi-runner.mjs", ImagePullPolicy.ALWAYS),
+            new PiAgentProperties(IMAGE, ImagePullPolicy.ALWAYS),
             registry
         );
 
@@ -60,7 +56,7 @@ class PiImagePullBootstrapperTest extends BaseUnitTest {
         var registry = new SimpleMeterRegistry();
         var bootstrapper = new PiImagePullBootstrapper(
             imageOps,
-            new PiAgentProperties(IMAGE, "pi-runner.mjs", ImagePullPolicy.ALWAYS),
+            new PiAgentProperties(IMAGE, ImagePullPolicy.ALWAYS),
             registry
         );
         when(imageOps.ping()).thenReturn(true);
@@ -78,7 +74,7 @@ class PiImagePullBootstrapperTest extends BaseUnitTest {
         var registry = new SimpleMeterRegistry();
         var bootstrapper = new PiImagePullBootstrapper(
             imageOps,
-            new PiAgentProperties(IMAGE, "pi-runner.mjs", ImagePullPolicy.ALWAYS),
+            new PiAgentProperties(IMAGE, ImagePullPolicy.ALWAYS),
             registry
         );
         when(imageOps.ping()).thenReturn(true);

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
@@ -558,7 +558,7 @@ class DockerInteractiveSandboxLiveTest {
             null,
             true,
             120,
-            "pi-mentor-runner.mjs",
+            new de.tum.in.www1.hephaestus.agent.mentor.MentorRunnerProfile(),
             Map.of(),
             ""
         );

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/task/TaskSealedHierarchyTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/task/TaskSealedHierarchyTest.java
@@ -1,0 +1,95 @@
+package de.tum.in.www1.hephaestus.agent.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guardrail for the sealed {@link Task} hierarchy. Three independent drift checks:
+ *
+ * <ol>
+ *   <li>{@code Task} stays {@code sealed} — javac alone enforces exhaustiveness at every sealed
+ *       switch, but only if the seal survives.</li>
+ *   <li>Every {@link JsonSubTypes.Type} entry on {@code Task} has a matching permit and vice
+ *       versa — a new permit added without registering its Jackson type id would serialise
+ *       fine but fail polymorphic deserialisation.</li>
+ *   <li>Every permit carries {@link JsonTypeName} matching its {@code @JsonSubTypes.Type(name=...)}
+ *       — keeps the type-id source of truth co-located with the subtype itself, so subtype-side
+ *       lookups (e.g. annotation introspection in a producer registry) don't silently disagree
+ *       with the supertype's {@code @JsonSubTypes} table.</li>
+ * </ol>
+ *
+ * <p>Java 21 sealed-switch bytecode is {@code invokedynamic} against {@code
+ * SwitchBootstraps.typeSwitch} and is opaque to ArchUnit 1.3.x — this test is reflection-based
+ * and serves as a structural guardrail, not a dispatch-site inspector.
+ */
+@Tag("architecture")
+@DisplayName("Task sealed hierarchy")
+class TaskSealedHierarchyTest {
+
+    @Test
+    @DisplayName("Task is sealed")
+    void taskIsSealed() {
+        assertThat(Task.class.isSealed())
+            .as("Task must remain sealed; adding a non-permit variant breaks every sealed switch")
+            .isTrue();
+    }
+
+    @Test
+    @DisplayName("permits set equals JsonSubTypes set")
+    void permitsMatchJsonSubTypes() {
+        Set<Class<?>> permitted = Set.of(Task.class.getPermittedSubclasses());
+
+        JsonSubTypes subtypesAnn = Task.class.getAnnotation(JsonSubTypes.class);
+        assertThat(subtypesAnn).as("Task must declare @JsonSubTypes alongside @JsonTypeInfo").isNotNull();
+        Set<Class<?>> jacksonSubtypes = Arrays.stream(subtypesAnn.value())
+            .map(JsonSubTypes.Type::value)
+            .collect(Collectors.toSet());
+
+        assertThat(jacksonSubtypes)
+            .as(
+                "Mismatch between Task.permittedSubclasses=%s and @JsonSubTypes=%s — every permit " +
+                    "must register a Jackson type id and vice versa",
+                permitted,
+                jacksonSubtypes
+            )
+            .isEqualTo(permitted);
+    }
+
+    @Test
+    @DisplayName("every permit has @JsonTypeName matching its @JsonSubTypes.Type(name=...)")
+    void everyPermitHasMatchingJsonTypeName() {
+        JsonSubTypes subtypesAnn = Task.class.getAnnotation(JsonSubTypes.class);
+        assertThat(subtypesAnn).isNotNull();
+
+        for (JsonSubTypes.Type entry : subtypesAnn.value()) {
+            Class<?> subtype = entry.value();
+            String supertypeName = entry.name();
+            JsonTypeName typeNameAnn = subtype.getAnnotation(JsonTypeName.class);
+            assertThat(typeNameAnn)
+                .as(
+                    "Permit %s must declare @JsonTypeName(\"%s\") so the type id stays " +
+                        "single-sourced with the subtype",
+                    subtype.getName(),
+                    supertypeName
+                )
+                .isNotNull();
+            assertThat(typeNameAnn.value())
+                .as(
+                    "Permit %s declares @JsonTypeName(\"%s\") but Task's @JsonSubTypes registers " +
+                        "it as \"%s\" — the two must match",
+                    subtype.getName(),
+                    typeNameAnn.value(),
+                    supertypeName
+                )
+                .isEqualTo(supertypeName);
+        }
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/task/TaskSealedHierarchyTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/task/TaskSealedHierarchyTest.java
@@ -12,23 +12,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * Guardrail for the sealed {@link Task} hierarchy. Three independent drift checks:
- *
- * <ol>
- *   <li>{@code Task} stays {@code sealed} — javac alone enforces exhaustiveness at every sealed
- *       switch, but only if the seal survives.</li>
- *   <li>Every {@link JsonSubTypes.Type} entry on {@code Task} has a matching permit and vice
- *       versa — a new permit added without registering its Jackson type id would serialise
- *       fine but fail polymorphic deserialisation.</li>
- *   <li>Every permit carries {@link JsonTypeName} matching its {@code @JsonSubTypes.Type(name=...)}
- *       — keeps the type-id source of truth co-located with the subtype itself, so subtype-side
- *       lookups (e.g. annotation introspection in a producer registry) don't silently disagree
- *       with the supertype's {@code @JsonSubTypes} table.</li>
- * </ol>
- *
- * <p>Java 21 sealed-switch bytecode is {@code invokedynamic} against {@code
- * SwitchBootstraps.typeSwitch} and is opaque to ArchUnit 1.3.x — this test is reflection-based
- * and serves as a structural guardrail, not a dispatch-site inspector.
+ * Guardrail against sealed-permit / {@code @JsonSubTypes} / {@code @JsonTypeName} drift on
+ * {@link Task}. ArchUnit can't introspect Java 21 sealed-switch bytecode (invokedynamic against
+ * {@code SwitchBootstraps.typeSwitch}), so the checks are reflection-based.
  */
 @Tag("architecture")
 @DisplayName("Task sealed hierarchy")

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/task/TaskSealedHierarchyTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/task/TaskSealedHierarchyTest.java
@@ -12,70 +12,30 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * Guardrail against sealed-permit / {@code @JsonSubTypes} / {@code @JsonTypeName} drift on
- * {@link Task}. ArchUnit can't introspect Java 21 sealed-switch bytecode (invokedynamic against
- * {@code SwitchBootstraps.typeSwitch}), so the checks are reflection-based.
+ * Guardrail against {@code permits} / {@code @JsonSubTypes} / {@code @JsonTypeName} drift on
+ * {@link Task}. ArchUnit can't introspect Java 21 sealed-switch bytecode, so this is reflection-based.
  */
 @Tag("architecture")
 @DisplayName("Task sealed hierarchy")
 class TaskSealedHierarchyTest {
 
     @Test
-    @DisplayName("Task is sealed")
-    void taskIsSealed() {
-        assertThat(Task.class.isSealed())
-            .as("Task must remain sealed; adding a non-permit variant breaks every sealed switch")
-            .isTrue();
-    }
-
-    @Test
-    @DisplayName("permits set equals JsonSubTypes set")
-    void permitsMatchJsonSubTypes() {
-        Set<Class<?>> permitted = Set.of(Task.class.getPermittedSubclasses());
+    @DisplayName("Task permits, @JsonSubTypes and per-permit @JsonTypeName all agree")
+    void permitsJsonSubtypesAndJsonTypeNameAgree() {
+        assertThat(Task.class.isSealed()).as("Task must remain sealed").isTrue();
 
         JsonSubTypes subtypesAnn = Task.class.getAnnotation(JsonSubTypes.class);
-        assertThat(subtypesAnn).as("Task must declare @JsonSubTypes alongside @JsonTypeInfo").isNotNull();
+        assertThat(subtypesAnn).as("Task must declare @JsonSubTypes").isNotNull();
         Set<Class<?>> jacksonSubtypes = Arrays.stream(subtypesAnn.value())
             .map(JsonSubTypes.Type::value)
             .collect(Collectors.toSet());
 
-        assertThat(jacksonSubtypes)
-            .as(
-                "Mismatch between Task.permittedSubclasses=%s and @JsonSubTypes=%s — every permit " +
-                    "must register a Jackson type id and vice versa",
-                permitted,
-                jacksonSubtypes
-            )
-            .isEqualTo(permitted);
-    }
-
-    @Test
-    @DisplayName("every permit has @JsonTypeName matching its @JsonSubTypes.Type(name=...)")
-    void everyPermitHasMatchingJsonTypeName() {
-        JsonSubTypes subtypesAnn = Task.class.getAnnotation(JsonSubTypes.class);
-        assertThat(subtypesAnn).isNotNull();
+        assertThat(jacksonSubtypes).isEqualTo(Set.of(Task.class.getPermittedSubclasses()));
 
         for (JsonSubTypes.Type entry : subtypesAnn.value()) {
-            Class<?> subtype = entry.value();
-            String supertypeName = entry.name();
-            JsonTypeName typeNameAnn = subtype.getAnnotation(JsonTypeName.class);
-            assertThat(typeNameAnn)
-                .as(
-                    "Permit %s must declare @JsonTypeName(\"%s\") so the type id stays " +
-                        "single-sourced with the subtype",
-                    subtype.getName(),
-                    supertypeName
-                )
-                .isNotNull();
-            assertThat(typeNameAnn.value())
-                .as(
-                    "Permit %s declares @JsonTypeName(\"%s\") but Task's @JsonSubTypes registers " +
-                        "it as \"%s\" — the two must match",
-                    subtype.getName(),
-                    typeNameAnn.value(),
-                    supertypeName
-                )
-                .isEqualTo(supertypeName);
+            JsonTypeName typeNameAnn = entry.value().getAnnotation(JsonTypeName.class);
+            assertThat(typeNameAnn).as("%s must declare @JsonTypeName", entry.value()).isNotNull();
+            assertThat(typeNameAnn.value()).isEqualTo(entry.name());
         }
     }
 }


### PR DESCRIPTION
## Description

Eliminate the boot-time shell `cp` shim that bridged `/workspace/.pi-runtime/` → `/home/agent/.pi/` by pointing `PI_CODING_AGENT_DIR` at `/workspace/.pi` — the same workspace-relative location the server already injects to via `inputFiles`. Pi now reads its config (settings.json, AGENTS.md, extensions) directly from where it's staged, so drift between the two halves becomes structurally impossible.

The shim's stated rationale ("redirect writable runtime state away from the read-only /workspace mount") was factually wrong: `ContainerSecurityPolicy:33-37` documents that `/workspace` is intentionally writable, and the agent already writes to `/workspace/.output/`, `/workspace/.sessions/`, etc.

Notable side-effects of the consolidation:
- `WorkspaceAbi.PI_RUNTIME_PREFIX` constant deleted (dead after rename); `PI_AGENT_PREFIX` and the new `PI_AGENT_DIR` both derive from a single private `PI_AGENT_NAME` segment so the two forms can't drift.
- `pi-runner.mjs` now fail-fasts on missing `PI_CODING_AGENT_DIR` (matches the `AGENT_BUDGET_MS` pattern at the top of the same file); stale `|| "/home/agent/.pi"` fallbacks removed from both runners.
- `docker/agents/pi/Dockerfile` no longer pre-creates `/home/agent/.pi` — nothing reads from there.
- `DeliveryComposer` filter list drops `PI_RUNTIME_PREFIX`; static imports replace the FQN-per-line block.
- Three documented workspace trees (`workspace-abi.mdx`, `ai-code-review.mdx`, `PullRequestReviewHandler` javadoc) re-aligned to show the consolidated `.pi/` layout with its children.

Net diff: 12 files, +77 / -61. Production code is −14 net (real consolidation); test code is +16 net (one focused regression guard + one env-var assertion). Container cold-start drops three `cp` invocations and one conditional `cp`.

Fixes #1075

## Follow-on (folded from #1090/#1091)

The maintainer asked for the runtime-kernel + workspace-ABI bits of the closed correctness-sweep and SPI-hygiene PRs to land *here*, adjacent to the staging consolidation, instead of as standalone follow-ups. The shared theme is "the kernel/workspace contract should be single-sourced, type-safe, and validated at boot." Items in this PR:

- **`WorkspaceAbi.MENTOR_SYSTEM_PROMPT_PATH` constant** (from #1090). The literal `"agent/mentor/system.md"` was scattered across `MentorPiAdapter` (writes the bytes) and `pi-mentor-runner.mjs` (reads them). Promoted to a single Java constant; the mentor adapter routes through it; the JS runner pins it as a top-level local and `WorkspaceAbiSyncTest` greps the file against the Java value. `git grep -n "agent/mentor/system.md" server/application-server/src/main` now shows exactly the Java declaration + JS sync line.
- **`pi-mentor-runner.mjs` envelope-mismatch exit 42** (from #1090). The mentor runner used `process.exit(2)` for *both* "envelope drift" and "uncaught crash" — same code, ambiguous failure mode. Now declares `ENVELOPE_MISMATCH_EXIT = 42` (matches `WorkspaceAbi.EXIT_ENVELOPE_MISMATCH`), adds a startup check against `MENTOR_RUNNER_EXPECTED_PROTOCOL_VERSION`, and repurposes legacy exit-2 paths to exit-1 (generic fatal). `WorkspaceAbiSyncTest` extended to scan the mentor runner for the constant value.
- **`TaskSealedHierarchyTest` restored** (from #1090). The reflection-based architecture guardrail was deleted in #1081's churn; `Task` could regain a permit without a matching `@JsonSubTypes` entry and serialise fine while breaking polymorphic *de*serialisation. Test asserts (a) `Task` stays `sealed`, (b) permits ≡ `@JsonSubTypes` set, (c) every permit carries `@JsonTypeName` matching the supertype-side registration. `Task.PracticeReview` gains the missing `@JsonTypeName` (the test's first failure surface).
- **`PiRunnerProfile` strategy** (from #1091). `PiRuntimeFactory.build()` had grown a 160-line god method with hardcoded `MENTOR_RUNNER_SCRIPT` filename dispatch, `nodeFlagsFor(kind)`, `nodeEnvFor(kind)`. Replaced with a profile interface — `PracticeRunnerProfile` + `MentorRunnerProfile` each own their own script filename, V8 flags, and per-process env fragment; the kernel reads three properties and renders. Profile is intentionally **non-sealed** (a sealed interface with `permits PracticeRunnerProfile, MentorRunnerProfile` would force `agent.runtime` to import its domain implementations — the precise dependency `AgentRuntimeBoundaryTest` forbids). New arch rule `PiRunnerProfilePlacement` enforces the same constraint structurally, mirroring the `ContentProvider` pattern.
- **`PiPlanSpec.extraInputs` workspace-path allowlist** (from #1091). Every key must appear in `WorkspaceAbi.allowedExtraInputPaths()` or be prefixed by an entry in `allowedExtraInputPrefixes()` — fails at construction time with a message naming the offending path. `MentorPiAdapter`'s `system.md` write is the first declared allowlist member; mentor session-restore writes go through `SESSIONS_DIR_PREFIX`. New `PiPlanSpecValidationTest` covers happy paths + the rejection message.
- **`runnerScript` config dead-property removed** (from #1091). `MentorAgentProperties.runnerScript` and `PiAgentProperties.runnerScript` were operator overrides that nobody ever used in production and risked drifting from the V8 flags / per-process env the kernel pairs with the script. Bumping the runner is a code change now.

Why fold in instead of stacking PRs: the staging consolidation already heavily modifies `PiRuntimeFactory.java`, `WorkspaceAbi.java`, and `pi-mentor-runner.mjs` — the three files most of these follow-ons also touch. Landing them as separate PRs would force three rebases on the same conflict surface for items that share the same "make the contract explicit" mental model.

## How to test

- Unit + architecture tests: `cd server/application-server && ./mvnw test -Dsurefire.includedGroups="unit | architecture"` — should report 2666 passing locally.
- Integration tests: `./mvnw test -Dsurefire.includedGroups="integration"` — should report 751 passing.
- Regression guard for the shim: `PiRuntimeFactoryTest#noCopyShim` asserts the boot command for a custom-provider-extension spec contains no ` cp ` substring. If a future change re-introduces a shell bridge for Pi config, this fails loudly.
- ABI sync gate: `WorkspaceAbiSyncTest#mentorRunnerLiteralsMatchAbi` greps `pi-mentor-runner.mjs` for the Java `CONTEXT_TARGET_PREFIX` / `MENTOR_SYSTEM_PROMPT_PATH` / `EXIT_ENVELOPE_MISMATCH=42` values. Drift on either side fails the test.
- Profile placement guard: `AgentRuntimeBoundaryTest$PiRunnerProfilePlacement` asserts every `PiRunnerProfile` impl resides under `agent.practice` or `agent.mentor`. A profile accidentally placed in `agent.runtime` (which would re-create the boundary violation a sealed interface would have introduced) fails the build.
- End-to-end against staging (manual): rebuild `ghcr.io/ls1intum/hephaestus/agent-pi:latest`, then `POST /actuator/dev/trigger-review?prId=<id>&workspaceId=1`. Confirm `result.json` is produced and stderr contains no Pi SDK errors reading from `~/.pi/`.
- Mentor chat session (manual): open a thread, send one prompt, confirm an LLM response — covers the parallel `MentorPiAdapter` codepath that consumes the same `PiPlan`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized runner profiles for mentor and practice agents, making runner configurations explicit and consistent.

* **Bug Fixes**
  * Fixed workspace path handling with improved validation for extra input paths.

* **Documentation**
  * Updated workspace directory layout documentation to reflect new `.pi/` structure with `AGENTS.md`, `settings.json`, and `extensions/` directories.

* **Chores**
  * Simplified workspace directory initialization; removed operator-configurable runner script properties in favor of predefined profiles.
  * Updated agent runtime environment variable usage and workspace path references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Hephaestus/pull/1088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->