### PR TITLE
refactor(server): remove dead getDefault() alias on WorkspaceProperties

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/workspace/WorkspaceProperties.java
@@ -119,20 +119,6 @@ public record WorkspaceProperties(
     }
 
     /**
-     * Alias getter required so Spring Boot can bind configuration expressed under
-     * the {@code default} key (since "default" is a reserved word in Java).
-     *
-     * @return the default workspace properties
-     * @deprecated use {@link #defaultProperties()} instead; this method exists only
-     *             for YAML binding compatibility
-     */
-    @Deprecated(forRemoval = false)
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    public DefaultProperties getDefault() {
-        return defaultProperties;
-    }
-
-    /**
      * Validates that credentials are provided when default workspace initialization is enabled.
      *
      * <p>This method is invoked by JSR-380 bean validation. The validation ensures that


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1307. That PR fixed the workspace config binding with `@Name("default")` but left behind the `getDefault()` alias getter, which is now dead and actively misleading.

- **Unused**: no caller in `src/main` or `src/test` (`grep` for `.getDefault()` only matches `Locale.getDefault()` elsewhere). The `@SuppressWarnings("DeprecatedIsStillUsed")` was therefore stale.
- **Misleading**: its Javadoc claimed it was *"required so Spring Boot can bind configuration expressed under the `default` key"*. That's false for record/constructor binding — and that exact belief is what produced the original binding bug. Binding is handled by `@Name("default")` on the constructor parameter.

Net: 14 lines of dead, false-documented code removed. No behavior change.

## Test plan

- [x] Server boots clean (`Started Application`, `/actuator/health` 200) with the getter removed
- [x] Diff is removal-only; no caller exists
- [ ] CI green