### PR TITLE
chore: streamline local dev (mprocs, dev:reset, sandbox default-on, doc fixes)

### DIFF
--- a/docs/contributor/local-development.mdx
+++ b/docs/contributor/local-development.mdx
@@ -12,9 +12,9 @@ Hephaestus supports full-stack development across Java and TypeScript. This guid
 Install and configure the following tools before you attempt a local build:
 
 1. **Java JDK 21** – Required for the Spring Boot application server.
-2. **Docker Desktop** – Used for PostgreSQL, Keycloak, and NATS containers.
+2. **Docker Desktop** – Used for the PostgreSQL and Keycloak containers.
 3. **Node.js LTS (>= 24)** and **pnpm (>= 11)** (enable via `corepack enable`) – For the React client and root scripts.
-4. **NATS CLI (optional)** – Helpful when debugging webhook messages.
+4. **NATS CLI (optional)** – Helpful when inspecting the agent job stream (NATS is disabled by default locally).
 
 ## Recommended IDE setup
 
@@ -32,7 +32,7 @@ JetBrains alternatives such as IntelliJ (Java) and WebStorm (React/TypeScript) w
 
 ### Maven profiles and local configuration
 
-We ship three Maven profiles: `local` (default), `prod`, and `spec`. For development stick to the `local` profile.
+We ship three Maven profiles: `local` (default), `prod`, and `specs`. For development stick to the `local` profile.
 
 Create `server/src/main/resources/application-local.yml` to override defaults. This file is gitignored.
 
@@ -49,7 +49,7 @@ Never commit `application-local.yml`. It may contain secrets and machine-specifi
    pnpm dev
    ```
 
-   This launches an `mprocs` session with the server and webapp in separate panes — each keeps its own clean log stream (switch panes with the arrow keys). The PostgreSQL and Keycloak containers are brought up automatically.
+   This launches an `mprocs` session with the server and webapp in separate panes (switch with the arrow keys). The PostgreSQL and Keycloak containers are brought up automatically.
 
    Prefer plain terminals? Run the two sides yourself:
 

--- a/docs/contributor/local-development.mdx
+++ b/docs/contributor/local-development.mdx
@@ -40,16 +40,27 @@ Create `server/src/main/resources/application-local.yml` to override defaults. T
 Never commit `application-local.yml`. It may contain secrets and machine-specific configuration.
 :::
 
-### Running the server
+### Running the stack
 
 1. Start Docker Desktop.
-2. From `server`, run:
+2. From the repo root, start everything with one command:
 
    ```bash
-   ./mvnw spring-boot:run
+   pnpm dev
    ```
 
-3. Access the API at `http://localhost:8080` or explore `http://localhost:8080/swagger-ui/index.html`.
+   This launches an `mprocs` session with the server and webapp in separate panes — each keeps its own clean log stream (switch panes with the arrow keys). The PostgreSQL and Keycloak containers are brought up automatically.
+
+   Prefer plain terminals? Run the two sides yourself:
+
+   ```bash
+   pnpm dev:server   # terminal 1 — brings up Postgres/Keycloak, then Spring Boot
+   pnpm dev:webapp   # terminal 2 — Vite dev server
+   ```
+
+3. Access the API at `http://localhost:8080` (Swagger UI at `http://localhost:8080/swagger-ui/index.html`) and the webapp at `http://localhost:4200`.
+
+To wipe the local database (e.g. after a bad migration or sync), run `pnpm dev:reset`. The Postgres data is a bind-mounted folder (`server/postgres-data`), so `docker compose down -v` alone does not clear it — `dev:reset` removes the folder and recreates the stack.
 
 ### Port overrides
 
