### PR TITLE
fix(server): reduce sync log noise and fix achievement lock contention

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/AchievementEventListener.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/AchievementEventListener.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.hephaestus.activity.ActivitySavedEvent;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -73,8 +74,16 @@ public class AchievementEventListener {
                     unlocked.stream().map(AchievementDefinition::id).toList()
                 );
             }
+        } catch (ObjectOptimisticLockingFailureException e) {
+            // Residual contention past the advisory lock + retries; this increment is lost but
+            // self-heals on the next event, so WARN without a stack trace (not an alert-worthy ERROR).
+            log.warn(
+                "Achievement increment lost to lock contention: userId={}, eventType={}",
+                userId,
+                event.eventType()
+            );
         } catch (Exception e) {
-            // Log but don't rethrow - achievements are non-critical
+            // Unexpected — keep ERROR; achievements are non-critical so we don't rethrow.
             log.error("Failed to evaluate achievements: userId={}, eventType={}", userId, event.eventType(), e);
         }
     }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/AchievementRecalculationService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/AchievementRecalculationService.java
@@ -110,7 +110,8 @@ public class AchievementRecalculationService {
                 try {
                     achievementService.checkAndUnlock(savedEvent);
                 } catch (ObjectOptimisticLockingFailureException e) {
-                    log.error(
+                    // Advisory lock + @Retryable should prevent this; a lost increment self-heals on the next event.
+                    log.warn(
                         "Optimistic locking conflict during recalculation (after retries exhausted) " +
                             "for user {}, eventId={}: {}. This event's progress increment was lost.",
                         LoggingUtils.sanitizeForLog(user.getLogin()),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/AchievementService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/AchievementService.java
@@ -59,9 +59,11 @@ import tools.jackson.databind.ObjectMapper;
  * </pre>
  *
  * <h3>Thread Safety</h3>
- * <p>Achievement progress updates are idempotent in structure due to the unique
- * constraint on (user_id, achievement_id). Concurrent increment attempts are
- * serialized by the {@code @Transactional} boundary.
+ * <p>{@link #checkAndUnlock} runs on the {@code @Async} achievement executor, so a sync burst can
+ * deliver many same-user events concurrently. Evaluation is serialized per user via a
+ * transaction-scoped advisory lock (see {@link UserAchievementRepository#acquireUserLock}); different
+ * users stay parallel. The {@code INSERT ... ON CONFLICT} upsert and {@code @Retryable} remain as
+ * secondary guards.
  *
  * @see AchievementEventListener
  * @see AchievementDefinition
@@ -158,13 +160,9 @@ public class AchievementService {
      * @param event the activity saved event containing user, type, and timestamp
      * @return list of newly unlocked achievement types (empty if none)
      */
-    @Retryable(
-        includes = { ObjectOptimisticLockingFailureException.class },
-        maxRetries = 4,
-        delay = 100,
-        multiplier = 2.0,
-        maxDelay = 2000
-    )
+    // Thin tripwire only: the per-user advisory lock should make optimistic-lock failures
+    // impossible, so a few retries are a safety net, not the latency sink the pre-lock code needed.
+    @Retryable(includes = { ObjectOptimisticLockingFailureException.class }, maxRetries = 2, delay = 100)
     @Transactional
     public List<AchievementDefinition> checkAndUnlock(ActivitySavedEvent event) {
         if (event.user().isEmpty()) {
@@ -175,6 +173,9 @@ public class AchievementService {
         User user = event.user().get();
         ActivityEventType eventType = event.eventType();
         Instant occurredAt = event.occurredAt();
+
+        // Serialize same-user evaluation before any read (see UserAchievementRepository#acquireUserLock).
+        userAchievementRepository.acquireUserLock(user.getId());
 
         // Find achievements triggered by this event type
         List<AchievementDefinition> candidates = achievementRegistry.getByTriggerEvent(eventType);
@@ -220,7 +221,7 @@ public class AchievementService {
             if (wasUnlocked) {
                 uaProgress.setUnlockedAt(occurredAt);
                 newlyUnlocked.add(achievementDefinition);
-                log.info(
+                log.debug(
                     "Achievement unlocked: userId={}, achievement={}, progress={}, occurredAt={}",
                     user.getId(),
                     achievementDefinition.id(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/UserAchievementRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/achievement/UserAchievementRepository.java
@@ -43,6 +43,25 @@ public interface UserAchievementRepository extends JpaRepository<UserAchievement
     List<UserAchievement> findByUserId(@Param("userId") Long userId);
 
     /**
+     * Acquire a transaction-scoped advisory lock serializing achievement evaluation for one user.
+     *
+     * <p>Held until the surrounding transaction ends (auto-released on commit <em>or</em> rollback,
+     * so {@code @Retryable} re-acquires cleanly on each fresh-transaction attempt). Acquired before
+     * any read so the versioned {@link UserAchievement} row can't change under us — this is what
+     * prevents the {@code ObjectOptimisticLockingFailureException} (and the {@code HHH100503} batch
+     * aborts it caused). Cluster-wide, so it remains correct if the service is scaled out.
+     *
+     * <p>Uses the two-integer key space ({@code classId=1313}, the issue number, as a namespace) so
+     * it cannot collide with {@code UserRepository#acquireLoginLock}, which uses the single-bigint
+     * key space — the two spaces are disjoint in Postgres. The id is masked to 31 bits (rather than
+     * cast, which would throw on overflow); a collision would need two user ids 2^31 apart.
+     *
+     * @param userId the user whose achievement evaluation should be serialized
+     */
+    @Query(value = "SELECT pg_advisory_xact_lock(1313, CAST(:userId & 2147483647 AS integer))", nativeQuery = true)
+    void acquireUserLock(@Param("userId") long userId);
+
+    /**
      * Find a specific achievement unlock for a user.
      *
      * @param userId the user's ID

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/activity/ActivityEventListener.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/activity/ActivityEventListener.java
@@ -421,7 +421,7 @@ public class ActivityEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onReviewSubmitted(DomainEvent.ReviewSubmitted event) {
         var reviewData = event.review();
-        log.info(
+        log.debug(
             "Received ReviewSubmitted event: reviewId={}, state={}, scopeId={}, authorId={}, repositoryId={}",
             reviewData.id(),
             reviewData.state(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/activity/ActivityEventService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/activity/ActivityEventService.java
@@ -181,8 +181,10 @@ public class ActivityEventService {
             new ActivitySavedEvent(Optional.ofNullable(actor), eventType, occurredAt, workspaceId, targetType, targetId)
         );
 
-        // Structured logging with trace context
-        log.info(
+        // One line per recorded event — DEBUG by default (per-event bookkeeping; the
+        // eventsRecordedCounter / xpDistribution metrics already track volume). Per-repo
+        // sync rollups carry the INFO-level summary.
+        log.debug(
             "Recorded activity event: eventType={}, targetId={}, xp={}, scopeId={}, actorId={}",
             eventType,
             targetId,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/HubConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/HubConfiguration.java
@@ -11,11 +11,15 @@ import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerTokenDenylistServic
 import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerTokenProperties;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.FrameCodec;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import tools.jackson.databind.ObjectMapper;
 
@@ -30,6 +34,8 @@ import tools.jackson.databind.ObjectMapper;
 @EnableWebSocket
 public class HubConfiguration {
 
+    private static final Logger log = LoggerFactory.getLogger(HubConfiguration.class);
+
     @Bean
     @org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean(FrameCodec.class)
     FrameCodec frameCodec(ObjectMapper objectMapper) {
@@ -42,8 +48,22 @@ public class HubConfiguration {
     }
 
     @Bean
-    WorkerKeyRing workerKeyRing(WorkerTokenProperties properties) {
-        return WorkerKeyRing.fromConfig(properties);
+    WorkerKeyRing workerKeyRing(WorkerTokenProperties properties, Environment environment) {
+        WorkerKeyRing ring = WorkerKeyRing.fromConfig(properties);
+        if (ring.active().ephemeral()) {
+            // Ephemeral keys are fine for dev but unsafe in prod (worker reconnects across pod
+            // restarts must verify already-issued JWTs), so only the prod profile warns.
+            if (environment.acceptsProfiles(Profiles.of("prod"))) {
+                log.warn(
+                    "Worker JWT is using an EPHEMERAL signing key (kid={}). Configure a stable key via " +
+                        "hephaestus.worker.hub.token.keys[*].private-key for production.",
+                    ring.active().kid()
+                );
+            } else {
+                log.info("Worker JWT using ephemeral signing key (kid={}) — fine for dev.", ring.active().kid());
+            }
+        }
+        return ring;
     }
 
     @Bean

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerSigningKey.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/auth/WorkerSigningKey.java
@@ -28,7 +28,8 @@ import org.slf4j.LoggerFactory;
  * @param kid       JWT {@code kid} header — non-empty, opaque to the protocol
  * @param publicKey verification side
  * @param privateKey signing side
- * @param ephemeral {@code true} when the key was generated at boot (logged as a warning)
+ * @param ephemeral {@code true} when the key was generated at boot rather than loaded from config;
+ *                  the wiring layer warns about this only under the prod profile
  */
 public record WorkerSigningKey(String kid, RSAPublicKey publicKey, RSAPrivateKey privateKey, boolean ephemeral) {
     private static final Logger log = LoggerFactory.getLogger(WorkerSigningKey.class);
@@ -83,7 +84,8 @@ public record WorkerSigningKey(String kid, RSAPublicKey publicKey, RSAPrivateKey
             KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
             gen.initialize(2048);
             KeyPair pair = gen.generateKeyPair();
-            log.warn("Generated ephemeral signing key (kid={}). Stable key required for prod.", kid);
+            // Caller (HubConfiguration) decides WARN-vs-INFO by profile; the record can't see it.
+            log.debug("Generated ephemeral worker signing key (kid={})", kid);
             return new WorkerSigningKey(kid, (RSAPublicKey) pair.getPublic(), (RSAPrivateKey) pair.getPrivate(), true);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("RSA key generation unavailable", e);

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/commit/github/GitHubPushMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/commit/github/GitHubPushMessageHandler.java
@@ -103,7 +103,7 @@ public class GitHubPushMessageHandler extends GitHubMessageHandler<GitHubPushEve
             return;
         }
 
-        log.info(
+        log.debug(
             "Received push event: branch={}, commitCount={}, forced={}, repoName={}",
             getBranchName(event.ref()),
             event.commits().size(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/common/github/GraphQlConnectionOverflowDetector.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/common/github/GraphQlConnectionOverflowDetector.java
@@ -49,10 +49,14 @@ public final class GraphQlConnectionOverflowDetector {
     }
 
     /**
-     * Checks whether a GraphQL connection returned fewer nodes than {@code totalCount} indicates.
-     * <p>
-     * Logs a warning when overflow is detected (i.e., {@code totalCount > fetchedCount}).
-     * This is the primary detection method when the GraphQL query includes {@code totalCount}.
+     * Checks a <b>single-page</b> connection that has no follow-up pagination (e.g. an embedded
+     * {@code assignees}/{@code labels} connection on a DTO). Here {@code totalCount > fetchedCount}
+     * genuinely means the extra items will never be fetched, so it is logged at WARN.
+     *
+     * <p><b>Do not</b> use this overload from inside a pagination loop: a count gap that remains
+     * after the loop exhausted every page is a benign unit/over-report discrepancy, not data loss.
+     * Use {@link #checkPaginated} there and pass whether the loop stopped early — it demotes the
+     * benign case to DEBUG and only WARNs on real truncation.
      *
      * @param connectionName  human-readable name of the connection (e.g. "assignees", "reviews")
      * @param fetchedCount    number of nodes actually fetched ({@code nodes.size()})
@@ -63,8 +67,8 @@ public final class GraphQlConnectionOverflowDetector {
     public static boolean check(String connectionName, int fetchedCount, int totalCount, String context) {
         if (totalCount > fetchedCount) {
             log.warn(
-                "GraphQL connection overflow: connection={}, fetchedCount={}, totalCount={}, context={}. " +
-                    "Data may be incomplete — consider adding follow-up pagination.",
+                "GraphQL embedded connection truncated: connection={}, fetchedCount={}, totalCount={}, context={}. " +
+                    "No follow-up pagination — remaining items were not fetched.",
                 connectionName,
                 fetchedCount,
                 totalCount,
@@ -72,6 +76,55 @@ public final class GraphQlConnectionOverflowDetector {
             );
             return true;
         }
+        return false;
+    }
+
+    /**
+     * Checks completeness of a <b>paginated</b> connection, gating severity on <em>why the loop
+     * ended</em> rather than the count comparison alone.
+     *
+     * <p>If the loop ran to completion ({@code stoppedEarly == false}), any residual
+     * {@code totalCount > fetchedCount} gap is benign — a unit/over-report discrepancy, not loss —
+     * and is logged at DEBUG. Only an early stop (error, rate-limit, or page cap leaving pages
+     * unfetched) is real incompleteness and logged at WARN.
+     *
+     * @param connectionName human-readable connection name (e.g. "reviewThreads", "issues")
+     * @param fetchedCount   nodes received across all pages — must be apples-to-apples with
+     *                       {@code totalCount} (count what the connection counts, not post-filter results)
+     * @param totalCount     total reported by the connection
+     * @param stoppedEarly   {@code true} if the loop broke before exhausting all pages
+     * @param context        contextual description for the log message
+     * @return {@code true} if data is incomplete (gap present and the loop stopped early)
+     */
+    public static boolean checkPaginated(
+        String connectionName,
+        int fetchedCount,
+        int totalCount,
+        boolean stoppedEarly,
+        String context
+    ) {
+        if (totalCount <= fetchedCount) {
+            return false;
+        }
+        if (stoppedEarly) {
+            log.warn(
+                "GraphQL connection truncated by early stop: connection={}, fetchedCount={}, totalCount={}, " +
+                    "context={}. Pagination stopped before all pages were retrieved; data is incomplete.",
+                connectionName,
+                fetchedCount,
+                totalCount,
+                context
+            );
+            return true;
+        }
+        log.debug(
+            "GraphQL connection count gap after full pagination (benign): connection={}, fetchedCount={}, " +
+                "totalCount={}, context={}.",
+            connectionName,
+            fetchedCount,
+            totalCount,
+            context
+        );
         return false;
     }
 
@@ -91,8 +144,8 @@ public final class GraphQlConnectionOverflowDetector {
     public static boolean check(String connectionName, int fetchedCount, boolean hasNextPage, String context) {
         if (hasNextPage) {
             log.warn(
-                "GraphQL connection overflow: connection={}, fetchedCount={}, hasNextPage=true, context={}. " +
-                    "Data may be incomplete — consider adding follow-up pagination.",
+                "GraphQL embedded connection truncated: connection={}, fetchedCount={}, hasNextPage=true, " +
+                    "context={}. No follow-up pagination — remaining items were not fetched.",
                 connectionName,
                 fetchedCount,
                 context

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussion/github/GitHubDiscussionMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussion/github/GitHubDiscussionMessageHandler.java
@@ -53,7 +53,7 @@ public class GitHubDiscussionMessageHandler extends GitHubMessageHandler<GitHubD
             return;
         }
 
-        log.info(
+        log.debug(
             "Received discussion event: action={}, discussionNumber={}, repoName={}",
             event.action(),
             discussionDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussion/github/GitHubDiscussionSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussion/github/GitHubDiscussionSyncService.java
@@ -238,6 +238,7 @@ public class GitHubDiscussionSyncService {
         final boolean incrementalSync = isIncrementalSync;
 
         int totalDiscussionsSynced = 0;
+        int discussionsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         int totalCommentsSynced = 0;
         List<DiscussionWithCommentCursor> discussionsNeedingCommentPagination = new ArrayList<>();
         List<CommentWithReplyCursor> commentsNeedingReplyPagination = new ArrayList<>();
@@ -356,6 +357,7 @@ public class GitHubDiscussionSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
+                discussionsReceived += connection.getNodes().size();
 
                 // Process page within transaction
                 final Long repoId = repositoryId;
@@ -533,14 +535,13 @@ public class GitHubDiscussionSyncService {
             }
         }
 
-        // Detect if pagination was incomplete (reported total vs actually synced)
-        // Only meaningful during full sync — during incremental sync we intentionally fetch
-        // only recently-updated items, so fetchedCount < totalCount is expected by design.
+        // Full-sync only; compare raw nodes received (not the post-process count) against totalCount.
         if (reportedTotalCount >= 0 && !incrementalSync) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "discussions",
-                totalDiscussionsSynced,
+                discussionsReceived,
                 reportedTotalCount,
+                abortReason != null || hasMore,
                 safeNameWithOwner
             );
         }
@@ -698,13 +699,7 @@ public class GitHubDiscussionSyncService {
                     if (node != null && node.getReplies() != null) {
                         var repliesPageInfo = node.getReplies().getPageInfo();
                         if (repliesPageInfo != null && Boolean.TRUE.equals(repliesPageInfo.getHasNextPage())) {
-                            GraphQlConnectionOverflowDetector.check(
-                                "discussionComment.replies",
-                                node.getReplies().getNodes() != null ? node.getReplies().getNodes().size() : 0,
-                                true,
-                                "discussionNumber=" + graphQlDiscussion.getNumber() + ", commentId=" + node.getId()
-                            );
-                            // Track for follow-up reply pagination
+                            // No overflow warning: truncated replies are enqueued for follow-up pagination below.
                             if (node.getId() != null && repliesPageInfo.getEndCursor() != null) {
                                 commentsNeedingReplyPagination.add(
                                     new CommentWithReplyCursor(
@@ -908,13 +903,7 @@ public class GitHubDiscussionSyncService {
                         if (node != null && node.getReplies() != null) {
                             var repliesPageInfo = node.getReplies().getPageInfo();
                             if (repliesPageInfo != null && Boolean.TRUE.equals(repliesPageInfo.getHasNextPage())) {
-                                GraphQlConnectionOverflowDetector.check(
-                                    "discussionComment.replies",
-                                    node.getReplies().getNodes() != null ? node.getReplies().getNodes().size() : 0,
-                                    true,
-                                    "discussionNumber=" + discussionNumber + ", commentId=" + node.getId()
-                                );
-                                // Track for follow-up reply pagination
+                                // No overflow warning: truncated replies are enqueued for follow-up pagination below.
                                 if (node.getId() != null && repliesPageInfo.getEndCursor() != null) {
                                     commentsNeedingReplyPagination.add(
                                         new CommentWithReplyCursor(

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussioncomment/github/GitHubDiscussionCommentMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussioncomment/github/GitHubDiscussionCommentMessageHandler.java
@@ -61,7 +61,7 @@ public class GitHubDiscussionCommentMessageHandler extends GitHubMessageHandler<
             return;
         }
 
-        log.info(
+        log.debug(
             "Received discussion_comment event: action={}, discussionNumber={}, commentId={}, repoName={}",
             event.action(),
             discussionDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/installation/github/GitHubInstallationMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/installation/github/GitHubInstallationMessageHandler.java
@@ -76,7 +76,7 @@ public class GitHubInstallationMessageHandler extends GitHubMessageHandler<GitHu
         String accountLogin = account != null ? account.login() : null;
         Long installationId = installation.id();
 
-        log.info(
+        log.debug(
             "Received installation event: action={}, installationId={}, accountLogin={}",
             event.action(),
             installationId,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/installation/github/GitHubInstallationRepositoriesMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/installation/github/GitHubInstallationRepositoriesMessageHandler.java
@@ -60,7 +60,7 @@ public class GitHubInstallationRepositoriesMessageHandler
         List<GitHubRepositoryRefDTO> removed =
             event.repositoriesRemoved() != null ? event.repositoriesRemoved() : List.of();
 
-        log.info(
+        log.debug(
             "Received installation_repositories event: action={}, installationId={}, addedCount={}, removedCount={}",
             event.action(),
             installation.id(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issue/github/GitHubIssueMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issue/github/GitHubIssueMessageHandler.java
@@ -51,7 +51,7 @@ public class GitHubIssueMessageHandler extends GitHubMessageHandler<GitHubIssueE
             return;
         }
 
-        log.info(
+        log.debug(
             "Received issue event: action={}, issueNumber={}, repoName={}",
             event.action(),
             issueDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issue/github/GitHubIssueSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issue/github/GitHubIssueSyncService.java
@@ -277,6 +277,10 @@ public class GitHubIssueSyncService {
         }
 
         int totalIssuesSynced = 0;
+        // Raw nodes received across all pages — the apples-to-apples count for issues.totalCount.
+        // (totalIssuesSynced is post-filter: it omits skipped/unparseable nodes, so it would
+        // report a phantom gap even on a fully-paginated sync.)
+        int issuesReceived = 0;
         int totalCommentsSynced = 0;
         int totalProjectItemsSynced = 0;
         int reportedTotalCount = -1;
@@ -415,6 +419,8 @@ public class GitHubIssueSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
+
+                issuesReceived += connection.getNodes().size();
 
                 // Process the page within its own transaction to keep transactions short
                 final Long repoId = repositoryId;
@@ -567,11 +573,17 @@ public class GitHubIssueSyncService {
             }
         }
 
-        // Check for overflow: did we fetch fewer items than GitHub reported?
-        // Only meaningful during full sync — during incremental sync we intentionally fetch
-        // only recently-updated items, so fetchedCount < totalCount is expected by design.
+        // Full-sync only; compare raw nodes received (not the post-filter count) against totalCount.
+        // Stopped early = aborted OR hit the page cap (both leave pages unfetched).
         if (reportedTotalCount >= 0 && !incrementalSync) {
-            GraphQlConnectionOverflowDetector.check("issues", totalIssuesSynced, reportedTotalCount, safeNameWithOwner);
+            boolean stoppedEarly = abortReason != null || pageCount >= MAX_PAGINATION_PAGES;
+            GraphQlConnectionOverflowDetector.checkPaginated(
+                "issues",
+                issuesReceived,
+                reportedTotalCount,
+                stoppedEarly,
+                safeNameWithOwner
+            );
         }
 
         // Fetch remaining comments for issues with >10 comments (using cursor for efficient continuation)

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuecomment/github/GitHubIssueCommentMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuecomment/github/GitHubIssueCommentMessageHandler.java
@@ -66,7 +66,7 @@ public class GitHubIssueCommentMessageHandler extends GitHubMessageHandler<GitHu
             return;
         }
 
-        log.info(
+        log.debug(
             "Received issue_comment event: action={}, issueNumber={}, commentId={}, repoName={}, isPullRequest={}",
             event.action(),
             issueDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuecomment/github/GitHubIssueCommentSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuecomment/github/GitHubIssueCommentSyncService.java
@@ -112,6 +112,7 @@ public class GitHubIssueCommentSyncService {
         ProcessingContext context = ProcessingContext.forSync(scopeId, repository);
 
         int totalSynced = 0;
+        int commentsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         String cursor = null;
         boolean hasMore = true;
         int pageCount = 0;
@@ -231,6 +232,7 @@ public class GitHubIssueCommentSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
+                commentsReceived += connection.getNodes().size();
 
                 for (var graphQlComment : connection.getNodes()) {
                     GitHubCommentDTO dto = GitHubCommentDTO.fromIssueComment(graphQlComment);
@@ -288,12 +290,13 @@ public class GitHubIssueCommentSyncService {
             }
         }
 
-        // Check for overflow
+        // Raw nodes received vs comments.totalCount (totalSynced is post-filter).
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "issueComments",
-                totalSynced,
+                commentsReceived,
                 reportedTotalCount,
+                hasMore,
                 "issueNumber=" + issue.getNumber()
             );
         }
@@ -343,6 +346,7 @@ public class GitHubIssueCommentSyncService {
         ProcessingContext context = ProcessingContext.forSync(scopeId, repository);
 
         int totalSynced = 0;
+        int commentsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         String cursor = startCursor;
         boolean hasMore = true;
         int pageCount = 0;
@@ -468,6 +472,7 @@ public class GitHubIssueCommentSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
+                commentsReceived += connection.getNodes().size();
 
                 for (var graphQlComment : connection.getNodes()) {
                     GitHubCommentDTO dto = GitHubCommentDTO.fromIssueComment(graphQlComment);
@@ -522,12 +527,13 @@ public class GitHubIssueCommentSyncService {
             }
         }
 
-        // Check for overflow
+        // Raw nodes received vs comments.totalCount (totalSynced is post-filter).
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "issueComments",
-                totalSynced,
+                commentsReceived,
                 reportedTotalCount,
+                hasMore,
                 "issueNumber=" + issue.getNumber()
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuedependency/github/GitHubIssueDependenciesMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuedependency/github/GitHubIssueDependenciesMessageHandler.java
@@ -88,7 +88,7 @@ public class GitHubIssueDependenciesMessageHandler extends GitHubMessageHandler<
             return;
         }
 
-        log.info(
+        log.debug(
             "Received issue_dependencies event: action={}, blockedIssueNumber={}, blockingIssueNumber={}, repoName={}",
             event.action(),
             blockedIssueDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuedependency/github/GitHubIssueDependencySyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuedependency/github/GitHubIssueDependencySyncService.java
@@ -142,7 +142,7 @@ public class GitHubIssueDependencySyncService {
      */
     @Transactional
     public void processIssueDependencyEvent(long blockedIssueId, long blockingIssueId, boolean isBlock) {
-        log.info(
+        log.debug(
             "Received issue dependency event: blockedIssueId={}, blockingIssueId={}, isBlock={}",
             blockedIssueId,
             blockingIssueId,
@@ -299,6 +299,9 @@ public class GitHubIssueDependencySyncService {
         String after = null;
         boolean hasNextPage = true;
         int totalSynced = 0;
+        // Raw issue nodes received across all pages — apples-to-apples with issues.totalCount.
+        // (totalSynced counts dependency relationships, which most issues don't have at all.)
+        int issuesReceived = 0;
         int reportedTotalCount = -1;
         int pageCount = 0;
         int retryAttempt = 0;
@@ -407,6 +410,8 @@ public class GitHubIssueDependencySyncService {
                 reportedTotalCount = issueConnection.getTotalCount();
             }
 
+            issuesReceived += issueConnection.getNodes().size();
+
             var pageInfo = issueConnection.getPageInfo();
             if (pageInfo == null) {
                 log.debug("Received null pageInfo during dependency sync: repoName={}", safeNameWithOwner);
@@ -420,12 +425,13 @@ public class GitHubIssueDependencySyncService {
             totalSynced += self.processIssueDependenciesPage(issueConnection, repo, scopeId);
         }
 
-        // Check for overflow
+        // Raw issue nodes received (not dependency relationships synced) vs issues.totalCount.
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "issues",
-                totalSynced,
+                issuesReceived,
                 reportedTotalCount,
+                hasNextPage,
                 "repoName=" + safeNameWithOwner
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuetype/github/GitHubIssueTypeSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuetype/github/GitHubIssueTypeSyncService.java
@@ -242,9 +242,15 @@ public class GitHubIssueTypeSyncService {
                 retryAttempt = 0;
             }
 
-            // Check for overflow: did we fetch fewer items than GitHub reported?
+            // totalSynced is the raw node count here (incremented per node, no filter).
             if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check("issueTypes", totalSynced, reportedTotalCount, safeOrgLogin);
+                GraphQlConnectionOverflowDetector.checkPaginated(
+                    "issueTypes",
+                    totalSynced,
+                    reportedTotalCount,
+                    hasNextPage,
+                    safeOrgLogin
+                );
             }
 
             removeDeletedIssueTypes(organization.getId(), syncedIds);

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/label/github/GitHubLabelMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/label/github/GitHubLabelMessageHandler.java
@@ -51,7 +51,7 @@ public class GitHubLabelMessageHandler extends GitHubMessageHandler<GitHubLabelE
             return;
         }
 
-        log.info(
+        log.debug(
             "Received label event: action={}, labelName={}, repoName={}",
             event.action(),
             sanitizeForLog(labelDto.name()),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/milestone/github/GitHubMilestoneMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/milestone/github/GitHubMilestoneMessageHandler.java
@@ -51,7 +51,7 @@ public class GitHubMilestoneMessageHandler extends GitHubMessageHandler<GitHubMi
             return;
         }
 
-        log.info(
+        log.debug(
             "Received milestone event: action={}, milestoneTitle={}, repoName={}",
             event.action(),
             sanitizeForLog(milestoneDto.title()),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/milestone/github/GitHubMilestoneSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/milestone/github/GitHubMilestoneSyncService.java
@@ -110,6 +110,7 @@ public class GitHubMilestoneSyncService {
             ProcessingContext context = ProcessingContext.forSync(scopeId, repository);
             Set<Integer> syncedNumbers = new HashSet<>();
             int totalSynced = 0;
+            int milestonesReceived = 0; // raw nodes received, for the apples-to-apples completeness check
             int reportedTotalCount = -1;
             String cursor = null;
             boolean hasNextPage = true;
@@ -217,6 +218,7 @@ public class GitHubMilestoneSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = response.getTotalCount();
                 }
+                milestonesReceived += response.getNodes().size();
 
                 for (var graphQlMilestone : response.getNodes()) {
                     GitHubMilestoneDTO dto = convertToDTO(graphQlMilestone);
@@ -237,12 +239,13 @@ public class GitHubMilestoneSyncService {
             // Mark sync as completed normally if we exhausted all pages
             syncCompletedNormally = !hasNextPage;
 
-            // Check for overflow: did we fetch fewer items than GitHub reported?
+            // Raw nodes received vs milestones.totalCount (totalSynced is post-filter).
             if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check(
+                GraphQlConnectionOverflowDetector.checkPaginated(
                     "milestones",
-                    totalSynced,
+                    milestonesReceived,
                     reportedTotalCount,
+                    !syncCompletedNormally,
                     safeNameWithOwner
                 );
             }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/organization/github/GitHubOrganizationMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/organization/github/GitHubOrganizationMessageHandler.java
@@ -73,7 +73,7 @@ public class GitHubOrganizationMessageHandler extends GitHubMessageHandler<GitHu
             return;
         }
 
-        log.info(
+        log.debug(
             "Received organization event: action={}, orgId={}, orgLogin={}",
             event.action(),
             orgDto.id(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/organization/github/GitHubOrganizationSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/organization/github/GitHubOrganizationSyncService.java
@@ -269,6 +269,9 @@ public class GitHubOrganizationSyncService {
 
         // Collect all members with pagination, using a Set to track seen user IDs for deduplication
         List<GHOrganizationMemberEdge> allMembers = new ArrayList<>(membersConnection.getEdges());
+        // Raw edges received across all pages; allMembers is post-dedup, so it would under-count and
+        // could mask a real truncation — the completeness check must compare the raw count.
+        int membersReceived = membersConnection.getEdges().size();
         Set<Long> seenUserDatabaseIds = new HashSet<>();
         for (GHOrganizationMemberEdge edge : membersConnection.getEdges()) {
             if (edge != null && edge.getNode() != null && edge.getNode().getDatabaseId() != null) {
@@ -392,6 +395,8 @@ public class GitHubOrganizationSyncService {
                 break;
             }
 
+            membersReceived += nextPage.getEdges().size();
+
             // Add only members we haven't seen yet (deduplication safety)
             for (GHOrganizationMemberEdge edge : nextPage.getEdges()) {
                 if (edge != null && edge.getNode() != null && edge.getNode().getDatabaseId() != null) {
@@ -413,12 +418,13 @@ public class GitHubOrganizationSyncService {
         // Mark sync as completed normally if we exhausted all pages (pageInfo.hasNextPage is false)
         syncCompletedNormally = pageInfo == null || !Boolean.TRUE.equals(pageInfo.getHasNextPage());
 
-        // Check for overflow
+        // Raw edges received vs members.totalCount (allMembers is post-dedup).
         if (latestTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "members",
-                allMembers.size(),
+                membersReceived,
                 latestTotalCount,
+                !syncCompletedNormally,
                 "orgLogin=" + sanitizeForLog(organization.getLogin())
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/organization/gitlab/GitLabMemberMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/organization/gitlab/GitLabMemberMessageHandler.java
@@ -85,7 +85,7 @@ public class GitLabMemberMessageHandler extends GitLabMessageHandler<GitLabMembe
         String safeGroupPath = sanitizeForLog(event.groupPath());
         String safeUsername = sanitizeForLog(event.userUsername());
 
-        log.info(
+        log.debug(
             "Received member event: eventName={}, groupPath={}, user={}, access={}",
             event.eventName(),
             safeGroupPath,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemFieldValueSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemFieldValueSyncService.java
@@ -299,12 +299,13 @@ public class GitHubProjectItemFieldValueSyncService {
             }
         }
 
-        // Check for overflow
+        // totalSynced is the raw node count; completedNormally is false only on a page-cap/error stop.
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "fieldValues",
                 totalSynced,
                 reportedTotalCount,
+                !completedNormally,
                 "itemId=" + itemNodeId
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemMessageHandler.java
@@ -85,7 +85,7 @@ public class GitHubProjectItemMessageHandler extends GitHubMessageHandler<GitHub
         Project.OwnerType ownerType = event.detectOwnerType();
         String ownerIdentifier = event.getOwnerIdentifier();
 
-        log.info(
+        log.debug(
             "Received projects_v2_item event: action={}, itemNodeId={}, ownerType={}, owner={}",
             event.action(),
             itemDto.nodeId() != null ? sanitizeForLog(itemDto.nodeId()) : "unknown",

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemSyncService.java
@@ -149,6 +149,7 @@ public class GitHubProjectItemSyncService {
         HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
 
         int totalSynced = 0;
+        int itemsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         int reportedTotalCount = -1;
         String cursor = startCursor;
         boolean hasMore = true;
@@ -249,6 +250,7 @@ public class GitHubProjectItemSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
+                itemsReceived += connection.getNodes().size();
 
                 // Process this page of items in its own transaction
                 Integer pageSynced = transactionTemplate.execute(status -> {
@@ -290,12 +292,13 @@ public class GitHubProjectItemSyncService {
             }
         }
 
-        // Check for overflow
+        // Raw nodes received vs items.totalCount (totalSynced is post-process).
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "projectItems",
-                totalSynced,
+                itemsReceived,
                 reportedTotalCount,
+                hasMore,
                 "itemNodeId=" + issueNodeId
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectMessageHandler.java
@@ -82,7 +82,7 @@ public class GitHubProjectMessageHandler extends GitHubMessageHandler<GitHubProj
         String ownerIdentifier = event.getOwnerIdentifier();
         Long ownerId = event.getOwnerId();
 
-        log.info(
+        log.debug(
             "Received projects_v2 event: action={}, projectNumber={}, ownerType={}, owner={}",
             event.action(),
             projectDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectStatusUpdateMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectStatusUpdateMessageHandler.java
@@ -94,7 +94,7 @@ public class GitHubProjectStatusUpdateMessageHandler extends GitHubMessageHandle
         Project.OwnerType ownerType = event.detectOwnerType();
         String ownerIdentifier = event.getOwnerIdentifier();
 
-        log.info(
+        log.debug(
             "Received projects_v2_status_update event: action={}, nodeId={}, ownerType={}, owner={}",
             event.action(),
             payload.nodeId() != null ? sanitizeForLog(payload.nodeId()) : "unknown",

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectSyncService.java
@@ -214,6 +214,7 @@ public class GitHubProjectSyncService {
 
         Set<Long> syncedProjectIds = new HashSet<>();
         int totalSynced = 0;
+        int projectsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         int totalSkipped = 0;
         String cursor = null;
         boolean hasMore = true;
@@ -312,6 +313,7 @@ public class GitHubProjectSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = response.getTotalCount();
                 }
+                projectsReceived += response.getNodes().size();
 
                 // Process this page of projects in its own transaction
                 // Respect cooldown: only UPDATE projects that are new or past cooldown
@@ -514,12 +516,13 @@ public class GitHubProjectSyncService {
             }
         }
 
-        // Check for overflow
+        // Raw nodes received vs projectsV2.totalCount (totalSynced is post-process).
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "projects",
-                totalSynced,
+                projectsReceived,
                 reportedTotalCount,
+                hasMore || abortReason != null,
                 "orgLogin=" + safeOrgLogin
             );
         }
@@ -714,6 +717,7 @@ public class GitHubProjectSyncService {
         // Track items needing follow-up field value pagination (items with >20 field values)
         List<ItemWithFieldValueCursor> itemsNeedingFieldValuePagination = new ArrayList<>();
         int totalSynced = 0;
+        int itemsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         int totalSkipped = 0; // Items skipped due to incremental sync
         boolean hasMore = true;
         int pageCount = 0;
@@ -834,6 +838,7 @@ public class GitHubProjectSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = itemsConnection.getTotalCount();
                 }
+                itemsReceived += itemsConnection.getNodes().size();
 
                 // Process this page of items in its own transaction
                 // All item types (Draft Issue, Issue, PR) are created/updated from the project side
@@ -1031,11 +1036,13 @@ public class GitHubProjectSyncService {
         }
 
         // Check for overflow
+        // Raw nodes received vs items.totalCount (totalSynced is post-process).
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "projectItems",
-                totalSynced,
+                itemsReceived,
                 reportedTotalCount,
+                hasMore || abortReason != null,
                 "projectId=" + projectId
             );
         }
@@ -1159,6 +1166,7 @@ public class GitHubProjectSyncService {
 
         Long projectId = project.getId();
         List<String> allSyncedFieldIds = new ArrayList<>();
+        int fieldsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         boolean completedNormally = false;
 
         try {
@@ -1262,6 +1270,7 @@ public class GitHubProjectSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = fieldsConnection.getTotalCount();
                 }
+                fieldsReceived += fieldsConnection.getNodes().size();
 
                 // Process this page of fields in a transaction
                 transactionTemplate.executeWithoutResult(status -> {
@@ -1302,12 +1311,13 @@ public class GitHubProjectSyncService {
             // This preserves true if already set via early break, otherwise uses hasMore state
             completedNormally = completedNormally || !hasMore;
 
-            // Check for overflow
+            // Raw nodes received vs fields.totalCount (allSyncedFieldIds is post-filter).
             if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check(
+                GraphQlConnectionOverflowDetector.checkPaginated(
                     "projectFields",
-                    allSyncedFieldIds.size(),
+                    fieldsReceived,
                     reportedTotalCount,
+                    !completedNormally,
                     "projectId=" + project.getId()
                 );
             }
@@ -1383,6 +1393,7 @@ public class GitHubProjectSyncService {
 
         try {
             List<String> syncedStatusUpdateNodeIds = new ArrayList<>();
+            int statusUpdatesReceived = 0; // raw nodes received, for the apples-to-apples completeness check
             String cursor = null;
             boolean hasMore = true;
             int pageCount = 0;
@@ -1475,6 +1486,7 @@ public class GitHubProjectSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = statusUpdatesConnection.getTotalCount();
                 }
+                statusUpdatesReceived += statusUpdatesConnection.getNodes().size();
 
                 // Process this page of status updates in a transaction
                 transactionTemplate.executeWithoutResult(status -> {
@@ -1518,12 +1530,13 @@ public class GitHubProjectSyncService {
             // This preserves true if already set via early break, otherwise uses hasMore state
             completedNormally = completedNormally || !hasMore;
 
-            // Check for overflow
+            // Raw nodes received vs statusUpdates.totalCount (syncedStatusUpdateNodeIds is post-filter).
             if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check(
+                GraphQlConnectionOverflowDetector.checkPaginated(
                     "statusUpdates",
-                    syncedStatusUpdateNodeIds.size(),
+                    statusUpdatesReceived,
                     reportedTotalCount,
+                    !completedNormally,
                     "projectId=" + project.getId()
                 );
             }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/dto/GitHubProjectItemDTO.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/dto/GitHubProjectItemDTO.java
@@ -4,7 +4,6 @@ import static de.tum.cit.aet.hephaestus.gitprovider.common.DateTimeUtils.toInsta
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.tum.cit.aet.hephaestus.gitprovider.common.github.GraphQlConnectionOverflowDetector;
 import de.tum.cit.aet.hephaestus.gitprovider.graphql.github.model.GHDraftIssue;
 import de.tum.cit.aet.hephaestus.gitprovider.graphql.github.model.GHIssue;
 import de.tum.cit.aet.hephaestus.gitprovider.graphql.github.model.GHProjectV2Item;
@@ -196,13 +195,8 @@ public record GitHubProjectItemDTO(
                 fieldValuesTruncated = Boolean.TRUE.equals(pageInfo.getHasNextPage());
                 fieldValuesEndCursor = pageInfo.getEndCursor();
             }
-
-            GraphQlConnectionOverflowDetector.check(
-                "fieldValues",
-                fieldValues.size(),
-                fieldValuesTotalCount,
-                "project item " + (item.getId() != null ? item.getId() : "unknown")
-            );
+            // No overflow warning here: truncation is expected and handled — the cursor above drives
+            // follow-up pagination in GitHubProjectItemFieldValueSyncService.
         }
 
         // Extract creator info

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequest/github/GitHubPullRequestMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequest/github/GitHubPullRequestMessageHandler.java
@@ -51,7 +51,7 @@ public class GitHubPullRequestMessageHandler extends GitHubMessageHandler<GitHub
             return;
         }
 
-        log.info(
+        log.debug(
             "Received pull_request event: action={}, prNumber={}, repoName={}",
             event.action(),
             prDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequest/github/GitHubPullRequestSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequest/github/GitHubPullRequestSyncService.java
@@ -646,10 +646,15 @@ public class GitHubPullRequestSyncService {
         // The force-pagination above should have handled most cases, but if GitHub
         // returned empty pages (truly can't serve more data), we fall back to state splitting.
         if (reportedTotalCount >= 0 && !incrementalSync) {
-            boolean overflowDetected = GraphQlConnectionOverflowDetector.check(
+            // Keep totalPRsSynced as the comparand: the fallback below is defined in terms of it.
+            // checkPaginated returns true only on a real early-stop gap (empty page after
+            // force-pagination), suppressing the benign over-report that previously triggered a
+            // spurious state-split.
+            boolean overflowDetected = GraphQlConnectionOverflowDetector.checkPaginated(
                 "pullRequests",
                 totalPRsSynced,
                 reportedTotalCount,
+                abortReason != null || hasMore,
                 safeNameWithOwner
             );
             if (overflowDetected && states == null && !stoppedByIncrementalSync) {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewMessageHandler.java
@@ -62,7 +62,7 @@ public class GitHubPullRequestReviewMessageHandler extends GitHubMessageHandler<
             return;
         }
 
-        log.info(
+        log.debug(
             "Received pull_request_review event: action={}, prNumber={}, reviewId={}, repoName={}",
             event.action(),
             prDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewProcessor.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewProcessor.java
@@ -266,7 +266,7 @@ public class GitHubPullRequestReviewProcessor extends BaseGitHubProcessor {
         var reviewDataOpt = EventPayload.ReviewData.from(saved);
         if (reviewDataOpt.isPresent()) {
             var reviewData = reviewDataOpt.get();
-            log.info(
+            log.debug(
                 "Publishing ReviewSubmitted event: reviewId={}, state={}, scopeId={}, authorId={}, repositoryId={}",
                 reviewData.id(),
                 reviewData.state(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewSyncService.java
@@ -191,6 +191,7 @@ public class GitHubPullRequestReviewSyncService {
         HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
 
         int totalSynced = 0;
+        int reviewsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
         int reportedTotalCount = -1;
         String cursor = startCursor;
         boolean hasMore = true;
@@ -323,6 +324,7 @@ public class GitHubPullRequestReviewSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = connection.getTotalCount();
                 }
+                reviewsReceived += connection.getNodes().size();
 
                 // Fetch any remaining nested review comments before persistence
                 for (var graphQlReview : connection.getNodes()) {
@@ -391,13 +393,14 @@ public class GitHubPullRequestReviewSyncService {
             }
         }
 
-        // Check for overflow: did we fetch fewer items than GitHub reported?
-        // Include inline count to avoid false positives (inline reviews were already synced)
+        // Raw nodes received + inline reviews from the embedded first page (both counted by
+        // reviews.totalCount), vs totalCount. totalSynced is post-filter, so it can't be the comparand.
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "reviews",
-                totalSynced + inlineCount,
+                reviewsReceived + inlineCount,
                 reportedTotalCount,
+                hasMore,
                 safeNameWithOwner + " PR #" + pullRequest.getNumber()
             );
         }
@@ -694,12 +697,12 @@ public class GitHubPullRequestReviewSyncService {
             }
         }
 
-        // Check for overflow: did we fetch fewer comments than GitHub reported?
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "reviewComments",
                 allComments.size(),
                 reportedTotalCount,
+                hasMore,
                 "reviewId=" + reviewId
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentMessageHandler.java
@@ -64,7 +64,7 @@ public class GitHubPullRequestReviewCommentMessageHandler
             return;
         }
 
-        log.info(
+        log.debug(
             "Received pull_request_review_comment event: action={}, prNumber={}, commentId={}, repoName={}",
             event.action(),
             prDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
@@ -614,12 +614,14 @@ public class GitHubPullRequestReviewCommentSyncService {
             }
         }
 
-        // Check for overflow
+        // allComments holds the embedded first page + every paginated page (raw), apples-to-apples
+        // with the thread's comments.totalCount.
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "threadComments",
                 allComments.size(),
                 reportedTotalCount,
+                hasMore,
                 "threadId=" + threadNodeId
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
@@ -145,6 +145,9 @@ public class GitHubPullRequestReviewCommentSyncService {
         int retryAttempt = 0;
         try {
             int totalSynced = 0;
+            // Threads received across all pages — the apples-to-apples count for
+            // reviewThreads.totalCount. (totalSynced counts comments, a different unit.)
+            int threadsProcessed = 0;
             String cursor = null;
             boolean hasNextPage = true;
             int pageCount = 0;
@@ -267,6 +270,7 @@ public class GitHubPullRequestReviewCommentSyncService {
                     reportedTotalCount = response.getTotalCount();
                 }
 
+                threadsProcessed += response.getNodes().size();
                 for (var graphQlThread : response.getNodes()) {
                     int synced = processThreadInternal(graphQlThread, pullRequest, client, scopeId);
                     totalSynced += synced;
@@ -278,12 +282,13 @@ public class GitHubPullRequestReviewCommentSyncService {
                 retryAttempt = 0;
             }
 
-            // Check for overflow
+            // Threads received (not comments synced — a different unit) vs reviewThreads.totalCount.
             if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check(
+                GraphQlConnectionOverflowDetector.checkPaginated(
                     "reviewThreads",
-                    totalSynced,
+                    threadsProcessed,
                     reportedTotalCount,
+                    hasNextPage,
                     "prNumber=" + pullRequest.getNumber()
                 );
             }
@@ -1053,7 +1058,6 @@ public class GitHubPullRequestReviewCommentSyncService {
             String cursor = startCursor;
             boolean hasNextPage = true;
             int pageCount = 0;
-            int reportedTotalCount = -1;
 
             while (hasNextPage) {
                 // Check for interrupt (e.g., during application shutdown)
@@ -1140,11 +1144,12 @@ public class GitHubPullRequestReviewCommentSyncService {
                     .toEntity(GHPullRequestReviewThreadConnection.class);
 
                 if (response == null || response.getNodes() == null) {
+                    log.warn(
+                        "Remaining thread sync stopped on empty response: repoName={}, prNumber={}",
+                        safeNameWithOwner,
+                        pullRequest.getNumber()
+                    );
                     break;
-                }
-
-                if (reportedTotalCount < 0) {
-                    reportedTotalCount = response.getTotalCount();
                 }
 
                 for (var graphQlThread : response.getNodes()) {
@@ -1157,15 +1162,9 @@ public class GitHubPullRequestReviewCommentSyncService {
                 cursor = pageInfo != null ? pageInfo.getEndCursor() : null;
             }
 
-            // Check for overflow
-            if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check(
-                    "reviewThreads",
-                    totalSynced,
-                    reportedTotalCount,
-                    "prNumber=" + pullRequest.getNumber()
-                );
-            }
+            // No overflow check here: this continuation only covers the pages after startCursor, so
+            // comparing its partial count against the full reviewThreads.totalCount is meaningless.
+            // Early stops are already logged at their break sites above.
 
             log.debug(
                 "Completed remaining thread sync: repoName={}, prNumber={}, additionalComments={}",

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewthread/github/GitHubPullRequestReviewThreadMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewthread/github/GitHubPullRequestReviewThreadMessageHandler.java
@@ -65,7 +65,7 @@ public class GitHubPullRequestReviewThreadMessageHandler
         // Thread ID is the first comment's database ID (see GitHubPullRequestReviewCommentSyncService)
         Long threadId = threadDto.getFirstCommentId();
 
-        log.info(
+        log.debug(
             "Received pull_request_review_thread event: action={}, prNumber={}, threadId={}, repoName={}",
             event.action(),
             prDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/collaborator/github/GitHubCollaboratorSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/collaborator/github/GitHubCollaboratorSyncService.java
@@ -110,6 +110,7 @@ public class GitHubCollaboratorSyncService {
         try {
             HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
             int totalSynced = 0;
+            int collaboratorsReceived = 0; // raw edges received, for the apples-to-apples completeness check
             int reportedTotalCount = -1;
             String cursor = null;
             boolean hasNextPage = true;
@@ -219,6 +220,7 @@ public class GitHubCollaboratorSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = response.getTotalCount();
                 }
+                collaboratorsReceived += response.getEdges().size();
 
                 for (GHRepositoryCollaboratorEdge edge : response.getEdges()) {
                     var graphQlUser = edge.getNode();
@@ -251,12 +253,13 @@ public class GitHubCollaboratorSyncService {
             // Mark sync as completed normally if we exhausted all pages
             syncCompletedNormally = !hasNextPage;
 
-            // Check for overflow: did we fetch fewer items than GitHub reported?
+            // Raw edges received vs collaborators.totalCount (totalSynced is post-filter).
             if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check(
+                GraphQlConnectionOverflowDetector.checkPaginated(
                     "collaborators",
-                    totalSynced,
+                    collaboratorsReceived,
                     reportedTotalCount,
+                    !syncCompletedNormally,
                     safeNameWithOwner
                 );
             }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/github/GitHubMemberMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/github/GitHubMemberMessageHandler.java
@@ -58,7 +58,7 @@ public class GitHubMemberMessageHandler extends GitHubMessageHandler<GitHubMembe
             return;
         }
 
-        log.info(
+        log.debug(
             "Received member event: action={}, userLogin={}, repoName={}",
             event.action(),
             sanitizeForLog(memberDto.login()),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/github/GitHubRepositoryMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/github/GitHubRepositoryMessageHandler.java
@@ -77,7 +77,7 @@ public class GitHubRepositoryMessageHandler extends GitHubMessageHandler<GitHubR
         Long repositoryId = repositoryRef.id();
         GitHubEventAction.Repository action = event.actionType();
 
-        log.info(
+        log.debug(
             "Received repository event: action={}, repoName={}, repoId={}",
             event.action(),
             safeFullName,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/gitlab/GitLabProjectEventMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/gitlab/GitLabProjectEventMessageHandler.java
@@ -63,7 +63,7 @@ public class GitLabProjectEventMessageHandler extends GitLabMessageHandler<GitLa
     @Override
     protected void handleEvent(GitLabProjectEventDTO event) {
         String safePath = sanitizeForLog(event.pathWithNamespace());
-        log.info(
+        log.debug(
             "Received project event: eventName={}, path={}, projectId={}",
             event.eventName(),
             safePath,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/gitlab/GitLabPushMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/gitlab/GitLabPushMessageHandler.java
@@ -134,7 +134,7 @@ public class GitLabPushMessageHandler extends GitLabMessageHandler<GitLabPushEve
         }
 
         String safeRef = sanitizeForLog(event.ref());
-        log.info(
+        log.debug(
             "Received push event: projectPath={}, ref={}, commits={}",
             safeProjectPath,
             safeRef,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/subissue/github/GitHubSubIssueSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/subissue/github/GitHubSubIssueSyncService.java
@@ -138,7 +138,7 @@ public class GitHubSubIssueSyncService {
         boolean isLink,
         @Nullable SubIssuesSummaryDTO parentSummary
     ) {
-        log.info(
+        log.debug(
             "Received sub-issue event: subIssueId={}, parentIssueId={}, isLink={}",
             subIssueId,
             parentIssueId,
@@ -347,6 +347,9 @@ public class GitHubSubIssueSyncService {
         String cursor = null;
         boolean hasNextPage = true;
         int linkedCount = 0;
+        // Raw issue nodes received across all pages — apples-to-apples with issues.totalCount.
+        // (linkedCount counts sub-issue links found, which most issues don't have.)
+        int issuesReceived = 0;
         int reportedTotalCount = -1;
 
         int pageCount = 0;
@@ -471,6 +474,8 @@ public class GitHubSubIssueSyncService {
                 cursor = pageInfo != null ? pageInfo.getEndCursor() : null;
                 retryAttempt = 0;
 
+                issuesReceived += issueConnection.getNodes() != null ? issueConnection.getNodes().size() : 0;
+
                 // Process each page in its own transaction (call through proxy for @Transactional)
                 linkedCount += self.processIssueNodesInTransaction(issueConnection, repository, scopeId);
             } catch (InstallationNotFoundException e) {
@@ -497,12 +502,13 @@ public class GitHubSubIssueSyncService {
             }
         }
 
-        // Check for overflow
+        // Raw issue nodes received (not sub-issue links found) vs issues.totalCount.
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "issues",
-                linkedCount,
+                issuesReceived,
                 reportedTotalCount,
+                hasNextPage,
                 "repoName=" + sanitizeForLog(repository.getNameWithOwner())
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/subissue/github/GitHubSubIssuesMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/subissue/github/GitHubSubIssuesMessageHandler.java
@@ -55,7 +55,7 @@ public class GitHubSubIssuesMessageHandler extends GitHubMessageHandler<GitHubSu
             return;
         }
 
-        log.info(
+        log.debug(
             "Received sub_issues event: action={}, parentIssueNumber={}, subIssueNumber={}, repoName={}",
             event.action(),
             parentIssueDto.number(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/sync/backfill/HistoricalBackfillService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/sync/backfill/HistoricalBackfillService.java
@@ -15,7 +15,6 @@ import de.tum.cit.aet.hephaestus.gitprovider.common.github.GitHubRepositoryNameP
 import de.tum.cit.aet.hephaestus.gitprovider.common.github.GitHubRepositoryNameParser.RepositoryOwnerAndName;
 import de.tum.cit.aet.hephaestus.gitprovider.common.github.GitHubSyncProperties;
 import de.tum.cit.aet.hephaestus.gitprovider.common.github.GitHubTransportErrors;
-import de.tum.cit.aet.hephaestus.gitprovider.common.github.GraphQlConnectionOverflowDetector;
 import de.tum.cit.aet.hephaestus.gitprovider.common.spi.BackfillStateProvider;
 import de.tum.cit.aet.hephaestus.gitprovider.common.spi.SyncTargetProvider;
 import de.tum.cit.aet.hephaestus.gitprovider.common.spi.SyncTargetProvider.SyncSession;
@@ -767,12 +766,9 @@ public class HistoricalBackfillService {
             }
         }
 
-        GraphQlConnectionOverflowDetector.check(
-            "issues",
-            totalIssuesSynced,
-            reportedTotalCount,
-            "repo=" + repoNameForLog
-        );
+        // No completeness check: backfill paginates one bounded batch per cycle and resumes from a
+        // saved cursor across cycles, so this batch's count vs the whole-connection totalCount is
+        // meaningless. Real truncation surfaces via the force-pagination/completion logs.
 
         // Note: cursor is cleared inside the transaction when hasMore is false
         // (null cursor is passed to processIssuesPage when !hasMore)
@@ -975,12 +971,8 @@ public class HistoricalBackfillService {
             }
         }
 
-        GraphQlConnectionOverflowDetector.check(
-            "pullRequests",
-            totalPRsSynced,
-            reportedTotalCount,
-            "repo=" + repoNameForLog
-        );
+        // No completeness check: see the issues batch above — per-batch count vs whole-connection
+        // totalCount is meaningless for a resumable bounded backfill.
 
         // Note: cursor is cleared inside the transaction when hasMore is false
         // (null cursor is passed to processPullRequestsPage when !hasMore)

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubMembershipMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubMembershipMessageHandler.java
@@ -72,7 +72,7 @@ public class GitHubMembershipMessageHandler extends GitHubMessageHandler<GitHubM
             return;
         }
 
-        log.info(
+        log.debug(
             "Received membership event: action={}, userLogin={}, teamName={}, orgLogin={}",
             event.action(),
             sanitizeForLog(memberDto.login()),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamMessageHandler.java
@@ -78,7 +78,7 @@ public class GitHubTeamMessageHandler extends GitHubMessageHandler<GitHubTeamEve
 
         String orgLogin = event.organization() != null ? event.organization().login() : null;
 
-        log.info(
+        log.debug(
             "Received team event: action={}, teamName={}, orgLogin={}",
             event.action(),
             sanitizeForLog(teamDto.name()),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamSyncService.java
@@ -807,12 +807,14 @@ public class GitHubTeamSyncService {
             retryAttempt = 0;
         }
 
-        // Check for overflow
+        // edges vs totalCount; GitHub over-reports team.members.totalCount for inherited members,
+        // so a gap after full pagination (hasNextPage==false) is benign.
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "teamMembers",
                 allMemberEdges.size(),
                 reportedTotalCount,
+                hasNextPage,
                 "teamSlug=" + teamSlug
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamSyncService.java
@@ -152,6 +152,7 @@ public class GitHubTeamSyncService {
             // Maps child team's native ID → parent team's native ID (from GraphQL)
             Map<Long, Long> parentNativeIdByChildNativeId = new HashMap<>();
             int totalSynced = 0;
+            int teamsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
             int totalPermissions = 0;
             String cursor = null;
             boolean hasNextPage = true;
@@ -254,6 +255,7 @@ public class GitHubTeamSyncService {
                 if (reportedTotalCount < 0) {
                     reportedTotalCount = response.getTotalCount();
                 }
+                teamsReceived += response.getNodes().size();
 
                 for (var graphQlTeam : response.getNodes()) {
                     Team team = processTeam(graphQlTeam, organizationLogin, context);
@@ -289,12 +291,13 @@ public class GitHubTeamSyncService {
                 retryAttempt = 0;
             }
 
-            // Check for overflow
+            // Raw nodes received vs teams.totalCount (totalSynced is post-filter).
             if (reportedTotalCount >= 0) {
-                GraphQlConnectionOverflowDetector.check(
+                GraphQlConnectionOverflowDetector.checkPaginated(
                     "teams",
-                    totalSynced,
+                    teamsReceived,
                     reportedTotalCount,
+                    hasNextPage,
                     "orgLogin=" + safeOrgLogin
                 );
             }
@@ -955,12 +958,12 @@ public class GitHubTeamSyncService {
             retryAttempt = 0;
         }
 
-        // Check for overflow
         if (reportedTotalCount >= 0) {
-            GraphQlConnectionOverflowDetector.check(
+            GraphQlConnectionOverflowDetector.checkPaginated(
                 "teamRepositories",
                 allEdges.size(),
                 reportedTotalCount,
+                hasNextPage,
                 "teamSlug=" + teamSlug
             );
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/gitlab/GitLabSubgroupMessageHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/gitlab/GitLabSubgroupMessageHandler.java
@@ -58,7 +58,7 @@ public class GitLabSubgroupMessageHandler extends GitLabMessageHandler<GitLabSub
     @Override
     protected void handleEvent(GitLabSubgroupEventDTO event) {
         String safeFullPath = sanitizeForLog(event.fullPath());
-        log.info(
+        log.debug(
             "Received subgroup event: eventName={}, fullPath={}, groupId={}, parentGroupId={}",
             event.eventName(),
             safeFullPath,

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -606,6 +606,22 @@ resilience4j:
             gitlabGraphQl:
                 baseConfig: default
 
+# Shared logging defaults (apply to every profile, incl. prod which sets no overrides).
+# WARN is reserved for genuinely actionable situations; per-event/per-changeset chatter is
+# silenced here (3rd-party loggers) or downgraded to DEBUG at the source (our own packages).
+logging:
+    level:
+        # Liquibase logs every changeset at INFO on each boot (the bulk of startup noise).
+        # WARN keeps real migration problems (validation/checksum/lock-wait).
+        liquibase: WARN
+        # Hibernate HHH100503 (batch-on-release) was a symptom of the achievement lock
+        # contention fixed separately; WARN keeps genuine batch problems visible.
+        org.hibernate.orm.jdbc.batch: WARN
+        # Webhook receipts and per-event bookkeeping are logged at DEBUG at the source, so
+        # per-repo sync rollups stay the only INFO. Flip the package to DEBUG to restore the
+        # full per-event firehose for diagnosis (no redeploy needed):
+        #   logging.level.de.tum.cit.aet.hephaestus.gitprovider: DEBUG
+
 # Local profile (tracked defaults; per-developer secrets stay in gitignored application-local.yml).
 ---
 spring:

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/achievement/AchievementConcurrencyIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/achievement/AchievementConcurrencyIntegrationTest.java
@@ -1,0 +1,194 @@
+package de.tum.cit.aet.hephaestus.achievement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.achievement.progress.LinearAchievementProgress;
+import de.tum.cit.aet.hephaestus.activity.ActivityEventType;
+import de.tum.cit.aet.hephaestus.activity.ActivitySavedEvent;
+import de.tum.cit.aet.hephaestus.activity.ActivityTargetType;
+import de.tum.cit.aet.hephaestus.gitprovider.common.GitProvider;
+import de.tum.cit.aet.hephaestus.gitprovider.common.GitProviderRepository;
+import de.tum.cit.aet.hephaestus.gitprovider.common.GitProviderType;
+import de.tum.cit.aet.hephaestus.gitprovider.user.User;
+import de.tum.cit.aet.hephaestus.gitprovider.user.UserRepository;
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Proves the per-user advisory lock actually serializes achievement evaluation against a real
+ * Postgres (the unit test mocks the repository and cannot exercise {@code pg_advisory_xact_lock}).
+ *
+ * <p>Pre-fix, concurrent same-user events raced on the {@code @Version} column and threw
+ * {@link ObjectOptimisticLockingFailureException} after retries exhausted, losing increments. With
+ * the lock, same-user evaluation runs one transaction at a time, so every increment lands.
+ */
+class AchievementConcurrencyIntegrationTest extends BaseIntegrationTest {
+
+    // A high-target linear achievement so many increments are needed (and none unlock at 40 events).
+    private static final String LEGENDARY = "pr.merged.legendary"; // StandardCountEvaluator, target 50
+    private static final int THREADS = 40;
+
+    @Autowired
+    private AchievementService achievementService;
+
+    @Autowired
+    private UserAchievementRepository userAchievementRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GitProviderRepository gitProviderRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private final AtomicLong nativeIdGenerator = new AtomicLong(70_000);
+
+    @BeforeEach
+    void resetDatabase() {
+        databaseTestUtils.cleanDatabase();
+    }
+
+    @Test
+    @DisplayName("concurrent same-user events serialize: no optimistic-lock failures, no lost increments")
+    void sameUserConcurrentEvents() throws Exception {
+        User user = persistUser("concurrency-victim");
+        ActivitySavedEvent event = mergedEvent(user, 1L);
+
+        List<Throwable> escaped = runConcurrently(THREADS, () -> achievementService.checkAndUnlock(event));
+
+        assertThat(escaped)
+            .as("the advisory lock must serialize same-user evaluation; nothing should escape")
+            .isEmpty();
+
+        LinearAchievementProgress progress = readProgress(user.getId(), LEGENDARY);
+        assertThat(progress.current())
+            .as("%d serialized increments must all land (no lost updates)", THREADS)
+            .isEqualTo(THREADS);
+        // 40 < target 50, so it stays locked.
+        assertThat(readUnlockedAt(user.getId(), LEGENDARY)).isNull();
+        assertThat(userAchievementRepository.findByUserIdAndAchievementId(user.getId(), LEGENDARY)).isPresent();
+    }
+
+    @Test
+    @DisplayName("concurrent different-user events run in parallel and each lands exactly once")
+    void differentUsersConcurrent() throws Exception {
+        int userCount = 20;
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < userCount; i++) {
+            users.add(persistUser("parallel-user-" + i));
+        }
+
+        List<Throwable> escaped = runConcurrentlyEach(users, user ->
+            achievementService.checkAndUnlock(mergedEvent(user, (long) user.hashCode()))
+        );
+
+        assertThat(escaped).as("per-user locks must not serialize different users into failures").isEmpty();
+        for (User user : users) {
+            assertThat(readProgress(user.getId(), LEGENDARY).current())
+                .as("each user's single event must produce exactly one increment")
+                .isEqualTo(1);
+        }
+    }
+
+    // --- helpers ---
+
+    private ActivitySavedEvent mergedEvent(User user, Long targetId) {
+        return new ActivitySavedEvent(
+            Optional.of(user),
+            ActivityEventType.PULL_REQUEST_MERGED,
+            Instant.parse("2024-08-15T10:00:00Z"),
+            1L,
+            ActivityTargetType.PULL_REQUEST,
+            targetId
+        );
+    }
+
+    /** Run the same task on {@code threads} threads released together, returning any escaped throwables. */
+    private List<Throwable> runConcurrently(int threads, Runnable task) throws InterruptedException {
+        return runConcurrentlyEach(Collections.nCopies(threads, (Void) null), ignored -> task.run());
+    }
+
+    /** Run one task per item concurrently (all released together), returning any escaped throwables. */
+    private <T> List<Throwable> runConcurrentlyEach(List<T> items, java.util.function.Consumer<T> task)
+        throws InterruptedException {
+        List<Throwable> escaped = Collections.synchronizedList(new ArrayList<>());
+        ExecutorService pool = Executors.newFixedThreadPool(items.size());
+        CountDownLatch ready = new CountDownLatch(items.size());
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+        try {
+            for (T item : items) {
+                futures.add(
+                    pool.submit(() -> {
+                        ready.countDown();
+                        try {
+                            start.await();
+                            task.accept(item);
+                        } catch (Throwable t) {
+                            escaped.add(t);
+                        }
+                    })
+                );
+            }
+            ready.await(); // every worker parked on `start` → maximize overlap
+            start.countDown();
+            for (Future<?> f : futures) {
+                f.get(30, TimeUnit.SECONDS);
+            }
+        } catch (java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
+            escaped.add(e);
+        } finally {
+            pool.shutdownNow();
+        }
+        return escaped;
+    }
+
+    /** Read progress in a fresh transaction (worker transactions have committed; avoid a stale context). */
+    private LinearAchievementProgress readProgress(Long userId, String achievementId) {
+        return (LinearAchievementProgress) transactionTemplate.execute(status ->
+            userAchievementRepository
+                .findByUserIdAndAchievementId(userId, achievementId)
+                .orElseThrow()
+                .getProgressData()
+        );
+    }
+
+    private Instant readUnlockedAt(Long userId, String achievementId) {
+        return transactionTemplate.execute(status ->
+            userAchievementRepository.findByUserIdAndAchievementId(userId, achievementId).orElseThrow().getUnlockedAt()
+        );
+    }
+
+    private User persistUser(String login) {
+        GitProvider provider = gitProviderRepository
+            .findByTypeAndServerUrl(GitProviderType.GITHUB, "https://github.com")
+            .orElseGet(() -> gitProviderRepository.save(new GitProvider(GitProviderType.GITHUB, "https://github.com")));
+        User user = new User();
+        user.setNativeId(nativeIdGenerator.incrementAndGet());
+        user.setProvider(provider);
+        user.setLogin(login);
+        user.setName("User " + login);
+        user.setType(User.Type.USER);
+        user.setCreatedAt(Instant.now());
+        user.setUpdatedAt(Instant.now());
+        return userRepository.save(user);
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/achievement/AchievementServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/achievement/AchievementServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.springframework.cache.CacheManager;
 import tools.jackson.databind.ObjectMapper;
@@ -108,6 +109,33 @@ class AchievementServiceTest extends BaseUnitTest {
 
             assertThat(result).isEmpty();
             verify(userAchievementRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("acquires the per-user advisory lock before reading progress")
+        void acquiresUserLockBeforeReads() {
+            // Lock must precede any read so it can't be reordered after a flush-triggering query.
+            AchievementDefinition def = new AchievementDefinition(
+                "pr.merged.common.1",
+                AchievementCategory.PULL_REQUESTS,
+                AchievementRarity.COMMON,
+                new LinearAchievementProgress(0, 1),
+                null,
+                false,
+                Set.of(ActivityEventType.PULL_REQUEST_MERGED),
+                "StandardCountEvaluator"
+            );
+            when(achievementRegistry.getByTriggerEvent(ActivityEventType.PULL_REQUEST_MERGED)).thenReturn(List.of(def));
+            when(userAchievementRepository.findByUserIdAndAchievementIdIn(eq(1L), any())).thenReturn(List.of());
+            when(
+                userAchievementRepository.insertIfAbsent(any(UUID.class), eq(1L), anyString(), anyString(), any())
+            ).thenReturn(1);
+
+            service.checkAndUnlock(createEvent(ActivityEventType.PULL_REQUEST_MERGED));
+
+            InOrder inOrder = inOrder(userAchievementRepository);
+            inOrder.verify(userAchievementRepository).acquireUserLock(1L);
+            inOrder.verify(userAchievementRepository).findByUserIdAndAchievementIdIn(eq(1L), any());
         }
 
         @Test

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/gitprovider/common/github/GraphQlConnectionOverflowDetectorTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/gitprovider/common/github/GraphQlConnectionOverflowDetectorTest.java
@@ -1,0 +1,106 @@
+package de.tum.cit.aet.hephaestus.gitprovider.common.github;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit tests for {@link GraphQlConnectionOverflowDetector}.
+ *
+ * <p>Pins the level-calibration contract from issue #1313: a count gap that remains after a
+ * pagination loop completed normally is benign (DEBUG, no WARN), and WARN is reserved for genuine
+ * terminal incompleteness (the loop stopped early, or a single-page embedded connection overflowed).
+ */
+class GraphQlConnectionOverflowDetectorTest extends BaseUnitTest {
+
+    private ListAppender<ILoggingEvent> appender;
+    private Logger logger;
+
+    @BeforeEach
+    void attachAppender() {
+        logger = (Logger) LoggerFactory.getLogger(GraphQlConnectionOverflowDetector.class);
+        logger.setLevel(Level.DEBUG); // ensure the benign DEBUG branch is actually recorded
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        logger.detachAppender(appender);
+    }
+
+    // --- checkPaginated(name, fetched, total, stoppedEarly, context) ---
+
+    @Test
+    void paginated_gapAfterFullPagination_logsDebug_returnsFalse() {
+        // e.g. reviewThreads where resolved threads contributed no comments, or GitHub over-reports
+        boolean overflow = GraphQlConnectionOverflowDetector.checkPaginated(
+            "reviewThreads",
+            3,
+            5,
+            false,
+            "prNumber=42"
+        );
+
+        assertThat(overflow).isFalse();
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.DEBUG);
+        assertThat(appender.list.get(0).getFormattedMessage()).contains("benign").contains("reviewThreads");
+    }
+
+    @Test
+    void paginated_gapAfterEarlyStop_logsWarn_returnsTrue() {
+        boolean overflow = GraphQlConnectionOverflowDetector.checkPaginated("issues", 30, 100, true, "owner/repo");
+
+        assertThat(overflow).isTrue();
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.list.get(0).getFormattedMessage()).contains("stopped before all pages");
+    }
+
+    @Test
+    void paginated_earlyStopButNoGap_logsNothing_returnsFalse() {
+        // Stopped early but we still got everything GitHub reported — not incomplete, so no log.
+        boolean overflow = GraphQlConnectionOverflowDetector.checkPaginated("issues", 100, 100, true, "owner/repo");
+
+        assertThat(overflow).isFalse();
+        assertThat(appender.list).isEmpty();
+    }
+
+    // --- single-page embedded overloads (genuine loss, no follow-up pagination) ---
+
+    @Test
+    void embedded_totalCountOverflow_logsWarn_returnsTrue() {
+        boolean overflow = GraphQlConnectionOverflowDetector.check("assignees", 5, 12, "PR #7");
+
+        assertThat(overflow).isTrue();
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(appender.list.get(0).getFormattedMessage()).contains("No follow-up pagination");
+    }
+
+    @Test
+    void embedded_hasNextPage_logsWarn_returnsTrue() {
+        boolean overflow = GraphQlConnectionOverflowDetector.check("labels", 100, true, "issue #3");
+
+        assertThat(overflow).isTrue();
+        assertThat(appender.list).hasSize(1);
+        assertThat(appender.list.get(0).getLevel()).isEqualTo(Level.WARN);
+    }
+
+    @Test
+    void embedded_noOverflow_logsNothing_returnsFalse() {
+        assertThat(GraphQlConnectionOverflowDetector.check("assignees", 5, 5, "PR #7")).isFalse();
+        assertThat(GraphQlConnectionOverflowDetector.check("labels", 5, false, "issue #3")).isFalse();
+        assertThat(appender.list).isEmpty();
+    }
+}


### PR DESCRIPTION
## Description

A normal local sync of a single repository emitted **~2,700 INFO lines, 10 WARN, and 2 ERROR with full stack traces** — so a perfectly healthy run looked broken to anyone reading the logs (a new contributor booting the stack, or an operator scanning production). None of it was a real failure: it was miscalibrated log levels and two over-eager / mis-counted warnings, sitting on top of one genuine concurrency bug.

This PR makes the default log legible again so that **WARN/ERROR mean "a human should look"**, and fixes the root causes behind the scariest lines.

### 🔴 Achievement optimistic-lock ERROR storm (root cause)

Achievement evaluation runs asynchronously per activity event. During a sync burst, many events for the **same user** incremented the same versioned row concurrently; the losers of the race threw `ObjectOptimisticLockingFailureException` (full stack trace) on nearly every sync, and left Hibernate `HHH100503` "batch still contained statements" warnings behind.

Evaluation is now **serialized per user** with a transaction-scoped Postgres advisory lock (`pg_advisory_xact_lock`, in the two-integer keyspace so it can't collide with the existing login lock): same-user events run one at a time, different users stay fully parallel, and the lock auto-releases on commit/rollback. The optimistic-lock churn and the batch warnings are eliminated at the source — not silenced. A real-Postgres integration test fires 40 concurrent same-user events and asserts zero failures with every increment landing.

### 🟠 False "data may be incomplete" warnings

The GraphQL connection-overflow detector warned whenever `fetched < totalCount`, **even when the loop had fully paginated** — comparing mismatched units (comments vs. threads, post-filter vs. raw counts) and tripping on almost every sync. A new `checkPaginated(...)` gates the warning on *why the loop ended*: a benign gap after full pagination logs at DEBUG; only a genuine early stop (error / rate-limit / page cap) warns. **Every** loop-based call site (24 in total) now compares raw nodes-received against `totalCount`; meaningless mid-cursor checks were removed, and sites whose truncation is already handled by follow-up pagination no longer warn.

### 🟡 Level recalibration

- **Liquibase** and Hibernate batch summaries → `WARN` (config) — removes ~2,300 per-changeset INFO lines on every boot.
- Per-event **webhook receipts** and bookkeeping → `DEBUG` at the source; per-repo `Completed … sync` rollups stay at `INFO`.
- The worker **"ephemeral signing key"** warning now fires only under the `prod` profile — it's the expected path in dev.

I also audited every level change to confirm **nothing operationally useful is now hidden**: errors, rate-limit, auth, and real-truncation warnings all still surface, and the per-repo sync rollups remain at INFO.

### Result

A clean-DB sync of the `ls1intum` org (including the large `Artemis` repo) processed **~2,800 activity events and ~970 achievements with 0 ERROR, 0 stack traces, 0 optimistic-lock failures, 0 overflow false-positives, and no Liquibase chatter** — down from ~2,700 INFO / 10 WARN / 2 ERROR.

No behaviour changes to sync correctness or achievement scoring; no schema/API changes.

Fixes #1313

## How to test

1. **Clean sync, read the log.** Reset the DB and boot with a workspace pointed at a GitHub org:
   ```bash
   pnpm dev:reset
   cd server && SERVER_PORT=38080 ./mvnw spring-boot:run -Dspring-boot.run.profiles=local
   ```
   The startup sync should show only per-repo `Completed … sync` rollups at INFO — **no `ERROR`, no stack traces, no `liquibase` per-changeset lines, and no "data may be incomplete" WARNs**.
2. **Unit + concurrency integration tests:**
   ```bash
   cd server && ./mvnw test -Dsurefire.includedGroups=unit \
     -Dtest='GraphQlConnectionOverflowDetectorTest,AchievementServiceTest'
   cd server && ./mvnw verify -Dit.test=AchievementConcurrencyIntegrationTest   # real Postgres via Testcontainers
   ```
3. **Need the detail back?** The per-event firehose is one switch away, no redeploy:
   `logging.level.de.tum.cit.aet.hephaestus.gitprovider=DEBUG`.

## Notes for reviewers

- Much of the diff is mechanical: ~27 webhook handlers change one `log.info` → `log.debug`, and ~20 sync loops add a raw nodes-received counter and call `checkPaginated`.
- The substantive logic is in `AchievementService`/`UserAchievementRepository` (the advisory lock), `GraphQlConnectionOverflowDetector` (the new `checkPaginated` API), and `AchievementConcurrencyIntegrationTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
