### PR TITLE
fix(server): local resource-server chain never activates (all APIs 403)

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/SecurityConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/SecurityConfig.java
@@ -8,9 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -24,6 +23,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
@@ -108,50 +108,46 @@ public class SecurityConfig {
     }
 
     /**
-     * Fallback chain when Spring's OAuth2 resource-server autoconfig produces no
-     * {@code JwtDecoder} (worker-only pod, smoke tests, fresh dev box). Mutually exclusive with
-     * {@link #resourceServerSecurityFilterChain(HttpSecurity, Converter)} via the same gate so
-     * only one "any request" chain ever loads at runtime.
+     * Application security chain (fallback after {@link #workerHubSecurityFilterChain}).
      *
-     * <p>Honors {@code hephaestus.dev.trigger-enabled=true} the same way the resource-server
-     * chain does — without this, a fresh dev box has no way to fire the trigger after enabling
-     * the flag, because the lockdown chain owns the {@code anyRequest()} slot.
+     * <p>The {@link JwtDecoder} is resolved via {@link ObjectProvider} when this bean is built, so
+     * it sees the decoder even when it comes from Spring Boot's OAuth2 autoconfig (registered after
+     * user config). {@code @ConditionalOnBean(JwtDecoder)} can't be used here: it evaluates before
+     * the autoconfig decoder is registered and would drop the server role into deny-all.
+     *
+     * <p>Decoder present (server role with Keycloak configured) → wire the OAuth2 resource server
+     * with the full rules. Absent (worker-only pod that excludes the OAuth2 autoconfig, or a box
+     * with no Keycloak) → deny everything. The {@code hephaestus.dev.trigger-enabled} carve-out
+     * applies in both modes.
      */
     @Bean
-    @ConditionalOnMissingBean(org.springframework.security.oauth2.jwt.JwtDecoder.class)
-    SecurityFilterChain lockdownSecurityFilterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain appSecurityFilterChain(
+        HttpSecurity http,
+        ObjectProvider<JwtDecoder> jwtDecoderProvider,
+        Converter<Jwt, AbstractAuthenticationToken> authenticationConverter
+    ) throws Exception {
         http
             .sessionManagement(sessions -> sessions.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .csrf(csrf -> csrf.disable())
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-            .authorizeHttpRequests(requests -> {
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()));
+
+        JwtDecoder jwtDecoder = jwtDecoderProvider.getIfAvailable();
+        if (jwtDecoder == null) {
+            http.authorizeHttpRequests(requests -> {
                 requests.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
                 if (devTriggerEnabled) {
                     requests.requestMatchers("/api/dev/**").permitAll();
                 }
                 requests.anyRequest().denyAll();
             });
-        return http.build();
-    }
+            return http.build();
+        }
 
-    @Bean
-    @ConditionalOnBean(org.springframework.security.oauth2.jwt.JwtDecoder.class)
-    SecurityFilterChain resourceServerSecurityFilterChain(
-        HttpSecurity http,
-        Converter<Jwt, AbstractAuthenticationToken> authenticationConverter
-    ) throws Exception {
         http.oauth2ResourceServer(resourceServer -> {
             resourceServer.jwt(jwtConfigurer -> {
-                jwtConfigurer.jwtAuthenticationConverter(authenticationConverter);
+                jwtConfigurer.decoder(jwtDecoder).jwtAuthenticationConverter(authenticationConverter);
             });
         });
-
-        http
-            .sessionManagement(sessions -> {
-                sessions.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-            })
-            .csrf(csrf -> csrf.disable())
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()));
 
         http.headers(headers ->
             headers

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -607,6 +607,15 @@ spring:
             # never needs to parse compose.yaml.
             enabled: false
 
+    security:
+        oauth2:
+            resourceserver:
+                jwt:
+                    # Pair jwk-set-uri with issuer-uri so the decoder is lazy: it skips the startup
+                    # discovery ping, so a boot before Keycloak is ready doesn't fail and auth
+                    # self-heals on first token use (iss is still validated against issuer-uri).
+                    jwk-set-uri: http://localhost:${KEYCLOAK_PORT:8081}/realms/hephaestus/protocol/openid-connect/certs
+
 hephaestus:
     sandbox:
         # On by default for local dev. Boots without Docker or an LLM key (image pull is


### PR DESCRIPTION
## Problem

On a normal local boot, **every authenticated API returns 403** (`/workspaces`, `/user/features`, `/auth/identity-providers`, …). The webapp can't load workspaces/users and falls back to "No workspace". This is **not a Keycloak startup race** — it reproduces even with Keycloak fully reachable at boot, so local dev auth is broken on `main` for everyone.

## Root cause (confirmed via the condition-evaluation report)

`SecurityConfig` picks between a deny-all **lockdown** chain (`@ConditionalOnMissingBean(JwtDecoder)`) and the **resource-server** chain (`@ConditionalOnBean(JwtDecoder)`). In the server role the `JwtDecoder` comes from Spring Boot's **OAuth2 autoconfig**, which registers **after** user config — so when those conditions evaluate, no decoder exists yet:

- `lockdownSecurityFilterChain matched: @ConditionalOnMissingBean(JwtDecoder) "did not find any beans"`
- the resource-server chain's `@ConditionalOnBean(JwtDecoder)` doesn't match → **deny-all wins**, and the decoder is created moments later, unused.

Prod escapes this only because its decoder is a *user* bean (`JwtDecoderConfig`, `@Profile("prod")`) registered before `SecurityConfig`. Worker-only pods correctly hit lockdown because `application-worker.yml` excludes the OAuth2 autoconfig.

## Fix

1. **Collapse the two chains into one** `appSecurityFilterChain` that resolves the decoder via `ObjectProvider<JwtDecoder>` **at build time** (after all bean definitions exist). The selection is then reliable regardless of bean-registration order — decoder present → resource server with full rules; absent → deny-all. Worker/prod semantics unchanged.
2. **Local profile: pair `jwk-set-uri` with `issuer-uri`** so the decoder is lazy (no startup discovery ping). A boot before Keycloak is ready no longer matters and auth self-heals on first token use; the `iss` claim is still validated against `issuer-uri` (Spring Security #7274).

## Verification (boot-tested on isolated ports)
- Keycloak reachable at boot → `/workspaces/providers` **200**, `/workspaces` (no token) **401** (real chain, proper auth).
- Keycloak **unreachable** at boot → app starts cleanly, `/workspaces/providers` **200** (resource-server chain active, self-heal-capable) — previously deny-all.

## Test plan
- [ ] CI green
- [ ] Reviewer with security context sanity-checks the chain merge (production-critical; worker/webhook roles)