@@ -198,15 +209,16 @@ Hephaestus supports two GitHub authentication modes. Pick the one that fits your
 When using GitHub App mode, your app might have access to hundreds of repositories. Use filters to focus on specific orgs/repos during development:
 
 ```yaml
-monitoring:
-  filters:
-    allowed-organizations:
-      - ls1intum
-      - HephaestusTest
-    allowed-repositories:
-      - ls1intum/Hephaestus
-      - ls1intum/Artemis
-      - HephaestusTest/demo-repository
+hephaestus:
+  sync:
+    filters:
+      allowed-organizations:
+        - ls1intum
+        - HephaestusTest
+      allowed-repositories:
+        - ls1intum/Hephaestus
+        - ls1intum/Artemis
+        - HephaestusTest/demo-repository
 ```
 
 Empty lists = no filtering (production behavior). Non-empty = only sync matching items.
@@ -238,7 +250,7 @@ Keycloak runs in Docker as part of the development compose stack. The bundled re
    The `KEYCLOAK_CLIENT_SECRET` is pre-configured with a development default (`hephaestus-dev-secret`). You do not need to copy a secret from the Keycloak admin console for local development.
    :::
 
-3. Run the application server with `./mvnw spring-boot:run`. Docker containers (Keycloak, PostgreSQL) start automatically via Spring Boot's Docker Compose support.
+3. Start the stack with `pnpm dev` (or `pnpm dev:server`). The `dev:*` scripts bring up the Keycloak and PostgreSQL containers via Docker Compose.
 4. Sign in via GitHub using the account referenced by `KEYCLOAK_GITHUB_ADMIN_USERNAME`. During the first brokered login Keycloak automatically grants that account the `admin` realm role and the `realm-management` → `realm-admin` client role, unlocking the administrative views in the application server and Keycloak console.
 
 #### Troubleshooting Keycloak

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,0 +1,5 @@
+procs:
+  server:
+    shell: pnpm dev:server
+  webapp:
+    shell: pnpm dev:webapp

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"commander": "14.0.3",
 		"graphql": "16.14.0",
 		"husky": "9.1.7",
-		"mprocs": "^0.9.3",
+		"mprocs": "0.9.3",
 		"npm-run-all2": "8.0.4",
 		"patch-package": "8.0.1",
 		"pg": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
 		"prepare": "husky",
 		"dev:compose": "cd server && docker compose up -d --wait",
 		"dev:compose:down": "cd server && docker compose down",
-		"dev:server": "cd server && ./mvnw spring-boot:run",
+		"dev:reset": "cd server && docker compose down -v && node -e \"import('node:fs/promises').then(fs => fs.rm('postgres-data', {recursive: true, force: true}))\" && docker compose up -d --wait",
+		"dev:server": "pnpm dev:compose && cd server && ./mvnw spring-boot:run",
 		"dev:webapp": "pnpm --filter webapp run dev",
-		"dev": "run-s dev:compose dev:run",
-		"dev:run": "run-p dev:server dev:webapp"
+		"dev": "mprocs"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.15",
@@ -67,6 +67,7 @@
 		"commander": "14.0.3",
 		"graphql": "16.14.0",
 		"husky": "9.1.7",
+		"mprocs": "^0.9.3",
 		"npm-run-all2": "8.0.4",
 		"patch-package": "8.0.1",
 		"pg": "8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       husky:
         specifier: 9.1.7
         version: 9.1.7
+      mprocs:
+        specifier: ^0.9.3
+        version: 0.9.3
       npm-run-all2:
         specifier: 8.0.4
         version: 8.0.4
@@ -5800,6 +5803,7 @@ packages:
 
   dompurify@3.4.4:
     resolution: {integrity: sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==}
