### PR TITLE
fix(server): unblock local dev — DB password default and workspace binding

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceProperties.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.AssertTrue;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.boot.context.properties.bind.Name;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 
@@ -70,7 +71,7 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "hephaestus.workspace")
 public record WorkspaceProperties(
     @DefaultValue("false") boolean initDefault,
-    @Valid DefaultProperties defaultProperties,
+    @Name("default") @Valid DefaultProperties defaultProperties,
     @DefaultValue("false") boolean initGitlabDefault,
     @Valid GitLabDefaultProperties gitlabDefault
 ) {

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     datasource:
         url: jdbc:postgresql://localhost:${POSTGRES_PORT:5432}/hephaestus
         username: ${DB_USERNAME:root}
-        password: ${DB_PASSWORD:}
+        password: ${DB_PASSWORD:root}
         hikari:
             connection-timeout: 45000
             idle-timeout: 600000


### PR DESCRIPTION
## Summary

Two defects in the server foundations prevented a fresh checkout from booting via `pnpm dev`. Both only surface locally (prod is unaffected), but they block every developer's first run.

- **DB password default** (`application.yml`): `DB_USERNAME` defaulted to `root` but `DB_PASSWORD` defaulted to empty, while the compose Postgres always requires password `root`. Result: every fresh boot failed Liquibase startup with `SCRAM-based authentication ... no password was provided`. Defaulted `DB_PASSWORD` to `root` to match compose and the username default — local dev is now zero-config.

- **Workspace config binding** (`WorkspaceProperties.java`): the record uses constructor binding, which binds by parameter name (`defaultProperties`). Spring's relaxed binding matches `default-properties` but **not** the YAML `default` key, so `default.login`/`default.token` never bound. With `init-default: true` (local default) this threw `hephaestus.workspace.default.login must not be blank`. The `getDefault()` getter alias does not help record/constructor binding. Bound the key explicitly with `@Name("default")`. Never seen in prod because prod runs `init-default: false`.

## Test plan

- [x] `pnpm dev` brings up compose and the server boots: `Started Application`, `/actuator/health` returns 200
- [x] Confirmed both target lines exist identically on `main` (clean apply)
- [ ] CI green