### PR TITLE
chore(server): mentor capacity observability + dead-code cleanup

### DIFF
--- a/docs/contributor/agent/observability.mdx
+++ b/docs/contributor/agent/observability.mdx
@@ -1,0 +1,90 @@
+---
+id: agent-observability
+sidebar_position: 6
+title: Agent Observability
+description: Mentor and interactive-sandbox metrics — names, tags, intended alerts.
+---
+
+This page catalogues the Micrometer metrics emitted by the mentor pipeline and the interactive
+sandbox layer underneath it. Names are stable contracts with the dashboards — coordinate any
+rename through the on-call rotation before shipping.
+
+## Capacity & lifecycle
+
+### `interactive_sandbox.evicted_total{reason}`
+
+Counter, one increment per sandbox eviction.
+
+| Tag value | Meaning |
+| --- | --- |
+| `idle` | Session evicted because it crossed `hephaestus.mentor.idle-ttl-seconds`. |
+| `max_lifetime` | Session evicted because it crossed `hephaestus.mentor.max-lifetime-minutes` (absolute lifetime cap, default 60 min). |
+| `manual` | Explicit `close()` from the chat layer (e.g., poisoned sandbox after a `-32002`). |
+| `error` | Forced eviction due to a pump/writer fault. |
+| `natural_exit` | The runner subprocess exited cleanly. |
+| `daemon_unhealthy` | Docker daemon health check failed during reap. |
+
+`mentor.session.eviction{reason}` carries the same data with the legacy name retained for
+back-compat — both increment together. Alert on the SPI-aligned name.
+
+### `mentor.chat.outcome{outcome=CAPACITY_EXCEEDED}`
+
+Counter, increments when a turn is rejected because `InteractiveSandboxRegistry.tryRegister`
+returned `MAX_SESSIONS_PER_USER` or `MAX_SESSIONS_TOTAL`. **Distinguish from
+`outcome=ERROR` when alerting** — capacity rejections are policy-driven and expected under load
+(answer: add a replica or raise the cap); `ERROR` is a genuine failure that needs investigation.
+
+### `mentor.session.active`
+
+Gauge of currently-attached sandbox sessions on this replica. Useful as the denominator for
+capacity dashboards.
+
+## Frame pipeline
+
+### `interactive_sandbox.frame_ring.dropped_total{userId}`
+
+Per-user counter of ring-buffer overflows. Tagged by `userId` and **capped at 50 distinct
+users** by a `MeterFilter` (`MetricsCardinalityConfig`) — the 51st user's drops still hit the
+global counter but are not separately attributed.
+
+Per `(userId, sandboxId)` the increment is **debounced to at most once per second**. The buffer
+still drops every overflowed frame (no data loss in the *behaviour*; just the *metric* is
+rate-limited). Under sustained overflow you get a stable per-second signal instead of a flood.
+
+How to read it:
+
+- A spike on one user → that user's stream is producing tokens faster than the subscriber
+  can drain. Check their subscriber queue (`mentor.subscriber.dropped`) — if it's also high,
+  the SSE pipe is saturated.
+- Several users at once → the **ring is too small for production traffic**. Raise
+  `hephaestus.mentor.ring-buffer-frames` (default `512`) after confirming via this metric.
+  The default has **not yet been benchmarked against real Pi token-delta volumes** — it is the
+  starting point for the observation, not the final answer.
+
+### `mentor.ring.buffer.dropped`
+
+Global, untagged counter — always increments, regardless of cardinality cap or debounce.
+Useful for the gross "is the system dropping frames at all" question. The per-user counter
+above is for attribution; this one is for total volume.
+
+## Send / receive bytes
+
+`mentor.send.frame.bytes{direction=in|out}` — bytes pushed to runner stdin / received from
+runner stdout. A clean way to compute steady-state token throughput.
+
+`mentor.send.rejected{reason}` — `send()` rejections by reason (`queue_full`, `write_timeout`,
+`broken_pipe`, `closed`). `queue_full` rising = upstream is producing faster than the runner
+can absorb.
+
+## Tuning knobs (none auto-bumped in this PR)
+
+The defaults are conservative starting points:
+
+- `hephaestus.mentor.ring-buffer-frames=512` — observe `frame_ring.dropped_total` for a week
+  before deciding to raise; bumping it eats per-session heap proportionally.
+- `hephaestus.mentor.max-lifetime-minutes=60` — backstop against runners that accumulate
+  state or leak FDs over hours. Range `[5, 480]`. Too low evicts chatty users; too high lets
+  a leaky runner drink resources before idle eviction catches it.
+
+This page intentionally **does not** raise either default — the right number comes from the
+metrics, not from a guess.

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatMetrics.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatMetrics.java
@@ -39,6 +39,12 @@ public class MentorChatMetrics {
         IN_FLIGHT_CONFLICT_LOCAL("in_flight_conflict_local"),
         IN_FLIGHT_CONFLICT_DB("in_flight_conflict_db"),
         REJECTED("rejected"),
+        /**
+         * Sandbox registration was denied because a capacity cap fired — either per-user or
+         * per-replica. Distinct from {@link #ERROR} so capacity-driven alerts don't bury a
+         * genuine failure (and vice versa).
+         */
+        CAPACITY_EXCEEDED("capacity_exceeded"),
         ERROR("error");
 
         private final String tag;

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatService.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatService.java
@@ -20,6 +20,7 @@ import de.tum.in.www1.hephaestus.agent.mentor.chat.wire.PiEventToUiChunkTranslat
 import de.tum.in.www1.hephaestus.agent.mentor.chat.wire.TranslatorState;
 import de.tum.in.www1.hephaestus.agent.mentor.chat.wire.UIMessageChunk;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.AttachedSandbox;
+import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxCapacityExceededException;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxService;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxSpec;
 import de.tum.in.www1.hephaestus.gitprovider.user.User;
@@ -306,6 +307,20 @@ public class MentorChatService {
             persistence.interrupt(cookie, state, timeout);
             channel.completeWithError("Mentor turn timed out before completion.");
             outcome = MentorChatMetrics.Outcome.TIMEOUT;
+        } catch (InteractiveSandboxCapacityExceededException capacity) {
+            // Per-user or per-replica cap — surfaceable on the dashboard as a capacity signal,
+            // NOT an error. INFO (not WARN): hitting the cap is policy-driven, expected behaviour
+            // under load; alerts on `mentor.turn.completed{outcome=CAPACITY_EXCEEDED}` should split
+            // from `outcome=ERROR` so on-call doesn't get paged when the fleet just needs scaling.
+            log.info(
+                "Mentor turn rejected by sandbox capacity (threadId={}, scope={}): {}",
+                request.threadId(),
+                capacity.scope(),
+                capacity.getMessage()
+            );
+            persistence.interrupt(cookie, state, capacity);
+            channel.completeWithError(userFacingError(capacity));
+            outcome = MentorChatMetrics.Outcome.CAPACITY_EXCEEDED;
         } catch (ClientDisconnectedException disconnect) {
             // Browser closed mid-turn (tab close, refresh, network blip). This is NOT a turn
             // failure: the runner subscription keeps draining and `handleEvent` will still call
@@ -501,6 +516,11 @@ public class MentorChatService {
      * Raw message stays in the WARN log for ops.
      */
     private static String userFacingError(Throwable e) {
+        if (e instanceof InteractiveSandboxCapacityExceededException capacity) {
+            return capacity.scope() == InteractiveSandboxCapacityExceededException.Scope.PER_USER
+                ? "You have too many mentor sessions open right now — close one and try again."
+                : "Mentor service is at capacity — please retry in a moment.";
+        }
         if (e instanceof MentorRunnerException) {
             return "Mentor service hit an unexpected error — please retry.";
         }

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/InteractiveSandboxProperties.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/InteractiveSandboxProperties.java
@@ -25,6 +25,11 @@ import org.springframework.validation.annotation.Validated;
  *     encoded character can be up to 4 bytes, so the on-wire memory ceiling is roughly 4× this).
  *     A longer line is treated as a stream-level fault and the session terminates {@code ERROR}.
  *     Without this bound a hostile runner could OOM the app-server.
+ * @param maxLifetimeMinutes absolute lifetime cap. A session attached this long ago is evicted
+ *     on the next reap tick regardless of recent activity — a backstop against runners that
+ *     accumulate state, drift on context, or leak file descriptors over time. Range {@code [5, 480]}
+ *     is a guard rail: too low and chatty users get evicted mid-conversation; too high and a
+ *     leaky runner can chew through the daemon's resources before idle eviction catches it.
  */
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.mentor")
@@ -39,5 +44,6 @@ public record InteractiveSandboxProperties(
     @DefaultValue("30") @Min(1) int attachFirstFrameTimeoutSeconds,
     @DefaultValue("3") @Min(1) int maxSessionsPerUser,
     @DefaultValue("50") @Min(1) int maxSessionsTotal,
-    @DefaultValue("1048576") @Min(1024) int maxFrameChars
+    @DefaultValue("1048576") @Min(1024) int maxFrameChars,
+    @DefaultValue("60") @Min(5) @Max(480) int maxLifetimeMinutes
 ) {}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerAttachedSandboxAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerAttachedSandboxAdapter.java
@@ -29,7 +29,8 @@ import reactor.core.Disposable;
  * Per-session adapter: owns the docker-exec subprocess, JSONL pump + writer, ring buffer, and
  * subscriber fan-out. State transitions {@code ATTACHED → CLOSING → CLOSED} are CAS-guarded.
  */
-public final class DockerAttachedSandboxAdapter implements AttachedSandbox, StdinWriteWatchdog.StallTarget {
+public final class DockerAttachedSandboxAdapter
+    implements AttachedSandbox, StdinWriteWatchdog.StallTarget, InteractiveSandboxRegistry.ReapTarget {
 
     private static final Logger log = LoggerFactory.getLogger(DockerAttachedSandboxAdapter.class);
 
@@ -246,8 +247,13 @@ public final class DockerAttachedSandboxAdapter implements AttachedSandbox, Stdi
         process.destroyForcibly();
     }
 
-    /** Forced close with a specific reason and the configured default grace. Idempotent. */
-    void terminate(EvictionReason reason) {
+    /**
+     * Forced close with a specific reason and the configured default grace. Idempotent. Public
+     * by virtue of {@link InteractiveSandboxRegistry.ReapTarget}, but {@code DockerAttachedSandbox}
+     * is itself a package-private surface — only the registry can resolve it.
+     */
+    @Override
+    public void terminate(EvictionReason reason) {
         if (!state.compareAndSet(AttachedSandboxState.ATTACHED, AttachedSandboxState.CLOSING)) {
             return;
         }
@@ -298,6 +304,12 @@ public final class DockerAttachedSandboxAdapter implements AttachedSandbox, Stdi
     }
 
     Instant attachedAt() {
+        return attachedAt;
+    }
+
+    /** SPI exposure of {@link #attachedAt}: required by the registry's lifetime reaper. */
+    @Override
+    public Instant createdAt() {
         return attachedAt;
     }
 
@@ -393,6 +405,10 @@ public final class DockerAttachedSandboxAdapter implements AttachedSandbox, Stdi
             EvictionReason reason = terminalReason.get();
             if (reason == null) reason = EvictionReason.ERROR;
             metrics.evictionsBy(reason).increment();
+            metrics.interactiveEvictedBy(reason).increment();
+            // Free the per-(user,sandbox) debounce entry: the 50-userId cardinality cap bounds
+            // the absolute table size, but evicting per session keeps churn under control.
+            metrics.evictDropDebounce(userId, sessionId);
 
             state.set(AttachedSandboxState.CLOSED);
             try {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxAdapter.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxAdapter.java
@@ -12,6 +12,7 @@ import de.tum.in.www1.hephaestus.agent.sandbox.docker.SandboxNetworkManager;
 import de.tum.in.www1.hephaestus.agent.sandbox.docker.SandboxWorkspaceManager;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.AttachedSandbox;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.EvictionReason;
+import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxCapacityExceededException;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxException;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxService;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxSpec;
@@ -222,10 +223,15 @@ public class DockerInteractiveSandboxAdapter implements InteractiveSandboxServic
                 }
                 case MAX_SESSIONS_PER_USER, MAX_SESSIONS_TOTAL -> {
                     metrics.attachFailureMaxSessions.increment();
-                    throw new InteractiveSandboxException(
-                        outcome == InteractiveSandboxRegistry.RegistrationOutcome.MAX_SESSIONS_PER_USER
-                            ? "Per-user session cap exceeded"
-                            : "Per-replica session cap exceeded"
+                    boolean perUser = outcome == InteractiveSandboxRegistry.RegistrationOutcome.MAX_SESSIONS_PER_USER;
+                    // Typed exception so the chat layer can route to the CAPACITY_EXCEEDED metric
+                    // outcome without string-matching on the message — alerts that split user-cap
+                    // from global-cap need the structured scope.
+                    throw new InteractiveSandboxCapacityExceededException(
+                        perUser
+                            ? InteractiveSandboxCapacityExceededException.Scope.PER_USER
+                            : InteractiveSandboxCapacityExceededException.Scope.GLOBAL,
+                        perUser ? "Per-user session cap exceeded" : "Per-replica session cap exceeded"
                     );
                 }
                 case REGISTERED -> registered = true;
@@ -288,7 +294,14 @@ public class DockerInteractiveSandboxAdapter implements InteractiveSandboxServic
         String networkId,
         PiProcessHandle process
     ) {
-        FrameRingBuffer ring = new FrameRingBuffer(properties.ringBufferFrames(), metrics.ringBufferDropped);
+        // Route every drop through the metrics facade so the per-user `frame_ring.dropped_total`
+        // counter sees the userId + sandboxId for debounce, while the global counter still ticks.
+        final java.util.UUID sandboxId = spec.sessionId();
+        final String userId = spec.userId();
+        FrameRingBuffer ring = new FrameRingBuffer(
+            properties.ringBufferFrames(),
+            () -> metrics.recordRingBufferDrop(userId, sandboxId)
+        );
         DockerAttachedSandboxAdapter.LifecycleOps lifecycleOps = new DockerAttachedSandboxAdapter.LifecycleOps() {
             @Override
             public void stopContainer(String cid, int graceSeconds) {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/FrameRingBuffer.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/FrameRingBuffer.java
@@ -1,29 +1,34 @@
 package de.tum.in.www1.hephaestus.agent.sandbox.docker.interactive;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.micrometer.core.instrument.Counter;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Bounded ring buffer of frames with drop-oldest on overflow. Frames carry a monotonic sequence
  * number; {@link #snapshotSince} lets a subscriber resume without duplicates from a known cursor.
+ *
+ * <p>The {@code onDrop} callback fires exactly once per evicted frame. The buffer itself stays
+ * metric-agnostic — the callback can route to one or more counters (debounced or not) without
+ * pulling Micrometer into the buffer's surface. Callbacks must be cheap and non-blocking; they
+ * run while holding the buffer's monitor.
  */
 final class FrameRingBuffer {
 
     private final int capacity;
     private final ArrayDeque<Entry> entries;
-    private final Counter droppedCounter;
+    private final Runnable onDrop;
     private long nextSequence;
 
-    FrameRingBuffer(int capacity, Counter droppedCounter) {
+    FrameRingBuffer(int capacity, Runnable onDrop) {
         if (capacity <= 0) {
             throw new IllegalArgumentException("capacity must be positive, got: " + capacity);
         }
         this.capacity = capacity;
         this.entries = new ArrayDeque<>(capacity);
-        this.droppedCounter = droppedCounter;
+        this.onDrop = Objects.requireNonNull(onDrop, "onDrop");
         this.nextSequence = 0L;
     }
 
@@ -31,7 +36,12 @@ final class FrameRingBuffer {
         long seq = nextSequence++;
         if (entries.size() == capacity) {
             entries.removeFirst();
-            droppedCounter.increment();
+            try {
+                onDrop.run();
+            } catch (RuntimeException ignored) {
+                // A metric callback throwing must not corrupt the buffer's state. The observability
+                // path is best-effort; the buffer's correctness guarantees are unconditional.
+            }
         }
         entries.addLast(new Entry(seq, frame));
         return seq;

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxMetrics.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxMetrics.java
@@ -5,8 +5,12 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.time.Clock;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Micrometer instruments for the interactive sandbox. Stable names — do not rename without
@@ -44,7 +48,42 @@ public final class InteractiveSandboxMetrics {
 
     private final Map<EvictionReason, Counter> evictionsByReason;
 
+    /**
+     * Parallel counter to {@link #evictionsByReason} under the SPI-aligned metric name. Kept
+     * pre-registered per reason so the hot path (eviction at close) is a single map lookup +
+     * counter increment with no allocation. The {@code mentor.session.eviction} variant is
+     * retained for dashboard back-compat — both increment together on every eviction.
+     */
+    private final Map<EvictionReason, Counter> interactiveEvictedByReason;
+
+    /**
+     * Per-user counter for {@code interactive_sandbox.frame_ring.dropped_total}. The cardinality
+     * cap (50 distinct userIds across the JVM) is enforced upstream by a {@code MeterFilter} —
+     * any further userId triggers a {@code denyAll} for THIS specific counter only, so the rest
+     * of the registry is unaffected.
+     */
+    private final ConcurrentHashMap<String, Counter> userDroppedCounters = new ConcurrentHashMap<>();
+
+    /**
+     * Debounce table: max one increment per second per {@code (userId, sandboxId)} pair. The
+     * buffer drop itself is unconditional — only the counter increment is throttled. Entries
+     * are evicted when {@link #evictDropDebounce(String, UUID)} is called from the per-sandbox
+     * close path; the 50-userId cardinality cap bounds the absolute size in the meantime.
+     */
+    private final ConcurrentHashMap<String, AtomicLong> dropDebounce = new ConcurrentHashMap<>();
+
+    private final MeterRegistry registry;
+    private final Clock clock;
+    private static final long DROP_DEBOUNCE_INTERVAL_MS = 1_000L;
+
     public InteractiveSandboxMetrics(MeterRegistry registry) {
+        this(registry, Clock.systemUTC());
+    }
+
+    /** Test seam — production wiring goes through {@link #InteractiveSandboxMetrics(MeterRegistry)}. */
+    InteractiveSandboxMetrics(MeterRegistry registry, Clock clock) {
+        this.registry = registry;
+        this.clock = clock;
         this.attachFailureImage = attachFailure(registry, "image_pull_failed");
         this.attachFailureStart = attachFailure(registry, "container_start_failed");
         this.attachFailureStdin = attachFailure(registry, "stdin_open_failed");
@@ -98,6 +137,7 @@ public final class InteractiveSandboxMetrics {
             .register(registry);
 
         this.evictionsByReason = new EnumMap<>(EvictionReason.class);
+        this.interactiveEvictedByReason = new EnumMap<>(EvictionReason.class);
         for (EvictionReason r : EvictionReason.values()) {
             evictionsByReason.put(
                 r,
@@ -106,11 +146,76 @@ public final class InteractiveSandboxMetrics {
                     .description("Session evictions by reason (covers all termination causes)")
                     .register(registry)
             );
+            interactiveEvictedByReason.put(
+                r,
+                Counter.builder("interactive_sandbox.evicted")
+                    .tag("reason", r.tag())
+                    .description("Interactive sandbox evictions by reason (SPI-aligned metric name)")
+                    .register(registry)
+            );
         }
     }
 
     Counter evictionsBy(EvictionReason reason) {
         return evictionsByReason.get(reason);
+    }
+
+    /**
+     * Pre-registered counter for {@code interactive_sandbox.evicted_total{reason}}. Both this
+     * and {@link #evictionsBy(EvictionReason)} are incremented from the same call site so the
+     * two metric streams agree.
+     */
+    Counter interactiveEvictedBy(EvictionReason reason) {
+        return interactiveEvictedByReason.get(reason);
+    }
+
+    /**
+     * Record a ring-buffer drop for {@code (userId, sandboxId)}. The caller is responsible for
+     * the actual buffer eviction; this only manages the metric increment. Two effects:
+     *
+     * <ol>
+     *   <li>Global counter {@link #ringBufferDropped} is always incremented (cheap, untagged).
+     *   <li>Per-user counter {@code interactive_sandbox.frame_ring.dropped_total{userId}} is
+     *       incremented at most once per {@value #DROP_DEBOUNCE_INTERVAL_MS}ms per
+     *       {@code (userId, sandboxId)} pair. Under steady-state overflow the per-second cap
+     *       gives dashboards a stable rate without amplifying registry pressure.
+     * </ol>
+     */
+    void recordRingBufferDrop(String userId, UUID sandboxId) {
+        ringBufferDropped.increment();
+        if (userId == null || sandboxId == null) {
+            return;
+        }
+        long now = clock.millis();
+        String key = userId + ':' + sandboxId;
+        AtomicLong lastEmit = dropDebounce.computeIfAbsent(key, k -> new AtomicLong(0L));
+        long prev = lastEmit.get();
+        if (now - prev < DROP_DEBOUNCE_INTERVAL_MS) {
+            return;
+        }
+        if (!lastEmit.compareAndSet(prev, now)) {
+            // Another thread won the CAS within the same window — they recorded, we skip.
+            return;
+        }
+        userDroppedCounter(userId).increment();
+    }
+
+    /**
+     * Eviction hook called from the per-sandbox close path. The debounce map is bounded by the
+     * 50-userId cardinality cap, but evicting per-sandbox keeps it tight under user churn.
+     */
+    void evictDropDebounce(String userId, UUID sandboxId) {
+        if (userId == null || sandboxId == null) return;
+        dropDebounce.remove(userId + ':' + sandboxId);
+    }
+
+    private Counter userDroppedCounter(String userId) {
+        return userDroppedCounters.computeIfAbsent(userId, u ->
+            Counter.builder("interactive_sandbox.frame_ring.dropped")
+                .tag("userId", u)
+                .description("Per-user frame ring overflow drops (debounced to <=1/s per session, capped at 50 distinct users)")
+                .register(registry)
+        );
     }
 
     private static Counter attachFailure(MeterRegistry registry, String reason) {

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistry.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistry.java
@@ -11,7 +11,9 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import jakarta.annotation.PreDestroy;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -38,6 +40,7 @@ public class InteractiveSandboxRegistry {
     private final SandboxContainerManager containerManager;
     private final InteractiveSandboxMetrics metrics;
     private final StdinWriteWatchdog watchdog;
+    private final Clock clock;
 
     private final ConcurrentHashMap<SessionKey, DockerAttachedSandboxAdapter> sessions = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, AtomicInteger> sessionsPerUser = new ConcurrentHashMap<>();
@@ -50,10 +53,26 @@ public class InteractiveSandboxRegistry {
         StdinWriteWatchdog watchdog,
         MeterRegistry meterRegistry
     ) {
+        this(properties, containerManager, metrics, watchdog, meterRegistry, Clock.systemUTC());
+    }
+
+    /**
+     * Test seam: a constructor-injected {@link Clock} lets {@code MAX_LIFETIME} reaper tests
+     * advance time without {@code Thread.sleep}. Production wiring uses {@link Clock#systemUTC()}.
+     */
+    InteractiveSandboxRegistry(
+        InteractiveSandboxProperties properties,
+        SandboxContainerManager containerManager,
+        InteractiveSandboxMetrics metrics,
+        StdinWriteWatchdog watchdog,
+        MeterRegistry meterRegistry,
+        Clock clock
+    ) {
         this.properties = properties;
         this.containerManager = containerManager;
         this.metrics = metrics;
         this.watchdog = watchdog;
+        this.clock = clock;
         Gauge.builder("mentor.session.active", sessions, ConcurrentHashMap::size)
             .description("Currently attached mentor sandbox sessions on this replica")
             .register(meterRegistry);
@@ -144,9 +163,32 @@ public class InteractiveSandboxRegistry {
             // and we'd run runClose inline on the scheduler thread, stalling the watchdog.
             return;
         }
+        reapInternal(sessions.values());
+    }
+
+    /**
+     * Pure reap logic over an arbitrary iterable — extracted so tests can drive a synthetic set
+     * of sandboxes without funneling through the full register/start machinery. Production wiring
+     * always passes {@code sessions.values()}.
+     */
+    void reapInternal(Iterable<? extends ReapTarget> targets) {
         Duration ttl = Duration.ofSeconds(properties.idleTtlSeconds());
-        for (DockerAttachedSandboxAdapter sandbox : sessions.values()) {
+        Duration maxLifetime = Duration.ofMinutes(properties.maxLifetimeMinutes());
+        Instant now = clock.instant();
+        for (ReapTarget sandbox : targets) {
             if (sandbox.state() != AttachedSandboxState.ATTACHED) {
+                continue;
+            }
+            // Lifetime check first: a chatty user who never goes idle would otherwise stay
+            // attached forever and the idle-only reaper never fires for them.
+            Duration lifetime = Duration.between(sandbox.createdAt(), now);
+            if (lifetime.compareTo(maxLifetime) > 0) {
+                log.info(
+                    "Reaping sandbox past max lifetime: sessionId={}, lifetimeMinutes={}",
+                    sandbox.sessionId(),
+                    lifetime.toMinutes()
+                );
+                sandbox.terminate(EvictionReason.MAX_LIFETIME);
                 continue;
             }
             if (sandbox.idleFor().compareTo(ttl) > 0) {
@@ -160,6 +202,18 @@ public class InteractiveSandboxRegistry {
                 sandbox.terminate(EvictionReason.IDLE);
             }
         }
+    }
+
+    /**
+     * Narrow surface the reaper actually needs. The production {@link DockerAttachedSandboxAdapter}
+     * trivially conforms; the test uses a hand-rolled fake to avoid having to mock a final class.
+     */
+    interface ReapTarget {
+        AttachedSandboxState state();
+        Instant createdAt();
+        Duration idleFor();
+        java.util.UUID sessionId();
+        void terminate(EvictionReason reason);
     }
 
     @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.SECONDS)

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/spi/AttachedSandbox.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/spi/AttachedSandbox.java
@@ -52,6 +52,17 @@ public interface AttachedSandbox extends AutoCloseable {
     Duration idleFor();
 
     /**
+     * Wall-clock instant the session was attached. Used by the registry's lifetime reaper to
+     * evict sessions that have accumulated state past a configured maximum. Every implementation
+     * captures this at construction time — the {@code default} fallback here exists only so a
+     * future SPI consumer that forgets to implement it returns a sensible value (caller treats
+     * "now" as a brand-new session, so the reaper simply won't fire).
+     */
+    default Instant createdAt() {
+        return Instant.now();
+    }
+
+    /**
      * Stops the underlying container with {@code docker stop --time=graceTimeout} (SIGTERM →
      * grace → SIGKILL), then removes it. Idempotent. The hard SIGKILL mitigates the Pi SDK
      * abort-hang risk.

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/spi/InteractiveSandboxCapacityExceededException.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/agent/sandbox/spi/InteractiveSandboxCapacityExceededException.java
@@ -1,0 +1,32 @@
+package de.tum.in.www1.hephaestus.agent.sandbox.spi;
+
+/**
+ * Thrown by the interactive sandbox when registration is denied because a capacity cap has been
+ * hit — either {@code hephaestus.mentor.max-sessions-per-user} (a user has too many concurrent
+ * sessions) or {@code hephaestus.mentor.max-sessions-total} (the replica is full).
+ *
+ * <p>This is a typed sibling of {@link InteractiveSandboxException} so upstream callers
+ * (notably {@code MentorChatService}) can route cap rejections to a dedicated metric outcome
+ * ({@code CAPACITY_EXCEEDED}) without string-matching on the message. The two cases share an
+ * enum to keep the wire-format stable; the dashboard alert split between them is one tag away.
+ */
+public class InteractiveSandboxCapacityExceededException extends InteractiveSandboxException {
+
+    public enum Scope {
+        /** Caller has the maximum permitted concurrent sessions for their user. */
+        PER_USER,
+        /** This replica is at the global cap. Future capacity work may shed via a different replica. */
+        GLOBAL,
+    }
+
+    private final Scope scope;
+
+    public InteractiveSandboxCapacityExceededException(Scope scope, String message) {
+        super(message);
+        this.scope = scope;
+    }
+
+    public Scope scope() {
+        return scope;
+    }
+}

--- a/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/MetricsCardinalityConfig.java
+++ b/server/application-server/src/main/java/de/tum/in/www1/hephaestus/config/MetricsCardinalityConfig.java
@@ -1,0 +1,38 @@
+package de.tum.in.www1.hephaestus.config;
+
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Defensive cardinality caps for Micrometer counters with potentially unbounded tag values.
+ *
+ * <p>{@code MeterRegistry} bombs (label explosions) account for a sizeable share of observability
+ * outages — once a meter is registered with a high-cardinality tag, evicting it is impractical.
+ * The fix is upstream: cap the distinct values at the registration site via {@link MeterFilter}.
+ *
+ * <p>Filters here are kept narrow on purpose. They target only the metric+tag pairs where the
+ * application code can theoretically register many distinct values; everything else uses
+ * pre-registered enums.
+ */
+@Configuration
+public class MetricsCardinalityConfig {
+
+    /**
+     * Cap the {@code interactive_sandbox.frame_ring.dropped_total{userId}} counter at 50 distinct
+     * userIds across the JVM. The 51st user is silently denied — the buffer still drops frames,
+     * the global counter still ticks, only the per-user attribution is lost. 50 is generous
+     * relative to the per-replica session cap (the registry defaults to {@code maxSessionsTotal=50}),
+     * so under normal traffic this never trips. The filter applies to THIS meter only —
+     * unrelated counters that happen to share a {@code userId} tag are unaffected.
+     */
+    @Bean
+    public MeterFilter frameRingDroppedUserCardinalityCap() {
+        return MeterFilter.maximumAllowableTags(
+            "interactive_sandbox.frame_ring.dropped",
+            "userId",
+            50,
+            MeterFilter.deny()
+        );
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/mentor/chat/MentorChatServiceTest.java
@@ -24,6 +24,7 @@ import de.tum.in.www1.hephaestus.agent.mentor.chat.wire.PiEventToUiChunkTranslat
 import de.tum.in.www1.hephaestus.agent.mentor.chat.wire.UIMessageChunk;
 import de.tum.in.www1.hephaestus.agent.sandbox.ImagePullPolicy;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.AttachedSandbox;
+import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxCapacityExceededException;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxException;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxService;
 import de.tum.in.www1.hephaestus.agent.sandbox.spi.InteractiveSandboxSpec;
@@ -350,6 +351,48 @@ class MentorChatServiceTest extends BaseUnitTest {
         // "load-shed retry". This persistence-throws path triggers the DB-index outcome —
         // the JVM lock was acquired, so the conflict comes from the durable backstop.
         assertOutcomeRecorded(MentorChatMetrics.Outcome.IN_FLIGHT_CONFLICT_DB);
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // 4a. Sandbox capacity (per-user/global cap) — distinct from ERROR
+    // ════════════════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("per-user cap exceeded: outcome=CAPACITY_EXCEEDED (not ERROR)")
+    void runTurn_perUserCapExceeded_recordsCapacityExceeded() throws Exception {
+        when(interactiveSandboxService.attach(any())).thenThrow(
+            new InteractiveSandboxCapacityExceededException(
+                InteractiveSandboxCapacityExceededException.Scope.PER_USER,
+                "Per-user session cap exceeded"
+            )
+        );
+
+        runTurnSync();
+
+        // Persistence sees an interrupted row (cap rejection is observable as a failed turn for
+        // the user, just not a *bug* failure).
+        verify(persistence).interrupt(any(), any(), any(Throwable.class));
+        assertThat(emitter.recordedTypes()).contains("error");
+        assertThat(turnLock.activeKeys()).isZero();
+        // Critical: this is the metric the dashboard alert splits on — capacity rejections must
+        // not bury a real ERROR signal (and vice versa).
+        assertOutcomeRecorded(MentorChatMetrics.Outcome.CAPACITY_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("global cap exceeded: outcome=CAPACITY_EXCEEDED (same outcome as per-user)")
+    void runTurn_globalCapExceeded_recordsCapacityExceeded() throws Exception {
+        when(interactiveSandboxService.attach(any())).thenThrow(
+            new InteractiveSandboxCapacityExceededException(
+                InteractiveSandboxCapacityExceededException.Scope.GLOBAL,
+                "Per-replica session cap exceeded"
+            )
+        );
+
+        runTurnSync();
+
+        verify(persistence).interrupt(any(), any(), any(Throwable.class));
+        assertOutcomeRecorded(MentorChatMetrics.Outcome.CAPACITY_EXCEEDED);
     }
 
     /**

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/SandboxArchitectureTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/SandboxArchitectureTest.java
@@ -52,6 +52,24 @@ class SandboxArchitectureTest extends HephaestusArchitectureTest {
                 .because("SPI types must not leak implementation details");
             rule.check(classes);
         }
+
+        @Test
+        @DisplayName("SPI types must not depend on Micrometer")
+        void spiHasNoMicrometerDeps() {
+            ArchRule rule = noClasses()
+                .that()
+                .resideInAPackage(SANDBOX_SPI)
+                .should()
+                .dependOnClassesThat()
+                .resideInAPackage("io.micrometer..")
+                .because(
+                    "SPI must stay transport- and observability-agnostic. " +
+                        "Metrics live in docker.interactive.* and agent.mentor.chat.* only — " +
+                        "depending on Micrometer here would force every future SPI consumer " +
+                        "to ship a MeterRegistry whether they care about metrics or not."
+                );
+            rule.check(classes);
+        }
     }
 
     @Nested

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
@@ -112,7 +112,8 @@ class DockerInteractiveSandboxLiveTest {
             /* attachFirstFrameTimeoutSeconds */ 15,
             /* maxSessionsPerUser */ 3,
             /* maxSessionsTotal */ 50,
-            /* maxFrameChars */ 64 * 1024
+            /* maxFrameChars */ 64 * 1024,
+            /* maxLifetimeMinutes */ 60
         );
 
         dockerClient = DockerClientImpl.getInstance(

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/FrameRingBufferMetricsTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/FrameRingBufferMetricsTest.java
@@ -1,0 +1,156 @@
+package de.tum.in.www1.hephaestus.agent.sandbox.docker.interactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.node.IntNode;
+import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behaviour of the per-user ring-buffer drop counter:
+ *
+ * <ul>
+ *   <li>Buffer drops are unconditional — every overflow records to the global counter.
+ *   <li>The per-user tagged counter is debounced to at most one increment per second per
+ *       {@code (userId, sandboxId)} pair.
+ * </ul>
+ */
+@DisplayName("FrameRingBuffer: per-user drop metric")
+class FrameRingBufferMetricsTest extends BaseUnitTest {
+
+    @Test
+    @DisplayName("100 drops within 1ms produce exactly 1 per-user increment but 100 global increments")
+    void debouncesWithinOneSecondWindow() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AtomicLong fakeMillis = new AtomicLong(1_000_000L);
+        Clock fixed = clockOf(fakeMillis);
+        InteractiveSandboxMetrics metrics = new InteractiveSandboxMetrics(registry, fixed);
+
+        String userId = "u1";
+        UUID sandboxId = UUID.randomUUID();
+        FrameRingBuffer ring = new FrameRingBuffer(8, () -> metrics.recordRingBufferDrop(userId, sandboxId));
+
+        // Fill to capacity, then drop 100 frames in the same 1ms tick.
+        for (int i = 0; i < 8; i++) ring.offer(IntNode.valueOf(i));
+        for (int i = 0; i < 100; i++) ring.offer(IntNode.valueOf(i));
+
+        assertThat(metrics.ringBufferDropped.count()).isEqualTo(100.0);
+        Counter perUser = registry
+            .find("interactive_sandbox.frame_ring.dropped")
+            .tag("userId", userId)
+            .counter();
+        assertThat(perUser).isNotNull();
+        // First call sets the timestamp; subsequent calls within 1s window are dropped.
+        assertThat(perUser.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("drops across multiple 1s windows produce one increment per window")
+    void emitOncePerSecondWindow() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AtomicLong fakeMillis = new AtomicLong(2_000_000L);
+        Clock fixed = clockOf(fakeMillis);
+        InteractiveSandboxMetrics metrics = new InteractiveSandboxMetrics(registry, fixed);
+
+        String userId = "u2";
+        UUID sandboxId = UUID.randomUUID();
+        FrameRingBuffer ring = new FrameRingBuffer(4, () -> metrics.recordRingBufferDrop(userId, sandboxId));
+
+        for (int i = 0; i < 4; i++) ring.offer(IntNode.valueOf(i));
+
+        long durationMillis = 5_500L; // 5.5 seconds of dropping
+        long start = fakeMillis.get();
+        long end = start + durationMillis;
+        int totalDrops = 0;
+        while (fakeMillis.get() < end) {
+            ring.offer(IntNode.valueOf(99));
+            totalDrops++;
+            fakeMillis.addAndGet(50L); // advance 50ms between drops
+        }
+        assertThat(metrics.ringBufferDropped.count()).isEqualTo((double) totalDrops);
+
+        Counter perUser = registry
+            .find("interactive_sandbox.frame_ring.dropped")
+            .tag("userId", userId)
+            .counter();
+        assertThat(perUser).isNotNull();
+        // Spec contract: at most ceil(durationMillis / 1000) + 1 increments.
+        double upperBound = Math.ceil(durationMillis / 1000.0) + 1.0;
+        assertThat(perUser.count()).isLessThanOrEqualTo(upperBound);
+        // And at least one — first eviction must record.
+        assertThat(perUser.count()).isGreaterThanOrEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("distinct users produce distinct tagged counters")
+    void distinctUsersTracked() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        // Start time must be > DROP_DEBOUNCE_INTERVAL_MS (1000 ms): each (userId, sandbox) pair
+        // has its own initial last-emit of 0, so `now - 0` must clear the window for the first
+        // call to record. A 0-millis clock would silently swallow the first emit on every key.
+        AtomicLong fakeMillis = new AtomicLong(10_000L);
+        InteractiveSandboxMetrics metrics = new InteractiveSandboxMetrics(registry, clockOf(fakeMillis));
+
+        UUID sandbox = UUID.randomUUID();
+        metrics.recordRingBufferDrop("alice", sandbox);
+        metrics.recordRingBufferDrop("bob", sandbox);
+
+        assertThat(registry.find("interactive_sandbox.frame_ring.dropped").tag("userId", "alice").counter().count())
+            .isEqualTo(1.0);
+        assertThat(registry.find("interactive_sandbox.frame_ring.dropped").tag("userId", "bob").counter().count())
+            .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("evictDropDebounce removes the per-pair tracking entry — next drop emits again immediately")
+    void evictResetsDebounceWindow() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        AtomicLong fakeMillis = new AtomicLong(1_000_000L);
+        InteractiveSandboxMetrics metrics = new InteractiveSandboxMetrics(registry, clockOf(fakeMillis));
+
+        String userId = "u3";
+        UUID sandboxId = UUID.randomUUID();
+        metrics.recordRingBufferDrop(userId, sandboxId);
+        // Second call inside the same window is suppressed.
+        metrics.recordRingBufferDrop(userId, sandboxId);
+        Counter c = registry.find("interactive_sandbox.frame_ring.dropped").tag("userId", userId).counter();
+        assertThat(c.count()).isEqualTo(1.0);
+
+        metrics.evictDropDebounce(userId, sandboxId);
+        // After eviction the debounce timestamp is gone — next call emits even though no time passed.
+        metrics.recordRingBufferDrop(userId, sandboxId);
+        assertThat(c.count()).isEqualTo(2.0);
+    }
+
+    private static Clock clockOf(AtomicLong millisSource) {
+        return new Clock() {
+            @Override
+            public ZoneId getZone() {
+                return ZoneId.systemDefault();
+            }
+
+            @Override
+            public Clock withZone(ZoneId zone) {
+                return this;
+            }
+
+            @Override
+            public Instant instant() {
+                return Instant.ofEpochMilli(millisSource.get());
+            }
+
+            @Override
+            public long millis() {
+                return millisSource.get();
+            }
+        };
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/FrameRingBufferTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/FrameRingBufferTest.java
@@ -6,9 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,13 +16,14 @@ import org.junit.jupiter.api.Test;
 @DisplayName("FrameRingBuffer")
 class FrameRingBufferTest extends BaseUnitTest {
 
-    private Counter dropped;
+    private AtomicInteger drops;
+    private Runnable onDrop;
     private FrameRingBuffer buffer;
 
     @BeforeEach
     void setUp() {
-        SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        dropped = registry.counter("test.dropped");
+        drops = new AtomicInteger();
+        onDrop = drops::incrementAndGet;
     }
 
     @Nested
@@ -33,32 +33,46 @@ class FrameRingBufferTest extends BaseUnitTest {
         @Test
         @DisplayName("rejects non-positive capacity")
         void rejectsBadCapacity() {
-            assertThatThrownBy(() -> new FrameRingBuffer(0, dropped)).isInstanceOf(IllegalArgumentException.class);
-            assertThatThrownBy(() -> new FrameRingBuffer(-3, dropped)).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> new FrameRingBuffer(0, onDrop)).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> new FrameRingBuffer(-3, onDrop)).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("accepts under-capacity offers without dropping")
         void underCapacityNoDropping() {
-            buffer = new FrameRingBuffer(4, dropped);
+            buffer = new FrameRingBuffer(4, onDrop);
             buffer.offer(IntNode.valueOf(1));
             buffer.offer(IntNode.valueOf(2));
             buffer.offer(IntNode.valueOf(3));
             assertThat(buffer.size()).isEqualTo(3);
-            assertThat(dropped.count()).isZero();
+            assertThat(drops.get()).isZero();
         }
 
         @Test
-        @DisplayName("drops oldest on overflow and increments counter")
+        @DisplayName("drops oldest on overflow and fires onDrop")
         void dropOldestOnOverflow() {
-            buffer = new FrameRingBuffer(3, dropped);
+            buffer = new FrameRingBuffer(3, onDrop);
             for (int i = 1; i <= 5; i++) {
                 buffer.offer(IntNode.valueOf(i));
             }
             assertThat(buffer.size()).isEqualTo(3);
-            assertThat(dropped.count()).isEqualTo(2.0);
+            assertThat(drops.get()).isEqualTo(2);
             List<JsonNode> snap = buffer.snapshotSince(-1L);
             assertThat(snap).extracting(JsonNode::intValue).containsExactly(3, 4, 5);
+        }
+
+        @Test
+        @DisplayName("a throwing onDrop callback does not corrupt the buffer state")
+        void throwingCallbackIsSwallowed() {
+            buffer = new FrameRingBuffer(2, () -> {
+                throw new RuntimeException("boom");
+            });
+            buffer.offer(IntNode.valueOf(1));
+            buffer.offer(IntNode.valueOf(2));
+            // Eviction path runs the callback, which throws; offer must still complete.
+            buffer.offer(IntNode.valueOf(3));
+            assertThat(buffer.size()).isEqualTo(2);
+            assertThat(buffer.snapshotSince(-1L)).extracting(JsonNode::intValue).containsExactly(2, 3);
         }
     }
 
@@ -69,7 +83,7 @@ class FrameRingBufferTest extends BaseUnitTest {
         @Test
         @DisplayName("snapshotSince(-1) returns all retained frames in arrival order")
         void snapshotAll() {
-            buffer = new FrameRingBuffer(4, dropped);
+            buffer = new FrameRingBuffer(4, onDrop);
             buffer.offer(IntNode.valueOf(10));
             buffer.offer(IntNode.valueOf(20));
             buffer.offer(IntNode.valueOf(30));
@@ -79,7 +93,7 @@ class FrameRingBufferTest extends BaseUnitTest {
         @Test
         @DisplayName("snapshotSince(cursor) returns only frames newer than cursor")
         void snapshotSinceCursor() {
-            buffer = new FrameRingBuffer(4, dropped);
+            buffer = new FrameRingBuffer(4, onDrop);
             long s0 = buffer.offer(IntNode.valueOf(100));
             long s1 = buffer.offer(IntNode.valueOf(200));
             long s2 = buffer.offer(IntNode.valueOf(300));
@@ -91,7 +105,7 @@ class FrameRingBufferTest extends BaseUnitTest {
         @Test
         @DisplayName("monotonic sequence numbers — never reused after eviction")
         void sequenceMonotonic() {
-            buffer = new FrameRingBuffer(2, dropped);
+            buffer = new FrameRingBuffer(2, onDrop);
             long s0 = buffer.offer(IntNode.valueOf(1));
             long s1 = buffer.offer(IntNode.valueOf(2));
             long s2 = buffer.offer(IntNode.valueOf(3));

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistryTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/InteractiveSandboxRegistryTest.java
@@ -1,0 +1,194 @@
+package de.tum.in.www1.hephaestus.agent.sandbox.docker.interactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import de.tum.in.www1.hephaestus.agent.sandbox.InteractiveSandboxProperties;
+import de.tum.in.www1.hephaestus.agent.sandbox.docker.SandboxContainerManager;
+import de.tum.in.www1.hephaestus.agent.sandbox.spi.AttachedSandboxState;
+import de.tum.in.www1.hephaestus.agent.sandbox.spi.EvictionReason;
+import de.tum.in.www1.hephaestus.testconfig.BaseUnitTest;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("InteractiveSandboxRegistry: reap policy")
+class InteractiveSandboxRegistryTest extends BaseUnitTest {
+
+    private static InteractiveSandboxProperties propertiesWith(int maxLifetimeMinutes, int idleTtlSeconds) {
+        return new InteractiveSandboxProperties(
+            idleTtlSeconds, // idleTtlSeconds
+            25, // graceTimeoutSeconds
+            30, // reapIntervalSeconds
+            512, // ringBufferFrames
+            5000, // stdinWriteTimeoutMs
+            64, // sendQueueCapacity
+            64, // subscriberQueueCapacity
+            30, // attachFirstFrameTimeoutSeconds
+            3, // maxSessionsPerUser
+            50, // maxSessionsTotal
+            1_048_576, // maxFrameChars
+            maxLifetimeMinutes
+        );
+    }
+
+    private static InteractiveSandboxRegistry buildRegistry(Clock clock, InteractiveSandboxProperties props) {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        InteractiveSandboxMetrics metrics = new InteractiveSandboxMetrics(registry);
+        return new InteractiveSandboxRegistry(
+            props,
+            mock(SandboxContainerManager.class),
+            metrics,
+            new StdinWriteWatchdog(),
+            registry,
+            clock
+        );
+    }
+
+    @Nested
+    @DisplayName("MAX_LIFETIME reaper")
+    class MaxLifetime {
+
+        @Test
+        @DisplayName("evicts a sandbox attached more than maxLifetime ago with reason=MAX_LIFETIME")
+        void evictsSandboxesExceedingMaxLifetime() {
+            AtomicReference<Instant> nowRef = new AtomicReference<>(Instant.parse("2026-01-01T00:00:00Z"));
+            Clock clock = clockOf(nowRef);
+            InteractiveSandboxProperties props = propertiesWith(60, 3600); // 60 min lifetime, 1h idle
+            InteractiveSandboxRegistry registry = buildRegistry(clock, props);
+
+            FakeReapTarget young = new FakeReapTarget(nowRef.get().minus(Duration.ofMinutes(10)), Duration.ZERO);
+            FakeReapTarget elderly = new FakeReapTarget(nowRef.get().minus(Duration.ofMinutes(70)), Duration.ZERO);
+
+            nowRef.set(nowRef.get().plus(Duration.ofMinutes(1))); // not strictly needed; helps express intent
+            registry.reapInternal(List.of(young, elderly));
+
+            assertThat(young.terminatedWith).isNull();
+            assertThat(elderly.terminatedWith).isEqualTo(EvictionReason.MAX_LIFETIME);
+        }
+
+        @Test
+        @DisplayName("MAX_LIFETIME wins over IDLE when both conditions hold")
+        void lifetimeBeatsIdleWhenBothHold() {
+            AtomicReference<Instant> nowRef = new AtomicReference<>(Instant.parse("2026-01-01T00:00:00Z"));
+            Clock clock = clockOf(nowRef);
+            InteractiveSandboxProperties props = propertiesWith(60, 60); // both checks tight
+            InteractiveSandboxRegistry registry = buildRegistry(clock, props);
+
+            FakeReapTarget stale = new FakeReapTarget(
+                nowRef.get().minus(Duration.ofMinutes(120)), // way past lifetime
+                Duration.ofMinutes(30) // also past idle
+            );
+            registry.reapInternal(List.of(stale));
+            assertThat(stale.terminatedWith).isEqualTo(EvictionReason.MAX_LIFETIME);
+        }
+
+        @Test
+        @DisplayName("does not evict a non-ATTACHED sandbox even if lifetime exceeded")
+        void skipsAlreadyClosing() {
+            AtomicReference<Instant> nowRef = new AtomicReference<>(Instant.parse("2026-01-01T00:00:00Z"));
+            Clock clock = clockOf(nowRef);
+            InteractiveSandboxProperties props = propertiesWith(60, 3600);
+            InteractiveSandboxRegistry registry = buildRegistry(clock, props);
+
+            FakeReapTarget closing = new FakeReapTarget(nowRef.get().minus(Duration.ofMinutes(120)), Duration.ZERO);
+            closing.state = AttachedSandboxState.CLOSING;
+            registry.reapInternal(List.of(closing));
+            assertThat(closing.terminatedWith).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("IDLE reaper")
+    class Idle {
+
+        @Test
+        @DisplayName("evicts a session idle past TTL when lifetime is within bounds")
+        void evictsIdle() {
+            AtomicReference<Instant> nowRef = new AtomicReference<>(Instant.parse("2026-01-01T00:00:00Z"));
+            Clock clock = clockOf(nowRef);
+            InteractiveSandboxProperties props = propertiesWith(60, 300); // 60 min lifetime, 5 min idle
+            InteractiveSandboxRegistry registry = buildRegistry(clock, props);
+
+            FakeReapTarget idle = new FakeReapTarget(
+                nowRef.get().minus(Duration.ofMinutes(5)),
+                Duration.ofSeconds(400) // idle > 300s
+            );
+            registry.reapInternal(List.of(idle));
+            assertThat(idle.terminatedWith).isEqualTo(EvictionReason.IDLE);
+        }
+    }
+
+    /** Hand-rolled fake to bypass the final {@code DockerAttachedSandboxAdapter}. */
+    private static final class FakeReapTarget implements InteractiveSandboxRegistry.ReapTarget {
+
+        final Instant createdAt;
+        final Duration idleFor;
+        final UUID id = UUID.randomUUID();
+        AttachedSandboxState state = AttachedSandboxState.ATTACHED;
+        EvictionReason terminatedWith;
+
+        FakeReapTarget(Instant createdAt, Duration idleFor) {
+            this.createdAt = createdAt;
+            this.idleFor = idleFor;
+        }
+
+        @Override
+        public AttachedSandboxState state() {
+            return state;
+        }
+
+        @Override
+        public Instant createdAt() {
+            return createdAt;
+        }
+
+        @Override
+        public Duration idleFor() {
+            return idleFor;
+        }
+
+        @Override
+        public UUID sessionId() {
+            return id;
+        }
+
+        @Override
+        public void terminate(EvictionReason reason) {
+            terminatedWith = reason;
+            state = AttachedSandboxState.CLOSING;
+        }
+    }
+
+    private static Clock clockOf(AtomicReference<Instant> source) {
+        return new Clock() {
+            @Override
+            public ZoneId getZone() {
+                return ZoneId.systemDefault();
+            }
+
+            @Override
+            public Clock withZone(ZoneId zone) {
+                return this;
+            }
+
+            @Override
+            public Instant instant() {
+                return source.get();
+            }
+
+            @Override
+            public long millis() {
+                return source.get().toEpochMilli();
+            }
+        };
+    }
+}

--- a/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/SubscribeOrderingPropertyTest.java
+++ b/server/application-server/src/test/java/de/tum/in/www1/hephaestus/agent/sandbox/docker/interactive/SubscribeOrderingPropertyTest.java
@@ -22,7 +22,7 @@ class SubscribeOrderingPropertyTest extends BaseUnitTest {
     @DisplayName("a subscriber that races a producer sees snapshot frames before any live frames")
     void snapshotThenLive() throws Exception {
         SimpleMeterRegistry reg = new SimpleMeterRegistry();
-        FrameRingBuffer ring = new FrameRingBuffer(1024, reg.counter("test.dropped"));
+        FrameRingBuffer ring = new FrameRingBuffer(1024, () -> reg.counter("test.dropped").increment());
         Object lock = new Object();
         CopyOnWriteArrayList<FrameSubscription> subs = new CopyOnWriteArrayList<>();
 


### PR DESCRIPTION
## Summary

Retrospective housekeeping on the mentor pipeline after #1078 / #1080 / #1081. Three observability gaps + a small SPI hygiene rule, plus closing out three issues that #1081 already resolved in place.

- **`interactive_sandbox.frame_ring.dropped_total{userId}`** — new counter. The ring buffer was bumping a global counter only; per-user attribution was unavailable. Per-user emission is debounced to <=1/s per `(userId, sandboxId)` and the userId tag is capped at 50 distinct values via a `MeterFilter` (`MetricsCardinalityConfig`). The 51st user still drops frames into the global counter; only attribution is lost. **Default `ringBufferFrames=512` is NOT bumped here** — that decision waits on observed traffic.
- **`interactive_sandbox.evicted_total{reason}`** — new counter under the SPI-aligned name. `mentor.session.eviction{reason}` stays for back-compat; both increment together.
- **`MAX_LIFETIME` reaper** — `EvictionReason.MAX_LIFETIME` was reserved-but-unwired. New property `hephaestus.mentor.max-lifetime-minutes` (default 60, range [5, 480]). Wired into the existing reap pass; checked before the idle check (a chatty user past lifetime should still evict). Backstop against runners that accumulate state, drift on context, or leak FDs over hours.
- **`mentor.chat.outcome{CAPACITY_EXCEEDED}`** — new outcome distinguishing per-user/global cap rejections from genuine errors. Previously routed through `ERROR` and was invisible on dashboards. Backed by a new typed `InteractiveSandboxCapacityExceededException` so the routing is structural, not message-based.
- **ArchUnit gate** — `agent.sandbox.spi.*` may not depend on `io.micrometer..`. Keeps the SPI transport-agnostic; metrics belong in `docker.interactive.*` and `agent.mentor.chat.*`.
- **`docs/contributor/agent/observability.mdx`** — new page (sidebar position 6) cataloguing the new metrics and explaining how to read the per-user drop signal before raising the ring buffer default.

### SPI changes

- `AttachedSandbox.createdAt()` added with a sensible default. `DockerAttachedSandboxAdapter` already captured `attachedAt` internally — the SPI method now exposes it. The default keeps the contract additive (no SPI break for hypothetical consumers).
- `DockerAttachedSandboxAdapter.terminate(...)` promoted from package-private to public (now implements the new `InteractiveSandboxRegistry.ReapTarget` interface — a narrow surface extracted so the reaper test can drive synthetic targets without mocking the final adapter).

### Tests

- `FrameRingBufferTest` rewritten to a `Runnable onDrop` callback (no more Counter coupling at the buffer layer).
- `FrameRingBufferMetricsTest` (new) — debounce, distinct-user attribution, eviction reset, ceil-bound assertion across a 5.5s window.
- `InteractiveSandboxRegistryTest` (new) — MAX_LIFETIME eviction, lifetime-beats-idle precedence, non-ATTACHED states skipped, IDLE path still works.
- `MentorChatServiceTest` — two new cases for `CAPACITY_EXCEEDED` (per-user + global).
- `SandboxArchitectureTest` — extended SPI boundary block with the Micrometer rule.
- `2,666` unit + architecture tests pass locally.

### Stranded issue housekeeping

Three issues from the #1081 epic that are obsolete:

- #1072: side-by-side strategy skipped — hard cutover landed in #1081.
- #1073: `MentorProxyController` deleted, `useMentorChat` rewritten in-place in #1081.
- #1074: intelligence-service removed + DB columns dropped in #1081 (migration `1778756946278_changelog.xml`).

I'll close these once this PR opens cleanly.

## Test plan

- [x] Local: `./mvnw test -Dsurefire.includedGroups="unit,architecture"` — 2,666 passed
- [x] New ArchUnit rule: `agent.sandbox.spi.*` ↛ `io.micrometer..` verified by adding the rule (no SPI files import Micrometer today)
- [x] `FrameRingBufferMetricsTest` exercises debounce + cardinality at the unit level
- [x] `InteractiveSandboxRegistryTest` exercises MAX_LIFETIME with a fixed `Clock`
- [x] `MentorChatServiceTest` exercises CAPACITY_EXCEEDED routing for both PER_USER and GLOBAL scopes
- [ ] Smoke-watch the `interactive_sandbox.frame_ring.dropped_total{userId}` counter on staging after merge — if drops show up at all, raise `ringBufferFrames` (this PR intentionally does not bump the default)
- [ ] Confirm `interactive_sandbox.evicted_total{reason=max_lifetime}` fires after one hour of soak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now support a configurable maximum lifetime cap, separate from idle timeout (default 60 minutes, configurable 5–480 minutes).
  * Capacity exceeded errors now distinguish between per-user and global capacity limits for clearer diagnostics.

* **Documentation**
  * Added comprehensive observability documentation detailing Micrometer metrics, dimensions, and alerting guidance for the mentor pipeline and interactive sandbox layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Hephaestus/pull/1089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->