+    deprecated: Fixed a security issue introduced in 3.4.4
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -7494,6 +7498,11 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  mprocs@0.9.3:
+    resolution: {integrity: sha512-fZwCPCToKtPQ8CNzs71+FI8pK/O0BEnIaYg6Zraql1TQND5TmzjmDbW/aP2rFStOANjxeaXtHDTSp3MMcjp78w==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -18454,6 +18463,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  mprocs@0.9.3: {}
 
   mrmime@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: 9.1.7
         version: 9.1.7
       mprocs:
-        specifier: ^0.9.3
+        specifier: 0.9.3
         version: 0.9.3
       npm-run-all2:
         specifier: 8.0.4

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -4,12 +4,12 @@ Spring Boot 4 backend providing the REST API for Hephaestus.
 
 ## Local development loop
 
-From the repo root: `pnpm dev`. It brings compose up with healthchecks, then runs `mvn spring-boot:run` + `pnpm --filter webapp dev` in parallel.
+From the repo root: `pnpm dev`. It launches `mprocs` with the server and webapp in separate panes (each with its own clean log stream); the Postgres/Keycloak containers come up automatically. For plain terminals, run `pnpm dev:server` and `pnpm dev:webapp` yourself.
 
 ### Conventions
 
 - **No devtools.** Hot reload uses JVM HotSwap via the IDE — IntelliJ's Spring Boot run config with *Update Classes and Resources* on save (or *On Frame Deactivation*). Method-body edits reload; signature changes, new methods, and `@Configuration` edits require a full restart ([Spring Boot 4 hot-swapping ref](https://docs.spring.io/spring-boot/how-to/hotswapping.html)).
-- **`ddl-auto: validate`** for local. Liquibase owns DDL. If the validator fails on boot, your DB has drifted — recreate with `docker compose down -v && docker compose up -d`.
+- **`ddl-auto: validate`** for local. Liquibase owns DDL. If the validator fails on boot, your DB has drifted — recreate with `pnpm dev:reset` (the Postgres folder is bind-mounted, so `docker compose down -v` alone does not clear it).
 - **`BufferingApplicationStartup`** is wired in `Application.main()`. With `app.profiles=local`, `GET /actuator/startup` returns the timeline; `StartupBudgetIntegrationTest` catches per-step regressions in CI.
 - **Maven build cache** is opt-in: `-Dmaven.build.cache.enabled=true` (CI does this). Default off until [MBUILDCACHE-118](https://issues.apache.org/jira/browse/MBUILDCACHE-118) lands.
 - **Pre-commit hook** (optional, install manually): `printf '#!/usr/bin/env sh\npnpm run format:check\n' > .husky/pre-commit && chmod +x .husky/pre-commit`. The existing `pre-push` hook runs the heavier `format:check && check` chain.
@@ -19,7 +19,7 @@ From the repo root: `pnpm dev`. It brings compose up with healthchecks, then run
 | Task              | Command                                          |
 | ----------------- | ------------------------------------------------ |
 | Run full stack    | `pnpm dev` (from repo root)                      |
-| Run server only   | `mvn spring-boot:run` (in `server/`) |
+| Run server only   | `pnpm dev:server` (infra + Spring Boot) |
 | Unit tests        | `mvn test`                                       |
 | Integration tests | `mvn verify`                                     |
 | Live GitHub tests | `mvn test -Plive-tests`                          |

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -4,7 +4,7 @@ Spring Boot 4 backend providing the REST API for Hephaestus.
 
 ## Local development loop
 
-From the repo root: `pnpm dev`. It launches `mprocs` with the server and webapp in separate panes (each with its own clean log stream); the Postgres/Keycloak containers come up automatically. For plain terminals, run `pnpm dev:server` and `pnpm dev:webapp` yourself.
+From the repo root: `pnpm dev`. It launches `mprocs` with the server and webapp in separate panes; the Postgres/Keycloak containers come up automatically. For plain terminals, run `pnpm dev:server` and `pnpm dev:webapp` yourself.
 
 ### Conventions
 
@@ -19,18 +19,18 @@ From the repo root: `pnpm dev`. It launches `mprocs` with the server and webapp 
 | Task              | Command                                          |
 | ----------------- | ------------------------------------------------ |
 | Run full stack    | `pnpm dev` (from repo root)                      |
-| Run server only   | `pnpm dev:server` (infra + Spring Boot) |
-| Unit tests        | `mvn test`                                       |
-| Integration tests | `mvn verify`                                     |
-| Live GitHub tests | `mvn test -Plive-tests`                          |
+| Run server only   | `pnpm dev:server` (infra + Spring Boot)          |
+| Unit tests        | `./mvnw test`                                    |
+| Integration tests | `./mvnw verify`                                  |
+| Live GitHub tests | `./mvnw test -Plive-tests`                       |
 | Format            | `pnpm run format:java`                           |
 | Generate OpenAPI  | `pnpm run generate:api:application-server:specs` |
 | Startup timeline  | `curl http://localhost:8080/actuator/startup`    |
-| Build prod image  | `mvn spring-boot:build-image`                    |
+| Build prod image  | `./mvnw spring-boot:build-image`                 |
 
 ### Container image
 
-Built with Paketo Cloud Native Buildpacks (Application CDS enabled); `pom.xml` `<image>` pins builder + run image by digest. See `docs/admin/buildpacks-cds-decision.md`. No `Dockerfile` — local builds use `mvn spring-boot:build-image`.
+Built with Paketo Cloud Native Buildpacks (Application CDS enabled); `pom.xml` `<image>` pins builder + run image by digest. See `docs/admin/buildpacks-cds-decision.md`. No `Dockerfile` — local builds use `./mvnw spring-boot:build-image`.
 
 ### JPA conventions
 
@@ -49,7 +49,7 @@ Liquibase 5.x logs a warning but continues when `DATABASECHANGELOG` references u
 The `generate:api:application-server:specs` script (springdoc) starts the app on port **8080** to download the spec. If port 8080 is occupied (e.g. by Coolify proxy), override with environment variables — **never stop other services**:
 
 ```bash
-SERVER_PORT=8090 MANAGEMENT_SERVER_PORT=8092 mvn verify -DskipTests=true -Dapp.profiles=specs
+SERVER_PORT=8090 MANAGEMENT_SERVER_PORT=8092 ./mvnw verify -DskipTests=true -Dapp.profiles=specs
 ```
 
 Then regenerate the client:
@@ -62,7 +62,7 @@ pnpm run generate:api:application-server:client
 
 ### Always
 
-- Run `mvn test` before committing
+- Run `./mvnw test` before committing
 - Use constructor injection (via `@RequiredArgsConstructor`)
 - Return `ResponseEntity` with proper status codes
 - Tag tests appropriately (`@Tag("unit")`, etc.)
@@ -156,11 +156,11 @@ public record UserDTO(
 
 ### Test Tiers (JUnit 5 Tags)
 
-| Tag                   | Purpose                           | Base Class            | Command                 |
-| --------------------- | --------------------------------- | --------------------- | ----------------------- |
-| `@Tag("unit")`        | Fast, no Spring context           | `BaseUnitTest`        | `mvn test`              |
-| `@Tag("integration")` | Full Spring Boot + Testcontainers | `BaseIntegrationTest` | `mvn verify`            |
-| `@Tag("live")`        | Real GitHub API calls             | -                     | `mvn test -Plive-tests` |
+| Tag                   | Purpose                           | Base Class            | Command                    |
+| --------------------- | --------------------------------- | --------------------- | -------------------------- |
+| `@Tag("unit")`        | Fast, no Spring context           | `BaseUnitTest`        | `./mvnw test`              |
+| `@Tag("integration")` | Full Spring Boot + Testcontainers | `BaseIntegrationTest` | `./mvnw verify`            |
+| `@Tag("live")`        | Real GitHub API calls             | -                     | `./mvnw test -Plive-tests` |
 
 ### Test Structure (AAA Pattern)
 

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -1,6 +1,5 @@
-# Local development stack. From the repo root: `pnpm dev` runs `docker compose up -d --wait`
-# then starts the server + webapp. After .env or realm-config changes:
-# `docker compose down -v && docker compose up -d`.
+# Local development stack (PostgreSQL + Keycloak), started by `pnpm dev` / `pnpm dev:compose`.
+# Reset the DB with `pnpm dev:reset` — Postgres is a bind mount, so `docker compose down -v` won't clear it.
 
 services:
   postgres:

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -64,6 +64,22 @@ services:
       retries: 12
       start_period: 30s
 
+  # Available for opt-in agent/webhook pipeline work (set the relevant hephaestus.*.nats.enabled
+  # in application-local.yml). Idle otherwise — no Spring connection opens unless enabled.
+  nats:
+    image: nats:alpine
+    command: ['-js', '-m', '8222']
+    ports:
+      - '${NATS_PORT:-4222}:4222'
+    networks:
+      - app-network
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '--quiet', 'http://localhost:8222/healthz']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
 networks:
   app-network:
     driver: bridge

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -607,6 +607,12 @@ spring:
             # never needs to parse compose.yaml.
             enabled: false
 
+hephaestus:
+    sandbox:
+        # On by default for local dev. Boots without Docker or an LLM key (image pull is
+        # skipped/lazy); workspaces supply provider credentials at runtime, stored in the DB.
+        enabled: ${SANDBOX_ENABLED:true}
+
 management:
     endpoints:
         web:


### PR DESCRIPTION
## Summary

Tightens the local-dev experience into one clear path and fixes docs that misled new contributors.

**Scripts (`package.json`)**
- `pnpm dev` now runs **mprocs** — server and webapp each in their own pane (separated logs) instead of `run-p` interleaving. Two-terminal `pnpm dev:server` / `pnpm dev:webapp` remains as the no-TUI path. `dev:run` artifact removed; `mprocs` pinned exact (`0.9.3`).
- `dev:server` is now infra-aware (`pnpm dev:compose && ./mvnw spring-boot:run`) so it can't fail on missing Postgres/Keycloak.
- `dev:reset` — wipes and recreates the local DB (Postgres is a bind mount that `docker compose down -v` can't clear).

**Dev stack (`server/compose.yaml`)**
- Added an **idle NATS (JetStream) service** mirroring `docker/compose.core.yaml`, so the broker is available at `localhost:4222` for opt-in agent/webhook pipeline work. It stays idle by default — no Spring connection opens unless `hephaestus.{sync,agent}.nats.enabled` is set in `application-local.yml`. Default boot (flags off) verified clean.

**Server (`application.yml`)**
- Agent **sandbox enabled by default** in the `local` profile (env-overridable via `SANDBOX_ENABLED`). Verified it boots with no LLM key and no Docker: lazy Docker client, graceful image-pull skip, DB-resolved per-workspace credentials. Prod/test keep explicit env control.

**Docs**
- Killed the false "`./mvnw spring-boot:run` auto-starts the containers" claim (local profile disables Spring's compose integration); dropped the phantom NATS prerequisite; reworded the NATS CLI note; fixed profile `spec` → `specs`; standardized `mvn` → `./mvnw` in `AGENTS.md`; corrected the `compose.yaml` reset header.

## Verification (boot-tested)
- `pnpm dev:reset` wipes + recreates the DB ✓
- Boots clean with sandbox on / no LLM key — `Started Application`, health 200 ✓
- Boots clean with the NATS service running and both nats flags off — no webhook wiring failure ✓
- mprocs installs/runs; config + script wiring validated ✓ (TUI needs a real terminal)

## Deferred (own PR)
Flipping `hephaestus.agent.nats.enabled` on by default is **not** included: boot-testing exposed a latent bug — `WebhookConfiguration` is gated by `@ConditionalOnBean(Connection.class)` but requires the sync-specific `@Qualifier("natsConnection")`. Enabling agent NATS creates a different `Connection` (`agentNatsConnection`) that satisfies the loose condition, making the webhook role demand a sync connection that isn't there → context fails to start. Fix (tighten to `name="natsConnection"`) touches the production-critical webhook role (ADR 0008) and belongs in a dedicated PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development setup instructions to reflect simplified full-stack startup via single command.
  * Clarified database reset procedures for local development.

* **New Features**
  * Added database reset utility for clearing local data during development.
  * Introduced NATS service support in the local development environment.

* **Chores**
  * Restructured development scripts for streamlined local setup orchestration.
  * Updated build and server startup commands for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Hephaestus/pull/1310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->