### PR TITLE
feat(server): safe multi-replica agent workers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Regeneration is destructive; stash local edits before running these commands. Ch
   2. Snapshot the schema, run Liquibase diff, and create a timestamped changelog file.
   3. Tear down the temporary container.
 - Trim the generated changelog to only the real schema deltas (e.g., new columns). Never commit the raw diff wholesale—prune back to the minimal change set before renaming it into `db/changelog/`.
+- **Filename convention (required):** the committed file MUST be `<epoch-ms-timestamp>_changelog.xml` — a real millisecond timestamp (`date +%s%3N`, i.e. what the draft tool emits), strictly greater than the latest existing changelog so `master.xml` stays monotonic. Do NOT invent a round number and do NOT use a descriptive suffix; keep the `_changelog.xml` name. `changeSet` ids follow `<timestamp>-1`, `<timestamp>-2`, …
+- **One consolidated changelog per branch/PR (required):** add every schema change for a branch as additional `<changeSet>` entries inside that single file. Never open a PR with more than one new changelog file — consolidate. Each `changeSet` should be preconditioned (`onFail="MARK_RAN"`) with a `<rollback>`, matching the existing files.
 - After drafting a changelog, run `pnpm run db:generate-erd-docs` to keep ERD docs in sync.
 - Never manually edit generated Liquibase diff sections unless you fully understand the implications. Prefer creating a follow-up changelog to fix mistakes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/contributor/erd/schema.mmd
+++ b/docs/contributor/erd/schema.mmd
@@ -75,6 +75,7 @@ erDiagram
         DOUBLE llm_cost_usd
         VARCHAR(50) llm_model_version
         VARCHAR(32) cancellation_reason
+        VARCHAR(255) worker_id
     }
 
     ChatMessage {
@@ -672,6 +673,12 @@ erDiagram
         BIGINT user_id FK,UK "NOT NULL"
         BOOLEAN participate_in_research "NOT NULL"
         BOOLEAN ai_review_enabled "NOT NULL"
+    }
+
+    WorkerRegistry {
+        VARCHAR(255) worker_id PK
+        TIMESTAMPTZ last_heartbeat "NOT NULL"
+        TIMESTAMPTZ registered_at "NOT NULL"
     }
 
     WorkerTokenDenylist {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJob.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJob.java
@@ -154,6 +154,15 @@ public class AgentJob {
     @Column(name = "retry_count", nullable = false)
     private int retryCount = 0;
 
+    /**
+     * Worker that owns this job while {@link #status} is {@link AgentJobStatus#RUNNING} (#1138).
+     * Soft reference to {@code worker_registry.worker_id} (no FK: a finished job must survive its
+     * worker row being reaped). Set on claim; routes cancels to the owner, detects jobs orphaned by a
+     * dead worker, and fences terminal writes so a requeued job's original worker can't clobber it.
+     */
+    @Column(name = "worker_id", length = 255)
+    private String workerId;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
@@ -115,8 +116,16 @@ public class AgentJobExecutor {
      * deregister. Survives thread restarts and exception paths via the try-finally.
      */
     private final Phaser inFlight = new Phaser(1); // 1 = the executor itself; deregistered on stop
+    /**
+     * Job ids this worker is currently executing. Source of truth for job-scoped cancellation
+     * (#1138): drain and hub-initiated cancels act only on jobs in this set, never on sibling
+     * workers' jobs. Populated on claim, removed in the {@code executeJob} finally block.
+     */
+    private final Set<UUID> localRunningJobs = ConcurrentHashMap.newKeySet();
     private final java.util.Optional<WorkerCapacityState> capacityState;
     private final java.util.Optional<WorkerProperties> workerProperties;
+    /** This worker's identity (null only when the worker role is off); stamped on claimed jobs to fence terminal writes. */
+    private final String workerId;
 
     public AgentJobExecutor(
         @Qualifier("agentNatsConnection") Connection natsConnection,
@@ -146,6 +155,7 @@ public class AgentJobExecutor {
         this.meterRegistry = meterRegistry;
         this.capacityState = capacityState;
         this.workerProperties = workerProperties;
+        this.workerId = workerProperties.map(WorkerProperties::resolvedWorkerId).orElse(null);
 
         // Internal scheduler for NATS InProgress heartbeats — not a @Bean to avoid
         // blocking Spring's TaskScheduler auto-configuration (ConditionalOnMissingBean).
@@ -174,8 +184,9 @@ public class AgentJobExecutor {
         pullThread = Thread.ofPlatform().name("agent-nats-pull").daemon(true).start(this::pullLoop);
 
         log.info(
-            "Agent job executor started: consumer={}, maxAckPending={}",
+            "Agent job executor started: consumer={}, workerId={}, maxAckPending={}",
             natsProperties.consumerName(),
+            workerId,
             natsProperties.maxAckPending()
         );
     }
@@ -226,34 +237,51 @@ public class AgentJobExecutor {
     }
 
     /**
-     * Transition every job currently {@link AgentJobStatus#RUNNING} on this worker to
-     * {@link AgentJobStatus#CANCELLED} with the given reason. The in-flight sandbox tasks
-     * continue running locally but their terminal-state write will fail the {@code IN :fromStatuses}
-     * guard and the result will be discarded; NATS holds the message unack'd and redelivers to
-     * the next worker.
-     *
-     * <p>{@code RUNNING} is shared across workers in principle, but in practice the JetStream
-     * WorkQueue + {@code maxAckPending} bound ensures only this worker holds RUNNING messages.
+     * Transition the jobs THIS worker is currently running to {@link AgentJobStatus#CANCELLED}
+     * with the given reason, and stop their containers promptly. Scoped to {@link #localRunningJobs}
+     * so sibling workers' jobs are untouched — this is the fix for #1138 that makes running more
+     * than one worker replica safe.
      */
     public void cancelInFlight(AgentJobCancellationReason reason) {
-        // TODO(#1138): scope to RUNNING jobs claimed by THIS worker once
-        // the dispatcher claim loop lands. Until then, do not scale worker
-        // replicas above 1 — sibling workers' jobs will be mass-cancelled.
-        java.util.List<AgentJob> running = jobRepository.findByStatus(AgentJobStatus.RUNNING);
-        if (running.isEmpty()) {
+        Set<UUID> snapshot = Set.copyOf(localRunningJobs);
+        if (snapshot.isEmpty()) {
             return;
         }
-        log.info("Cancelling {} in-flight job(s) with reason {}", running.size(), reason);
+        log.info("Cancelling {} in-flight job(s) owned by this worker with reason {}", snapshot.size(), reason);
         Instant now = Instant.now();
         String error = "worker draining";
-        for (AgentJob job : running) {
+        for (UUID jobId : snapshot) {
             try {
                 transactionTemplate.executeWithoutResult(status ->
-                    jobRepository.transitionToCancelled(job.getId(), now, error, reason, Set.of(AgentJobStatus.RUNNING))
+                    jobRepository.transitionToCancelled(jobId, now, error, reason, Set.of(AgentJobStatus.RUNNING))
                 );
+                // Stop the container so drain doesn't wait for the agent to finish naturally.
+                sandboxManager.cancel(jobId);
             } catch (Exception e) {
-                log.warn("Failed to cancel in-flight job {}: {}", job.getId(), e.getClass().getSimpleName());
+                log.warn("Failed to cancel in-flight job {}: {}", jobId, e.getClass().getSimpleName());
             }
+        }
+    }
+
+    /**
+     * Promptly stop a locally-running job's container in response to a hub-initiated cancel
+     * (the authoritative {@code agent_job} status transition is performed hub-side before the
+     * {@code CancelJob} frame is dispatched). No-op if this worker does not own the job, which is
+     * how job-scoped cancellation stays safe across replicas.
+     *
+     * @return {@code true} if this worker owns the job and a stop was requested
+     */
+    public boolean cancelLocalJob(UUID jobId, String reason) {
+        if (!localRunningJobs.contains(jobId)) {
+            return false;
+        }
+        log.info("Hub-initiated cancel for locally-running job {}: {}", jobId, reason);
+        try {
+            sandboxManager.cancel(jobId);
+            return true;
+        } catch (Exception e) {
+            log.warn("Local cancel failed for job {}: {}", jobId, e.getClass().getSimpleName());
+            return false;
         }
     }
 
@@ -277,8 +305,11 @@ public class AgentJobExecutor {
                 StreamContext streamContext = natsConnection.getStreamContext(natsProperties.streamName());
                 ConsumerContext consumerContext = streamContext.getConsumerContext(natsProperties.consumerName());
 
+                // Pull only a worker-local batch (not the cluster-wide maxAckPending) so a single
+                // replica doesn't claim the whole unacked budget and starve siblings (#1138). The
+                // pool-full path NAKs-with-delay, returning surplus to other replicas.
                 FetchConsumeOptions fetchOptions = FetchConsumeOptions.builder()
-                    .maxMessages(natsProperties.maxAckPending())
+                    .maxMessages(natsProperties.fetchBatchSize())
                     .expiresIn(Duration.ofSeconds(30).toMillis())
                     .build();
 
@@ -348,6 +379,7 @@ public class AgentJobExecutor {
             if (claimed) {
                 releaseCapacity();
             }
+            localRunningJobs.remove(jobId);
             MDC.remove(MDC_JOB_ID);
             MDC.remove(MDC_JOB_TYPE);
         }
@@ -569,15 +601,9 @@ public class AgentJobExecutor {
 
     /** Handle a job cancelled during sandbox execution. */
     private void handleCancellation(UUID jobId, Message msg) {
-        transactionTemplate.executeWithoutResult(status -> {
-            jobRepository.transitionStatus(
-                jobId,
-                AgentJobStatus.CANCELLED,
-                Instant.now(),
-                "Cancelled during execution",
-                Set.of(AgentJobStatus.RUNNING)
-            );
-        });
+        transactionTemplate.executeWithoutResult(status ->
+            transitionTerminal(jobId, AgentJobStatus.CANCELLED, Instant.now(), "Cancelled during execution")
+        );
         msg.ack();
         log.info("Agent job cancelled: jobId={}", jobId);
     }
@@ -601,15 +627,9 @@ public class AgentJobExecutor {
         String errorMessage = truncateErrorMessage(e.getMessage());
         log.error("Agent job failed: jobId={}, error={}", jobId, errorMessage, e);
 
-        transactionTemplate.executeWithoutResult(status -> {
-            jobRepository.transitionStatus(
-                jobId,
-                AgentJobStatus.FAILED,
-                Instant.now(),
-                errorMessage,
-                Set.of(AgentJobStatus.RUNNING)
-            );
-        });
+        transactionTemplate.executeWithoutResult(status ->
+            transitionTerminal(jobId, AgentJobStatus.FAILED, Instant.now(), errorMessage)
+        );
         msg.ack();
     }
 
@@ -664,13 +684,14 @@ public class AgentJobExecutor {
                 }
             }
 
-            // Transition to RUNNING
+            ConfigSnapshot snapshot = ConfigSnapshot.fromJson(job.getConfigSnapshot(), objectMapper);
             job.setStatus(AgentJobStatus.RUNNING);
             job.setStartedAt(Instant.now());
+            job.setWorkerId(workerId); // owner for cancel routing, orphan recovery, and terminal-write fencing (#1138)
             jobRepository.save(job);
 
-            ConfigSnapshot snapshot = ConfigSnapshot.fromJson(job.getConfigSnapshot(), objectMapper);
-
+            // Track locally so drain / hub-initiated cancels target only this worker's jobs.
+            localRunningJobs.add(jobId);
             capacityState.ifPresent(WorkerCapacityState::claimReview);
             return new ClaimResult(job, snapshot);
         });
@@ -679,6 +700,21 @@ public class AgentJobExecutor {
     /** Release the review-capacity slot on any terminal transition (success/failure/cancel/timeout). */
     private void releaseCapacity() {
         capacityState.ifPresent(WorkerCapacityState::releaseReview);
+    }
+
+    /**
+     * Terminal RUNNING→{@code status} transition, fenced to this worker's ownership when a worker id
+     * is known (#1138): if the job was orphan-requeued to a sibling, this worker's late write finds a
+     * different {@code worker_id} and no-ops instead of clobbering the sibling's run. Falls back to an
+     * unfenced transition only when no worker identity exists (worker role off) — where there are no
+     * siblings to fence against.
+     *
+     * @return rows updated (0 if no longer RUNNING or no longer owned by this worker)
+     */
+    private int transitionTerminal(UUID jobId, AgentJobStatus status, Instant now, String error) {
+        return workerId != null
+            ? jobRepository.transitionStatusOwnedBy(jobId, status, now, error, Set.of(AgentJobStatus.RUNNING), workerId)
+            : jobRepository.transitionStatus(jobId, status, now, error, Set.of(AgentJobStatus.RUNNING));
     }
 
     // ── Complete: micro-transaction #2 ──
@@ -691,8 +727,14 @@ public class AgentJobExecutor {
         AgentJob job
     ) {
         AgentJobStatus terminalStatus = determineTerminalStatus(sandboxResult, agentResult);
-        persistTerminalState(jobId, agentResult, sandboxResult, terminalStatus);
-        deliverResults(jobId, terminalStatus, handler);
+        // persistTerminalState returns false when we lost the fence (cancelled / orphan-requeued); we
+        // must not deliver then, or a stuck-then-recovered worker would double-post the sibling's findings.
+        boolean persisted = persistTerminalState(jobId, agentResult, sandboxResult, terminalStatus);
+        if (persisted) {
+            deliverResults(jobId, terminalStatus, handler);
+        } else {
+            log.info("Skipping delivery: job no longer owned/RUNNING (requeued or cancelled): jobId={}", jobId);
+        }
     }
 
     /**
@@ -747,10 +789,12 @@ public class AgentJobExecutor {
     }
 
     /**
-     * Persist terminal status and output within a single transaction.
-     * Ensures cancelled jobs don't get output persisted.
+     * Persist terminal status and output within a single transaction, fenced to this worker.
+     *
+     * @return {@code true} if this worker won the terminal write (still RUNNING-and-owned); {@code false}
+     *     if the job was cancelled or orphan-requeued to a sibling, in which case the caller must NOT deliver.
      */
-    private void persistTerminalState(
+    private boolean persistTerminalState(
         UUID jobId,
         AgentResult agentResult,
         SandboxResult sandboxResult,
@@ -762,19 +806,14 @@ public class AgentJobExecutor {
             default -> null;
         };
 
-        transactionTemplate.executeWithoutResult(status -> {
-            int updated = jobRepository.transitionStatus(
-                jobId,
-                terminalStatus,
-                Instant.now(),
-                errorMessage,
-                Set.of(AgentJobStatus.RUNNING)
-            );
+        Boolean persisted = transactionTemplate.execute(status -> {
+            int updated = transitionTerminal(jobId, terminalStatus, Instant.now(), errorMessage);
 
             if (updated == 0) {
-                // Job was cancelled during execution — skip output persist
-                log.info("Job was cancelled during execution, skipping output persist: jobId={}", jobId);
-                return;
+                // No longer RUNNING-and-ours: cancelled during execution, or orphan-requeued to a
+                // sibling (fence). Skip output persist so we don't clobber the new owner's run.
+                log.info("Job no longer owned/RUNNING, skipping output persist: jobId={}", jobId);
+                return false;
             }
 
             AgentJob freshJob = jobRepository.findById(jobId).orElse(null);
@@ -836,7 +875,9 @@ public class AgentJobExecutor {
                 }
                 jobRepository.saveAndFlush(freshJob);
             }
+            return true;
         });
+        return Boolean.TRUE.equals(persisted);
     }
 
     /**

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobRepository.java
@@ -101,6 +101,28 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
     );
 
     /**
+     * Terminal transition fenced to the owning worker (#1138): like {@link #transitionStatus} but also
+     * requires {@code worker_id = :workerId}, so a worker whose job was orphan-requeued to a sibling
+     * cannot clobber the sibling's run with its own late terminal write.
+     *
+     * @return rows updated (0 or 1)
+     */
+    @WorkspaceAgnostic("ID-based fenced transition; job ID + owner from worker-local execution context")
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(
+        "UPDATE AgentJob j SET j.status = :newStatus, j.completedAt = :now, j.errorMessage = :error " +
+            "WHERE j.id = :id AND j.status IN :fromStatuses AND j.workerId = :workerId"
+    )
+    int transitionStatusOwnedBy(
+        @Param("id") UUID id,
+        @Param("newStatus") AgentJobStatus newStatus,
+        @Param("now") Instant now,
+        @Param("error") String error,
+        @Param("fromStatuses") Collection<AgentJobStatus> fromStatuses,
+        @Param("workerId") String workerId
+    );
+
+    /**
      * Conditional transition to {@link AgentJobStatus#CANCELLED} that also records the
      * cancellation reason. Used by the worker drain coordinator and explicit user-cancel paths.
      *
@@ -121,15 +143,56 @@ public interface AgentJobRepository extends JpaRepository<AgentJob, UUID> {
         @Param("fromStatuses") Collection<AgentJobStatus> fromStatuses
     );
 
-    /** Zombie sweeper: find QUEUED jobs older than cutoff (never picked up by NATS consumer). */
+    /**
+     * Zombie sweeper: QUEUED jobs older than cutoff (never picked up by the NATS consumer). Returns a
+     * projection (not entities) so the sweeper can re-publish outside any transaction — without it the
+     * lazy {@code workspace} access would force the publish loop to hold a DB connection across NATS I/O.
+     */
     @WorkspaceAgnostic("Cross-workspace zombie recovery; caller is @WorkspaceAgnostic sweeper")
-    @Query("SELECT j FROM AgentJob j WHERE j.status = 'QUEUED' AND j.createdAt < :cutoff")
-    List<AgentJob> findStaleQueuedJobs(@Param("cutoff") Instant cutoff);
+    @Query(
+        "SELECT j.id AS jobId, j.workspace.id AS workspaceId, j.retryCount AS retryCount " +
+            "FROM AgentJob j WHERE j.status = 'QUEUED' AND j.createdAt < :cutoff"
+    )
+    List<OrphanedJobRef> findStaleQueuedJobs(@Param("cutoff") Instant cutoff);
 
     /** Stale RUNNING reaper: find RUNNING jobs that exceeded their expected lifetime. */
     @WorkspaceAgnostic("Cross-workspace stale job reaper; caller is @WorkspaceAgnostic sweeper")
     @Query("SELECT j FROM AgentJob j WHERE j.status = 'RUNNING' AND j.startedAt < :cutoff")
     List<AgentJob> findStaleRunningJobs(@Param("cutoff") Instant cutoff);
+
+    /**
+     * Orphan recovery (#1138): RUNNING jobs whose owning worker has no fresh heartbeat (crashed /
+     * partitioned / gone). Native so the liveness comparison stays on the DB clock both sides —
+     * {@code last_heartbeat} is written with the DB {@code now()}, and the cutoff is
+     * {@code now() - leaseTtlSeconds}, so no app/DB skew enters the alive/dead decision. The
+     * {@code startedAt < :graceCutoff} startup grace is app-clock on both sides (started_at is set
+     * app-side at claim); clock skew there only shifts grace timing and cannot cause a false orphan.
+     */
+    @WorkspaceAgnostic("Cross-workspace orphan recovery; caller is @WorkspaceAgnostic sweeper")
+    @Query(
+        value = "SELECT j.id AS jobId, j.workspace_id AS workspaceId, j.retry_count AS retryCount " +
+            "FROM agent_job j WHERE j.status = 'RUNNING' AND j.worker_id IS NOT NULL " +
+            "AND j.started_at < :graceCutoff " +
+            "AND NOT EXISTS (SELECT 1 FROM worker_registry w WHERE w.worker_id = j.worker_id " +
+            "AND w.last_heartbeat >= now() - make_interval(secs => :leaseTtlSeconds))",
+        nativeQuery = true
+    )
+    List<OrphanedJobRef> findOrphanedRunningJobs(
+        @Param("graceCutoff") Instant graceCutoff,
+        @Param("leaseTtlSeconds") long leaseTtlSeconds
+    );
+
+    /**
+     * CAS requeue of an orphaned job: RUNNING → QUEUED, clear ownership, bump retry_count. Returns 1
+     * if this caller won the race (so it should re-publish), 0 if another sweeper already moved it.
+     */
+    @WorkspaceAgnostic("ID-based orphan requeue; caller is @WorkspaceAgnostic sweeper")
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(
+        "UPDATE AgentJob j SET j.status = 'QUEUED', j.workerId = null, " +
+            "j.startedAt = null, j.retryCount = j.retryCount + 1 WHERE j.id = :id AND j.status = 'RUNNING'"
+    )
+    int requeueOrphan(@Param("id") UUID id);
 
     // ── Delivery tracking (issue #748) ──
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobService.java
@@ -12,6 +12,7 @@ import de.tum.cit.aet.hephaestus.agent.handler.spi.JobSubmissionRequest;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobTypeHandler;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxManager;
 import de.tum.cit.aet.hephaestus.core.exception.EntityNotFoundException;
+import de.tum.cit.aet.hephaestus.core.runtime.hub.WorkerJobCancelDispatcher;
 import de.tum.cit.aet.hephaestus.gitprovider.common.events.EventPayload;
 import de.tum.cit.aet.hephaestus.gitprovider.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.gitprovider.pullrequest.PullRequestRepository;
@@ -52,6 +53,7 @@ public class AgentJobService {
     private final TransactionTemplate transactionTemplate;
     private final PracticeReviewProperties reviewProperties;
     private final @Nullable SandboxManager sandboxManager;
+    private final Optional<WorkerJobCancelDispatcher> workerJobCancelDispatcher;
 
     public AgentJobService(
         AgentJobRepository agentJobRepository,
@@ -63,7 +65,8 @@ public class AgentJobService {
         ApplicationEventPublisher eventPublisher,
         TransactionTemplate transactionTemplate,
         PracticeReviewProperties reviewProperties,
-        @Nullable SandboxManager sandboxManager
+        @Nullable SandboxManager sandboxManager,
+        Optional<WorkerJobCancelDispatcher> workerJobCancelDispatcher
     ) {
         this.agentJobRepository = agentJobRepository;
         this.agentConfigRepository = agentConfigRepository;
@@ -75,6 +78,7 @@ public class AgentJobService {
         this.transactionTemplate = transactionTemplate;
         this.reviewProperties = reviewProperties;
         this.sandboxManager = sandboxManager;
+        this.workerJobCancelDispatcher = workerJobCancelDispatcher;
     }
 
     // ── Read operations ──
@@ -408,8 +412,16 @@ public class AgentJobService {
             }
         }
 
-        // Best-effort inline sandbox cancel when worker is co-located. When worker runs in a
-        // separate JVM, SandboxManager is null and reconciler/zombie-sweeper backstops apply.
+        // Reload to read worker_id (set at claim) for cancel routing.
+        AgentJob fresh = agentJobRepository
+            .findByIdAndWorkspaceId(jobId, workspaceId)
+            .orElseThrow(() -> new EntityNotFoundException("AgentJob", jobId.toString()));
+
+        // Split deployment: ask the owning worker to stop its container over the WSS channel (#1138).
+        // No-op if that worker isn't connected here — the DB transition + backstops still finish the cancel.
+        workerJobCancelDispatcher.ifPresent(d -> d.dispatch(fresh.getWorkerId(), jobId, "user-cancel"));
+
+        // Monolith / co-located worker: stop the container in-process.
         if (sandboxManager != null) {
             try {
                 sandboxManager.cancel(jobId);
@@ -418,10 +430,7 @@ public class AgentJobService {
             }
         }
 
-        // Reload to return fresh state
-        return agentJobRepository
-            .findByIdAndWorkspaceId(jobId, workspaceId)
-            .orElseThrow(() -> new EntityNotFoundException("AgentJob", jobId.toString()));
+        return fresh;
     }
 
     // ── Cooldown helpers ──

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeper.java
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,17 +15,21 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * Periodic recovery for orphaned agent jobs.
+ * Periodic recovery for orphaned agent jobs. Runs on the server role only (relies on
+ * {@code @EnableScheduling}, which is server-scoped); reads {@code worker_registry} written by workers.
  *
- * <p>Two sweeps:
+ * <p>Three sweeps:
  * <ol>
- *   <li><b>Zombie QUEUED</b> (every 5 min): re-publishes QUEUED jobs older than 10 minutes
- *       that were never picked up — typically due to NATS publish failure after DB commit.</li>
- *   <li><b>Stale RUNNING</b> (every 2 min): marks RUNNING jobs as FAILED if they've exceeded
- *       their timeout + 5-minute buffer — handles executor crashes and OOM kills.</li>
+ *   <li><b>Orphan requeue</b> (every 20s): requeues RUNNING jobs whose owning worker's heartbeat went
+ *       stale, so a sibling re-runs them within seconds rather than waiting out the full timeout (#1138).</li>
+ *   <li><b>Zombie QUEUED</b> (every 5 min): re-publishes QUEUED jobs older than 10 minutes that were
+ *       never picked up — typically a NATS publish failure after DB commit.</li>
+ *   <li><b>Stale RUNNING</b> (every 2 min): the absolute-timeout backstop — marks RUNNING jobs
+ *       {@code TIMED_OUT} once they exceed their timeout + buffer.</li>
  * </ol>
  */
 @Component
@@ -37,57 +42,91 @@ public class AgentJobZombieSweeper {
     private static final Duration QUEUED_STALE_THRESHOLD = Duration.ofMinutes(10);
     private static final Duration RUNNING_BUFFER = Duration.ofMinutes(5);
 
+    /**
+     * A worker is "alive" if it self-reported within this window. ~2.4× the worker's liveness
+     * heartbeat cadence ({@code hephaestus.agent.nats.heartbeat-interval}, 25s), so a couple of
+     * dropped heartbeats don't falsely declare a live worker dead.
+     */
+    private static final Duration WORKER_LEASE_TTL = Duration.ofSeconds(60);
+
+    /**
+     * Startup grace: only consider a RUNNING job orphaned once it has been running longer than this,
+     * giving a freshly-(re)connected worker time to write its first heartbeat before we reason about
+     * its liveness. Mirrors Artemis's stale-detection startup grace.
+     */
+    private static final Duration ORPHAN_STARTUP_GRACE = Duration.ofSeconds(120);
+
+    /** Registrations older than this are purged (≫ the orphan lease, so live jobs are recovered first). */
+    private static final Duration STALE_REGISTRATION_TTL = Duration.ofHours(1);
+
     private final AgentJobRepository jobRepository;
+    private final WorkerRegistryRepository workerRegistryRepository;
     private final AgentJobSubmitter submitter;
+    private final AgentNatsProperties natsProperties;
     private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
     private final Counter zombieRepublished;
     private final Counter zombieReaped;
+    private final Counter orphanRequeued;
+    private final Counter orphanFailed;
 
     public AgentJobZombieSweeper(
         AgentJobRepository jobRepository,
+        WorkerRegistryRepository workerRegistryRepository,
         AgentJobSubmitter submitter,
+        AgentNatsProperties natsProperties,
         ObjectMapper objectMapper,
+        TransactionTemplate transactionTemplate,
         MeterRegistry meterRegistry
     ) {
         this.jobRepository = jobRepository;
+        this.workerRegistryRepository = workerRegistryRepository;
         this.submitter = submitter;
+        this.natsProperties = natsProperties;
         this.objectMapper = objectMapper;
+        this.transactionTemplate = transactionTemplate;
         this.zombieRepublished = Counter.builder("agent.job.zombie.republished")
             .description("QUEUED jobs re-published to NATS")
             .register(meterRegistry);
         this.zombieReaped = Counter.builder("agent.job.zombie.reaped")
             .description("Stale RUNNING jobs marked as TIMED_OUT")
             .register(meterRegistry);
+        this.orphanRequeued = Counter.builder("agent.job.orphan.requeued")
+            .description("RUNNING jobs whose owning worker was lost, requeued for another worker")
+            .register(meterRegistry);
+        this.orphanFailed = Counter.builder("agent.job.orphan.failed")
+            .description("Orphaned jobs that hit the retry cap and were failed")
+            .register(meterRegistry);
     }
 
     /**
-     * Re-publish QUEUED jobs that were never picked up by the NATS consumer.
+     * Re-publish QUEUED jobs the NATS consumer never picked up (publish failed after the DB commit).
+     * Not {@code @Transactional}: the fetch is a projection query (own read tx) and the blocking NATS
+     * publish runs outside any tx, so we never hold a pooled DB connection across network I/O.
      */
-    @Transactional(readOnly = true)
     @Scheduled(fixedDelay = 5, timeUnit = TimeUnit.MINUTES, initialDelay = 2)
     public void republishStaleQueuedJobs() {
-        Instant cutoff = Instant.now().minus(QUEUED_STALE_THRESHOLD);
-        List<AgentJob> staleJobs = jobRepository.findStaleQueuedJobs(cutoff);
-
+        List<OrphanedJobRef> staleJobs = jobRepository.findStaleQueuedJobs(Instant.now().minus(QUEUED_STALE_THRESHOLD));
         if (staleJobs.isEmpty()) {
             return;
         }
-
         log.info("Found {} stale QUEUED jobs, re-publishing to NATS", staleJobs.size());
-
-        for (AgentJob job : staleJobs) {
+        for (OrphanedJobRef job : staleJobs) {
             try {
-                submitter.publish(job.getId(), job.getWorkspace().getId());
+                submitter.publish(job.getJobId(), job.getWorkspaceId());
                 zombieRepublished.increment();
-                log.info("Re-published stale job: jobId={}, createdAt={}", job.getId(), job.getCreatedAt());
             } catch (Exception e) {
-                log.warn("Failed to re-publish stale job: jobId={}, error={}", job.getId(), e.getMessage());
+                log.warn("Failed to re-publish stale job {}: {}", job.getJobId(), e.getMessage());
             }
         }
     }
 
     /**
-     * Mark stale RUNNING jobs as FAILED (executor crashed or OOM-killed).
+     * Absolute-timeout backstop: mark RUNNING jobs {@code TIMED_OUT} once they exceed their per-job
+     * timeout + buffer. This is the last resort for the case where {@link #recoverOrphanedJobs} can't
+     * run (e.g. its node is down); in normal operation the faster heartbeat-driven orphan sweep (20s)
+     * requeues a dead worker's jobs long before this 2-minute reaper's {@code timeout + 5min} cutoff
+     * fires, so the two don't fight over dead-worker jobs — they're separated by timing.
      */
     @Transactional
     @Scheduled(fixedDelay = 2, timeUnit = TimeUnit.MINUTES, initialDelay = 1)
@@ -125,6 +164,81 @@ public class AgentJobZombieSweeper {
             } catch (Exception e) {
                 log.warn("Failed to reap stale job: jobId={}, error={}", job.getId(), e.getMessage());
             }
+        }
+    }
+
+    /**
+     * Fast orphan recovery (#1138): requeue RUNNING jobs whose owning worker stopped heartbeating
+     * (crash / partition / kill), so a sibling worker picks them up within seconds instead of waiting
+     * out the full job timeout. CAS-guarded so concurrent sweepers on multiple replicas can't
+     * double-requeue. Jobs past the retry cap are failed. Runs more often than the absolute-timeout
+     * reaper because heartbeat loss is detectable far sooner than timeout expiry.
+     *
+     * <p>Unlike the sibling sweeps this is not method-{@code @Transactional}: each job's CAS runs in
+     * its own transaction so re-publish happens after that job's requeue commits, and one poison job
+     * can't roll back the batch.
+     */
+    @Scheduled(fixedDelay = 20, timeUnit = TimeUnit.SECONDS, initialDelay = 30)
+    public void recoverOrphanedJobs() {
+        List<OrphanedJobRef> orphans = jobRepository.findOrphanedRunningJobs(
+            Instant.now().minus(ORPHAN_STARTUP_GRACE),
+            WORKER_LEASE_TTL.toSeconds()
+        );
+        if (orphans.isEmpty()) {
+            return;
+        }
+        log.warn("Found {} orphaned RUNNING job(s) (owning worker lost); recovering", orphans.size());
+        for (OrphanedJobRef orphan : orphans) {
+            try {
+                // DB retry_count is the authoritative cross-requeue budget (each requeue publishes a
+                // FRESH NATS message, so NATS's own per-message maxDeliver almost never bounds this path);
+                // capping here at maxDeliver keeps the two budgets aligned to the same ceiling.
+                if (orphan.getRetryCount() >= natsProperties.maxDeliver()) {
+                    Integer failed = transactionTemplate.execute(s ->
+                        jobRepository.transitionStatus(
+                            orphan.getJobId(),
+                            AgentJobStatus.FAILED,
+                            Instant.now(),
+                            "Orphaned: owning worker lost and retry limit reached",
+                            Set.of(AgentJobStatus.RUNNING)
+                        )
+                    );
+                    if (failed != null && failed > 0) {
+                        orphanFailed.increment();
+                        log.warn(
+                            "Orphaned job {} hit retry cap ({}); failed",
+                            orphan.getJobId(),
+                            orphan.getRetryCount()
+                        );
+                    }
+                    continue;
+                }
+                Integer requeued = transactionTemplate.execute(s -> jobRepository.requeueOrphan(orphan.getJobId()));
+                if (requeued != null && requeued > 0) {
+                    // Re-publish only after the requeue commits so the consumer can re-claim it.
+                    submitter.publish(orphan.getJobId(), orphan.getWorkspaceId());
+                    orphanRequeued.increment();
+                    log.warn("Requeued orphaned job {} (retry {})", orphan.getJobId(), orphan.getRetryCount() + 1);
+                }
+            } catch (Exception e) {
+                log.warn("Failed to recover orphaned job {}: {}", orphan.getJobId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Bound {@code worker_registry} growth: purge registrations whose heartbeat is long stale (#1138).
+     * Workers that exit cleanly delete their own row; this reaps the rest — SIGKILLed workers and
+     * {@code worker_id} churn (hostname-derived ids across pod restarts). The TTL is far longer than the
+     * orphan lease, so jobs owned by such a worker are already requeued before its row is removed.
+     */
+    @Scheduled(fixedDelay = 60, initialDelay = 5, timeUnit = TimeUnit.MINUTES)
+    public void purgeStaleWorkerRegistrations() {
+        Integer removed = transactionTemplate.execute(s ->
+            workerRegistryRepository.deleteStale(STALE_REGISTRATION_TTL.toSeconds())
+        );
+        if (removed != null && removed > 0) {
+            log.info("Purged {} stale worker_registry row(s)", removed);
         }
     }
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentNatsConsumerConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentNatsConsumerConfig.java
@@ -22,10 +22,9 @@ import org.springframework.core.annotation.Order;
 /**
  * Agent NATS stream + durable pull consumer setup. Worker-only.
  *
- * <p>Stream bootstrap is idempotent ({@code updateStream} → {@code addStream} fallback);
- * config-mismatch races are logged at ERROR. Multi-replica workers should gate stream
- * creation via {@code hephaestus.agent.nats.bootstrap-stream=false} on replicas N+1 (not
- * needed today — worker is single-replica).
+ * <p>Stream bootstrap is idempotent ({@code updateStream} → {@code addStream} fallback), so
+ * multiple worker replicas racing to create the stream converge safely; the loser logs the
+ * benign create race at ERROR. The durable pull consumer is shared across replicas.
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnExpression("${hephaestus.agent.nats.enabled:false} and ${" + RuntimeRole.WORKER_PROPERTY + ":true}")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentNatsProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentNatsProperties.java
@@ -25,7 +25,8 @@ import org.springframework.validation.annotation.Validated;
  *       consumer-name: hephaestus-agent-executor
  *       ack-wait: 70m
  *       max-deliver: 5
- *       max-ack-pending: 5
+ *       max-ack-pending: 16   # cluster-wide; ≈ replicas × per-worker concurrency
+ *       fetch-batch-size: 5   # per-replica pull; keep ≤ a single worker's concurrency
  *       heartbeat-interval: 25s
  * }</pre>
  *
@@ -36,7 +37,13 @@ import org.springframework.validation.annotation.Validated;
  * @param ackWait           max time before NATS redelivers an unacknowledged message
  *                          (must exceed max container timeout + buffer)
  * @param maxDeliver        max delivery attempts before dead-lettering
- * @param maxAckPending     max outstanding unacknowledged messages (concurrency limit)
+ * @param maxAckPending     max outstanding unacknowledged messages on the (shared, durable) consumer.
+ *                          This is a CLUSTER-WIDE bound across all worker replicas — set it to roughly
+ *                          {@code replicas × per-worker concurrency} so N replicas aren't throttled to
+ *                          a single worker's worth of work (#1138).
+ * @param fetchBatchSize    max messages a single replica pulls per fetch. Keep this near a single
+ *                          worker's local capacity so one replica doesn't grab the whole cluster's
+ *                          unacked budget and starve siblings; excess is left for other replicas.
  * @param heartbeatInterval interval between NATS InProgress heartbeats
  */
 @Validated
@@ -48,7 +55,8 @@ public record AgentNatsProperties(
     @DefaultValue("hephaestus-agent-executor") @NotBlank String consumerName,
     @DurationUnit(ChronoUnit.MINUTES) @DefaultValue("70m") @NotNull Duration ackWait,
     @DefaultValue("5") @Positive int maxDeliver,
-    @DefaultValue("5") @Min(1) int maxAckPending,
+    @DefaultValue("16") @Min(1) int maxAckPending,
+    @DefaultValue("5") @Min(1) int fetchBatchSize,
     @DurationUnit(ChronoUnit.SECONDS) @DefaultValue("25s") @NotNull Duration heartbeatInterval
 ) {
     /** Subject prefix for agent job messages. Used by both publisher and consumer. */

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/OrphanedJobRef.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/OrphanedJobRef.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import java.util.UUID;
+
+/**
+ * Projection of an orphaned RUNNING job (#1138) so the orphan-recovery sweep can requeue + re-publish
+ * without lazy-loading the {@code Workspace} entity outside a transaction.
+ */
+public interface OrphanedJobRef {
+    UUID getJobId();
+    Long getWorkspaceId();
+    int getRetryCount();
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerLivenessReporter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerLivenessReporter.java
@@ -1,0 +1,117 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import de.tum.cit.aet.hephaestus.agent.runtime.worker.WorkerProperties;
+import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Self-reports this worker's liveness into {@code worker_registry} on a timer (#1138).
+ *
+ * <p>Liveness must track the JVM that actually executes jobs (NATS pull + Docker sandbox), not the
+ * WSS control channel — a worker can lose WSS while still running jobs, and orphaning those would
+ * double-execute them. Driving the heartbeat from the worker itself makes "stale heartbeat" mean
+ * "this executor is gone", which is the only safe trigger for {@link AgentJobZombieSweeper} to requeue
+ * a RUNNING job to a sibling.
+ *
+ * <p>Uses a manual scheduler (not {@code @Scheduled}) because {@code @EnableScheduling} is server-role
+ * only; this bean runs on worker pods. Worker identity always binds on the worker role independent of
+ * the WSS endpoint, so every executing worker is registered. {@code @Order(1)} + a synchronous first
+ * beat guarantee the registry row exists before the executor ({@code @Order(2)}) claims its first job,
+ * so a freshly-claimed job is never seen as orphaned.
+ */
+@Component
+@ConditionalOnExpression("${hephaestus.agent.nats.enabled:false} and ${" + RuntimeRole.WORKER_PROPERTY + ":true}")
+@WorkspaceAgnostic("Fleet-wide worker liveness; not workspace-scoped.")
+public class WorkerLivenessReporter {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkerLivenessReporter.class);
+
+    private final WorkerRegistryRepository repository;
+    private final TransactionTemplate transactionTemplate;
+    private final Duration interval;
+    private final String workerId;
+    private final Counter heartbeatFailures;
+
+    private volatile int consecutiveFailures;
+    private ScheduledExecutorService scheduler;
+
+    public WorkerLivenessReporter(
+        WorkerRegistryRepository repository,
+        TransactionTemplate transactionTemplate,
+        AgentNatsProperties natsProperties,
+        WorkerProperties workerProperties,
+        MeterRegistry meterRegistry
+    ) {
+        this.repository = repository;
+        this.transactionTemplate = transactionTemplate;
+        this.interval = natsProperties.heartbeatInterval();
+        this.workerId = workerProperties.resolvedWorkerId();
+        this.heartbeatFailures = Counter.builder("worker.liveness.heartbeat.failures")
+            .description("Failed worker_registry heartbeat writes (a stalled reporter risks false orphaning)")
+            .register(meterRegistry);
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Order(1) // before AgentJobExecutor.start() (@Order(2)) so the registry row exists pre-first-claim
+    public void start() {
+        beat(); // synchronous first heartbeat — registry row present before any job is claimed
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "worker-liveness");
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.scheduleAtFixedRate(this::beat, interval.toSeconds(), interval.toSeconds(), TimeUnit.SECONDS);
+        log.info("Worker liveness reporter started: workerId={}, interval={}", workerId, interval);
+    }
+
+    private void beat() {
+        try {
+            transactionTemplate.executeWithoutResult(s -> repository.heartbeat(workerId));
+            if (consecutiveFailures > 0) {
+                log.info(
+                    "Worker liveness heartbeat recovered after {} failure(s): workerId={}",
+                    consecutiveFailures,
+                    workerId
+                );
+                consecutiveFailures = 0;
+            }
+        } catch (Exception e) {
+            // Visible, not silent: a worker that can't heartbeat will be falsely orphaned and its jobs
+            // double-executed, so this must surface (WARN + metric), not hide at DEBUG.
+            heartbeatFailures.increment();
+            consecutiveFailures++;
+            log.warn(
+                "Worker liveness heartbeat failed (consecutive={}): workerId={}, error={}",
+                consecutiveFailures,
+                workerId,
+                e.getClass().getSimpleName()
+            );
+        }
+    }
+
+    @PreDestroy
+    public void stop() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+        // Deliberately do NOT delete the registry row here. Drain is best-effort (cancelInFlight only
+        // logs on failure), so a job could still be RUNNING; deleting the row would immediately orphan
+        // it and a sibling would re-run it. Stopping the heartbeat lets the lease expire uniformly —
+        // genuinely-unfinished jobs are recovered after the 60s lease, the stale row is purged after 1h.
+    }
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerRegistry.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerRegistry.java
@@ -1,0 +1,35 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Self-reported worker liveness for multi-replica orphan recovery (#1138). Each worker upserts its
+ * own row and refreshes {@code last_heartbeat} on a timer, so staleness reflects the JVM that
+ * actually executes jobs — not the WSS control channel, which can drop while a worker keeps running.
+ * A worker whose heartbeat goes stale has its in-flight jobs requeued by {@link AgentJobZombieSweeper}.
+ */
+@Entity
+@Table(name = "worker_registry")
+@Getter
+@Setter
+@NoArgsConstructor
+public class WorkerRegistry {
+
+    /** Stable worker identity (configured {@code workerId} or container hostname). */
+    @Id
+    @Column(name = "worker_id", length = 255)
+    private String workerId;
+
+    @Column(name = "last_heartbeat", nullable = false)
+    private Instant lastHeartbeat;
+
+    @Column(name = "registered_at", nullable = false)
+    private Instant registeredAt;
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerRegistryRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/WorkerRegistryRepository.java
@@ -1,0 +1,45 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Persistence for the self-reported worker liveness registry (#1138). Written by each worker
+ * ({@code WorkerLivenessReporter}); read by the orphan-recovery sweep to find jobs whose owning
+ * worker has gone stale.
+ */
+@Repository
+@WorkspaceAgnostic("Fleet-wide worker coordination; not workspace-scoped.")
+public interface WorkerRegistryRepository extends JpaRepository<WorkerRegistry, String> {
+    /**
+     * Upsert this worker's heartbeat, keyed by {@code worker_id}, using the DB clock for both
+     * {@code last_heartbeat} and {@code registered_at} so liveness comparisons stay on one clock.
+     */
+    @Modifying
+    @Query(
+        value = "INSERT INTO worker_registry (worker_id, last_heartbeat, registered_at) " +
+            "VALUES (:workerId, now(), now()) " +
+            "ON CONFLICT (worker_id) DO UPDATE SET last_heartbeat = now()",
+        nativeQuery = true
+    )
+    void heartbeat(@Param("workerId") String workerId);
+
+    /**
+     * Delete registrations whose heartbeat is older than {@code ttlSeconds} (DB clock). Bounds table
+     * growth from workers that died without a clean shutdown (SIGKILL) or from {@code worker_id} churn
+     * (e.g. hostname-derived ids across pod restarts). Uses a TTL far longer than the orphan lease, so
+     * any RUNNING job owned by such a worker has already been requeued before its row is removed.
+     *
+     * @return number of rows deleted
+     */
+    @Modifying
+    @Query(
+        value = "DELETE FROM worker_registry WHERE last_heartbeat < now() - make_interval(secs => :ttlSeconds)",
+        nativeQuery = true
+    )
+    int deleteStale(@Param("ttlSeconds") long ttlSeconds);
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerConfiguration.java
@@ -10,7 +10,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +27,6 @@ import tools.jackson.databind.ObjectMapper;
 @org.springframework.boot.autoconfigure.condition.ConditionalOnExpression(
     "'${hephaestus.worker.control.endpoint:}'.length() > 0"
 )
-@EnableConfigurationProperties(WorkerProperties.class)
 public class WorkerConfiguration {
 
     /**
@@ -123,6 +121,19 @@ public class WorkerConfiguration {
         WorkerProperties properties
     ) {
         return new WorkerControlChannelHealthIndicator(client, properties);
+    }
+
+    /**
+     * Wire hub-originated {@code CancelJob} frames to the executor's local-cancel path (#1138).
+     * Done after singletons are instantiated so the optional executor (only present when agent
+     * NATS is enabled) is resolved without creating a hard dependency cycle.
+     */
+    @Bean
+    org.springframework.beans.factory.SmartInitializingSingleton workerCancelHandlerWiring(
+        WorkerControlClient client,
+        Optional<AgentJobExecutor> executor
+    ) {
+        return () -> executor.ifPresent(e -> client.setCancelHandler(e::cancelLocalJob));
     }
 
     @Bean

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClient.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerControlClient.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.agent.runtime.worker;
 
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CancelJob;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CapacityReport;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.ForceReconnect;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.FrameCodec;
@@ -22,6 +23,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +31,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -70,6 +73,13 @@ public class WorkerControlClient {
     private volatile Thread outboundThread;
     private volatile Thread inboundThread;
     private volatile Thread connectionThread;
+
+    /**
+     * Handler for hub-originated {@link CancelJob} frames: {@code (jobId, reason)}. Wired by
+     * {@code WorkerConfiguration} to the job executor's local-cancel path. Kept as a callback so the
+     * transport layer stays decoupled from job execution.
+     */
+    private volatile BiConsumer<UUID, String> cancelHandler;
 
     public WorkerControlClient(
         WorkerProperties properties,
@@ -137,6 +147,14 @@ public class WorkerControlClient {
         return connected.get();
     }
 
+    /**
+     * Register the handler invoked when the hub sends a {@link CancelJob}. Idempotent; the last
+     * registration wins. {@code null} disables handling (frames are logged and dropped).
+     */
+    public void setCancelHandler(BiConsumer<UUID, String> handler) {
+        this.cancelHandler = handler;
+    }
+
     /** Sentinel {@link Instant#EPOCH} when no frame has been received yet. */
     public Instant lastInboundAt() {
         return lastInboundAt.get();
@@ -201,6 +219,7 @@ public class WorkerControlClient {
                     log.info("Hub requested reconnect: {}", r.reason());
                     forceReconnect("server-requested:" + r.reason());
                 }
+                case CancelJob c -> handleCancelJob(c);
                 // Hub never originates these — log once and ignore (protocol violation by the hub).
                 case Heartbeat h -> warnSourceMismatch(h);
                 case WorkerHello h -> warnSourceMismatch(h);
@@ -209,6 +228,22 @@ public class WorkerControlClient {
         } catch (RuntimeException e) {
             log.error("Inbound dispatch threw for {}", frame.getClass().getSimpleName(), e);
         }
+    }
+
+    private void handleCancelJob(CancelJob frame) {
+        BiConsumer<UUID, String> handler = cancelHandler;
+        if (handler == null) {
+            log.debug("CancelJob received for {} but no cancel handler is wired; ignoring", frame.jobId());
+            return;
+        }
+        UUID jobId;
+        try {
+            jobId = UUID.fromString(frame.jobId());
+        } catch (IllegalArgumentException e) {
+            log.warn("CancelJob with malformed jobId '{}'; ignoring", frame.jobId());
+            return;
+        }
+        handler.accept(jobId, frame.reason());
     }
 
     private void warnSourceMismatch(WorkerControlFrame frame) {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerProperties.java
@@ -25,22 +25,33 @@ public record WorkerProperties(
     public static final String AUTO = "auto";
 
     /**
-     * @return the configured worker id, or the container hostname when unset (so compose/K8s
-     *     replicas don't collide in {@code WorkerSessionRegistry}).
+     * Per-process-instance suffix, stable for the JVM's lifetime. Appended to the hostname default so
+     * a worker that crashes and restarts (or a fixed-hostname compose/bare-metal redeploy) gets a
+     * DIFFERENT id than its dead predecessor — otherwise the restarted process would re-heartbeat the
+     * old id and mask its predecessor's orphaned jobs (#1138). K8s pod names are already unique, but
+     * this makes fast orphan recovery hold in every topology.
+     */
+    private static final String INSTANCE_SUFFIX = java.util.UUID.randomUUID().toString().substring(0, 8);
+
+    /**
+     * @return the configured worker id (operator owns its restart semantics), or
+     *     {@code <hostname>-<instance-suffix>} when unset — unique per process instance so a dead
+     *     worker and its restart never share an id.
      */
     public String resolvedWorkerId() {
         if (workerId != null && !workerId.isBlank()) {
             return workerId;
         }
+        String host = "worker";
         try {
             String hostname = InetAddress.getLocalHost().getHostName();
             if (hostname != null && !hostname.isBlank()) {
-                return hostname;
+                host = hostname;
             }
         } catch (UnknownHostException ignored) {
-            // fall through
+            // fall through to the generic prefix
         }
-        return "worker-" + Long.toHexString(System.nanoTime());
+        return host + "-" + INSTANCE_SUFFIX;
     }
 
     @Override

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerPropertiesConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/runtime/worker/WorkerPropertiesConfiguration.java
@@ -1,0 +1,19 @@
+package de.tum.cit.aet.hephaestus.agent.runtime.worker;
+
+import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Binds {@link WorkerProperties} whenever the worker role is enabled — independent of whether the WSS
+ * control channel is configured. Worker identity ({@code resolvedWorkerId()}) is a job-execution
+ * concern (job ownership + orphan recovery, #1138), not a WSS concern; gating it on the WSS endpoint
+ * (as {@link WorkerConfiguration} does for the control-channel beans) would silently disable orphan
+ * recovery on a NATS-only worker. This keeps the two concerns separate so identity is always present
+ * wherever {@code AgentJobExecutor} / {@code WorkerLivenessReporter} run.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = RuntimeRole.WORKER_PROPERTY, havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(WorkerProperties.class)
+public class WorkerPropertiesConfiguration {}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SecurityProfile.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/spi/SecurityProfile.java
@@ -36,8 +36,11 @@ public record SecurityProfile(
             "rw,noexec,nosuid,nodev,size=1073741824",
             "/run",
             "rw,noexec,nosuid,nodev,size=67108864",
+            // exec (not noexec): Pi's Node.js runtime extracts native addons here at runtime.
+            // ContainerSecurityPolicy.MANDATORY_TMPFS already forces this to exec; keep the SPI
+            // default in sync so it doesn't mislead readers into re-breaking native addons.
             "/home/agent/.local",
-            "rw,noexec,nosuid,nodev,size=1073741824"
+            "rw,exec,nosuid,nodev,size=1073741824"
         )
     );
 }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/HubConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/HubConfiguration.java
@@ -48,6 +48,11 @@ public class HubConfiguration {
     }
 
     @Bean
+    WorkerJobCancelDispatcher workerJobCancelDispatcher(WorkerSessionRegistry registry) {
+        return new WorkerJobCancelDispatcher(registry);
+    }
+
+    @Bean
     WorkerKeyRing workerKeyRing(WorkerTokenProperties properties, Environment environment) {
         WorkerKeyRing ring = WorkerKeyRing.fromConfig(properties);
         if (ring.active().ephemeral()) {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerControlWebSocketHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerControlWebSocketHandler.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.runtime.hub;
 
 import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwt;
 import de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerJwtHandshakeInterceptor;
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CancelJob;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CapacityReport;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.ForceReconnect;
 import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.FrameCodec;
@@ -165,6 +166,7 @@ public class WorkerControlWebSocketHandler extends TextWebSocketHandler {
             }
             case WorkerWelcome w -> warnUnexpectedFrame(session, w);
             case ForceReconnect f -> warnUnexpectedFrame(session, f);
+            case CancelJob c -> warnUnexpectedFrame(session, c); // hub originates this; never inbound
         }
     }
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerJobCancelDispatcher.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerJobCancelDispatcher.java
@@ -1,0 +1,46 @@
+package de.tum.cit.aet.hephaestus.core.runtime.hub;
+
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CancelJob;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Routes a job cancellation to the worker that owns the running job, over the WSS control channel
+ * (#1138). The caller (e.g. {@code AgentJobService.cancel}) performs the authoritative
+ * {@code agent_job} status transition first; this just asks the owning worker to stop its container
+ * promptly. If the owning worker is not connected to this hub, the cancel still takes effect via the
+ * DB transition + reconciler/zombie-sweeper backstops — the container is simply not stopped early.
+ */
+public class WorkerJobCancelDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkerJobCancelDispatcher.class);
+
+    private final WorkerSessionRegistry registry;
+
+    public WorkerJobCancelDispatcher(WorkerSessionRegistry registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * Send a {@link CancelJob} to {@code workerId} if it has a live session on this hub.
+     *
+     * @return {@code true} if the frame was dispatched to a connected worker
+     */
+    public boolean dispatch(String workerId, UUID jobId, String reason) {
+        if (workerId == null || workerId.isBlank()) {
+            return false;
+        }
+        return registry
+            .findByWorkerId(workerId)
+            .map(session -> {
+                session.send(new CancelJob(jobId.toString(), reason));
+                log.info("Dispatched CancelJob for {} to worker {}", jobId, workerId);
+                return true;
+            })
+            .orElseGet(() -> {
+                log.debug("No live session for worker {} to cancel job {}; relying on DB + backstops", workerId, jobId);
+                return false;
+            });
+    }
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/CancelJob.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/CancelJob.java
@@ -1,0 +1,20 @@
+package de.tum.cit.aet.hephaestus.core.runtime.worker.protocol;
+
+/**
+ * Hub → worker frame requesting prompt cancellation of a specific running job (#1138).
+ *
+ * <p>Job-scoped (carries a {@code jobId}) so the owning worker — and only the owning worker — stops
+ * its container. The authoritative {@code agent_job} status transition is performed by the hub
+ * before dispatching this frame; the frame exists purely to stop the container promptly rather than
+ * waiting for it to finish naturally. A worker that does not own the job ignores it.
+ *
+ * @param jobId the job UUID (string form)
+ * @param reason short human-readable reason, for worker-side logging
+ */
+public record CancelJob(String jobId, String reason) implements WorkerControlFrame {
+    public CancelJob {
+        if (jobId == null || jobId.isBlank()) {
+            throw new IllegalArgumentException("jobId must not be blank");
+        }
+    }
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/WorkerControlFrame.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/worker/protocol/WorkerControlFrame.java
@@ -12,7 +12,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = Heartbeat.class, name = "Heartbeat"),
         @JsonSubTypes.Type(value = CapacityReport.class, name = "CapacityReport"),
         @JsonSubTypes.Type(value = ForceReconnect.class, name = "ForceReconnect"),
+        @JsonSubTypes.Type(value = CancelJob.class, name = "CancelJob"),
     }
 )
 public sealed interface WorkerControlFrame
-    permits WorkerHello, WorkerWelcome, Heartbeat, CapacityReport, ForceReconnect {}
+    permits WorkerHello, WorkerWelcome, Heartbeat, CapacityReport, ForceReconnect, CancelJob {}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/tenancy/WorkspaceScopedTables.java
@@ -54,6 +54,8 @@ public class WorkspaceScopedTables {
         "model_pricing",
         // Fleet-wide worker JWT revocation; worker JWTs are not workspace-scoped
         "worker_token_denylist",
+        // Fleet-wide worker liveness/capacity registry (#1138); not workspace-scoped
+        "worker_registry",
         // Liquibase machinery
         "databasechangelog",
         "databasechangeloglock"

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -490,7 +490,10 @@ hephaestus:
             # Must exceed max container timeout (1hr) + buffer
             ack-wait: 70m
             max-deliver: 5
-            max-ack-pending: 5
+            # Cluster-wide unacked bound across all worker replicas. Set ≈ replicas × per-worker
+            # concurrency; the per-replica pull is capped by fetch-batch-size so no replica starves siblings.
+            max-ack-pending: ${AGENT_NATS_MAX_ACK_PENDING:16}
+            fetch-batch-size: ${AGENT_NATS_FETCH_BATCH_SIZE:5}
             heartbeat-interval: 25s
 
     # ═══════════════════════════════════════════════════════════════════════════

--- a/server/src/main/resources/db/changelog/1780067945030_changelog.xml
+++ b/server/src/main/resources/db/changelog/1780067945030_changelog.xml
@@ -1,0 +1,67 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Multi-replica worker coordination (#1138). Coordination state lives in PostgreSQL (we already
+        claim jobs with FOR UPDATE SKIP LOCKED); NATS stays the work queue and the existing WSS channel
+        carries job-scoped cancellation. No NATS KV, no new datastore.
+
+        Liveness is self-reported: each worker upserts its own worker_registry row (last_heartbeat),
+        so staleness tracks the JVM that actually executes jobs — not the WSS control channel.
+        agent_job.worker_id (soft ref, no FK so a finished job survives its worker row being reaped)
+        records the owner of a RUNNING job for orphan recovery and as a fence on terminal writes.
+    -->
+
+    <changeSet author="FelixTJDietrich" id="1780067945030-1">
+        <preConditions onFail="MARK_RAN" onFailMessage="worker_registry already present">
+            <not><tableExists tableName="worker_registry"/></not>
+        </preConditions>
+        <comment>Self-reported worker liveness registry (#1138).</comment>
+        <createTable tableName="worker_registry">
+            <column name="worker_id" type="varchar(255)">
+                <constraints primaryKey="true" primaryKeyName="pk_worker_registry" nullable="false"/>
+            </column>
+            <column name="last_heartbeat" type="timestamp with time zone">
+                <constraints nullable="false"/>
+            </column>
+            <column name="registered_at" type="timestamp with time zone">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <createIndex tableName="worker_registry" indexName="ix_worker_registry_last_heartbeat">
+            <column name="last_heartbeat"/>
+        </createIndex>
+        <rollback>
+            <dropTable tableName="worker_registry"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="FelixTJDietrich" id="1780067945030-2">
+        <preConditions onFail="MARK_RAN" onFailMessage="agent_job.worker_id already present">
+            <not><columnExists tableName="agent_job" columnName="worker_id"/></not>
+        </preConditions>
+        <comment>Owner of a RUNNING job (soft ref to worker_registry.worker_id; no FK by design).</comment>
+        <addColumn tableName="agent_job">
+            <column name="worker_id" type="varchar(255)"/>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="agent_job" columnName="worker_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="FelixTJDietrich" id="1780067945030-3">
+        <preConditions onFail="MARK_RAN" onFailMessage="ix_agent_job_running_owner already present">
+            <not><indexExists indexName="ix_agent_job_running_owner"/></not>
+        </preConditions>
+        <comment>Partial index for the orphan-recovery sweep over RUNNING jobs by owner.</comment>
+        <sql>CREATE INDEX ix_agent_job_running_owner ON agent_job (worker_id) WHERE status = 'RUNNING'</sql>
+        <rollback>
+            <dropIndex tableName="agent_job" indexName="ix_agent_job_running_owner"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/master.xml
+++ b/server/src/main/resources/db/master.xml
@@ -75,4 +75,5 @@
     <include file="./changelog/1779118456457_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1779173113243_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1779520390544_worker_runtime_substrate.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1780067945030_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -94,6 +94,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
         "hephaestus-agent-executor",
         Duration.ofMinutes(70),
         5,
+        16,
         5,
         Duration.ofSeconds(25)
     );
@@ -181,6 +182,66 @@ class AgentJobExecutorTest extends BaseUnitTest {
     }
 
     @Nested
+    @DisplayName("Job-scoped cancellation (#1138)")
+    class ScopedCancellation {
+
+        @Test
+        @DisplayName("cancelLocalJob returns false and does not touch the sandbox for a job this worker doesn't run")
+        void cancelLocalJobUnknownIsNoOp() {
+            boolean cancelled = executor.cancelLocalJob(UUID.randomUUID(), "user-cancel");
+
+            org.assertj.core.api.Assertions.assertThat(cancelled).isFalse();
+            verify(sandboxManager, never()).cancel(any());
+        }
+
+        @Test
+        @DisplayName("cancelInFlight on a worker with no local jobs cancels nothing (no DB-wide sweep)")
+        void cancelInFlightEmptyIsNoOp() {
+            executor.cancelInFlight(AgentJobCancellationReason.DRAIN_GRACEFUL);
+
+            verify(sandboxManager, never()).cancel(any());
+            verify(jobRepository, never()).transitionToCancelled(any(), any(), any(), any(), any());
+            // Critically: never queries all RUNNING jobs cluster-wide.
+            verify(jobRepository, never()).findByStatus(AgentJobStatus.RUNNING);
+        }
+
+        @Test
+        @DisplayName("does NOT deliver when the fenced terminal write loses ownership (orphan-requeued)")
+        void doesNotDeliverWhenFencedOut() {
+            // Worker has identity "test-worker" → terminal writes are fenced to the owner.
+            executor = new AgentJobExecutor(
+                natsConnection,
+                NATS_PROPS,
+                jobRepository,
+                configRepository,
+                handlerRegistry,
+                practiceAgent,
+                sandboxManager,
+                sandboxExecutor,
+                transactionTemplate,
+                objectMapper,
+                meterRegistry,
+                Optional.empty(),
+                Optional.of(workerPropsWithLlm(null, null))
+            );
+
+            Message msg = createMessage(jobId);
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(jobId)).thenReturn(Optional.of(job));
+            when(configRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(config));
+            when(jobRepository.countByConfigIdAndStatusIn(eq(10L), any())).thenReturn(0L);
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            JobTypeHandler handler = setupFullExecution();
+            // Fence loses: another worker owns the job now (it was orphan-requeued mid-execution).
+            when(jobRepository.transitionStatusOwnedBy(any(), any(), any(), any(), any(), any())).thenReturn(0);
+
+            executor.executeJob(msg);
+
+            // The job is no longer ours — we must not double-deliver the sibling's findings.
+            verify(handler, never()).deliver(any());
+        }
+    }
+
+    @Nested
     @DisplayName("Claim phase")
     class ClaimPhase {
 
@@ -224,7 +285,11 @@ class AgentJobExecutorTest extends BaseUnitTest {
 
             executor.executeJob(msg);
 
-            verify(jobRepository).save(any(AgentJob.class));
+            // Assert the actual claim contract, not just "save was called": status flips to RUNNING.
+            ArgumentCaptor<AgentJob> claimed = ArgumentCaptor.forClass(AgentJob.class);
+            verify(jobRepository).save(claimed.capture());
+            assertThat(claimed.getValue().getStatus()).isEqualTo(AgentJobStatus.RUNNING);
+            assertThat(claimed.getValue().getStartedAt()).isNotNull();
         }
     }
 
@@ -466,7 +531,8 @@ class AgentJobExecutorTest extends BaseUnitTest {
             freshJob.prePersist();
             when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(freshJob));
             when(jobRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
-            when(jobRepository.transitionStatus(any(), any(), any(), any(), any())).thenReturn(1);
+            // Worker identity is set ("test-worker"), so the terminal write is fenced to the owner.
+            when(jobRepository.transitionStatusOwnedBy(any(), any(), any(), any(), any(), any())).thenReturn(1);
 
             executor.executeJob(msg);
 
@@ -513,7 +579,8 @@ class AgentJobExecutorTest extends BaseUnitTest {
             freshJob.prePersist();
             when(jobRepository.findById(any(UUID.class))).thenReturn(Optional.of(freshJob));
             when(jobRepository.saveAndFlush(any())).thenAnswer(inv -> inv.getArgument(0));
-            when(jobRepository.transitionStatus(any(), any(), any(), any(), any())).thenReturn(1);
+            // Worker identity is set ("test-worker"), so the terminal write is fenced to the owner.
+            when(jobRepository.transitionStatusOwnedBy(any(), any(), any(), any(), any(), any())).thenReturn(1);
 
             executor.executeJob(msg);
 
@@ -528,12 +595,12 @@ class AgentJobExecutorTest extends BaseUnitTest {
 
     // ── Helpers ──
 
-    private void setupFullExecution() {
+    private JobTypeHandler setupFullExecution() {
         SandboxResult successResult = new SandboxResult(0, Map.of(), "success", false, Duration.ofMinutes(2));
-        setupFullExecution(successResult);
+        return setupFullExecution(successResult);
     }
 
-    private void setupFullExecution(SandboxResult sandboxResult) {
+    private JobTypeHandler setupFullExecution(SandboxResult sandboxResult) {
         JobTypeHandler handler = mock(JobTypeHandler.class);
         when(handlerRegistry.getHandler(AgentJobType.PULL_REQUEST_REVIEW)).thenReturn(handler);
         when(handler.prepareInputFiles(any())).thenReturn(Map.of("code.py", "print('hi')".getBytes()));
@@ -552,6 +619,7 @@ class AgentJobExecutorTest extends BaseUnitTest {
         when(practiceAgent.parseResult(any())).thenReturn(new AgentResult(true, Map.of("review", "LGTM")));
 
         when(sandboxManager.execute(any())).thenReturn(sandboxResult);
+        return handler;
     }
 
     private static WorkerProperties workerPropsWithLlm(String baseUrl, String apiKey) {

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobServiceTest.java
@@ -95,7 +95,8 @@ class AgentJobServiceTest extends BaseUnitTest {
             eventPublisher,
             transactionTemplate,
             new PracticeReviewProperties(false, true, false, "", 15),
-            sandboxManager
+            sandboxManager,
+            java.util.Optional.empty()
         );
 
         workspace = new Workspace();

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeperTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobZombieSweeperTest.java
@@ -12,7 +12,6 @@ import de.tum.cit.aet.hephaestus.agent.CredentialMode;
 import de.tum.cit.aet.hephaestus.agent.LlmProvider;
 import de.tum.cit.aet.hephaestus.agent.config.ConfigSnapshot;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
-import de.tum.cit.aet.hephaestus.workspace.Workspace;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.List;
@@ -34,31 +33,53 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
     @Mock
     private AgentJobSubmitter submitter;
 
+    @Mock
+    private WorkerRegistryRepository workerRegistryRepository;
+
+    @Mock
+    private org.springframework.transaction.support.TransactionTemplate transactionTemplate;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     private SimpleMeterRegistry meterRegistry;
 
     private AgentJobZombieSweeper sweeper;
 
+    private static final AgentNatsProperties NATS_PROPS = new AgentNatsProperties(
+        true,
+        "nats://localhost:4222",
+        "AGENT",
+        "hephaestus-agent-executor",
+        java.time.Duration.ofMinutes(70),
+        5,
+        16,
+        5,
+        java.time.Duration.ofSeconds(25)
+    );
+
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        sweeper = new AgentJobZombieSweeper(jobRepository, submitter, objectMapper, meterRegistry);
+        // Run the TransactionTemplate callback inline so CAS writes execute in tests.
+        lenient()
+            .when(transactionTemplate.execute(any()))
+            .thenAnswer(inv -> {
+                @SuppressWarnings("unchecked")
+                org.springframework.transaction.support.TransactionCallback<Object> cb = inv.getArgument(0);
+                return cb.doInTransaction(mock(org.springframework.transaction.TransactionStatus.class));
+            });
+        sweeper = new AgentJobZombieSweeper(
+            jobRepository,
+            workerRegistryRepository,
+            submitter,
+            NATS_PROPS,
+            objectMapper,
+            transactionTemplate,
+            meterRegistry
+        );
     }
 
-    private AgentJob mockQueuedJob(UUID id, Long workspaceId) {
-        AgentJob job = mock(AgentJob.class);
-        Workspace ws = mock(Workspace.class);
-        lenient().when(ws.getId()).thenReturn(workspaceId);
-        lenient().when(job.getId()).thenReturn(id);
-        lenient().when(job.getWorkspace()).thenReturn(ws);
-        lenient().when(job.getCreatedAt()).thenReturn(Instant.now().minusSeconds(900)); // 15 min ago
-        return job;
-    }
-
-    private AgentJob mockRunningJob(UUID id, Instant startedAt, int timeoutSeconds) {
-        AgentJob job = mock(AgentJob.class);
-        lenient().when(job.getId()).thenReturn(id);
-        lenient().when(job.getStartedAt()).thenReturn(startedAt);
+    /** Real entity (owned JPA types must not be mocked) for the absolute-timeout reaper tests. */
+    private AgentJob runningJob(UUID id, Instant startedAt, int timeoutSeconds) {
         ConfigSnapshot snapshot = new ConfigSnapshot(
             1,
             1L,
@@ -71,8 +92,92 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
             timeoutSeconds,
             false
         );
-        lenient().when(job.getConfigSnapshot()).thenReturn(snapshot.toJson(objectMapper));
+        AgentJob job = new AgentJob();
+        job.setId(id);
+        job.setStatus(AgentJobStatus.RUNNING);
+        job.setStartedAt(startedAt);
+        job.setConfigSnapshot(snapshot.toJson(objectMapper));
         return job;
+    }
+
+    private static OrphanedJobRef orphan(UUID jobId, Long workspaceId, int retryCount) {
+        return new OrphanedJobRef() {
+            @Override
+            public UUID getJobId() {
+                return jobId;
+            }
+
+            @Override
+            public Long getWorkspaceId() {
+                return workspaceId;
+            }
+
+            @Override
+            public int getRetryCount() {
+                return retryCount;
+            }
+        };
+    }
+
+    @Nested
+    @DisplayName("recoverOrphanedJobs (#1138)")
+    class RecoverOrphaned {
+
+        @Test
+        @DisplayName("re-publishes to the job's workspace only after the requeue CAS wins")
+        void requeuesOrphanedJob() {
+            UUID jobId = UUID.randomUUID();
+            when(jobRepository.findOrphanedRunningJobs(any(), org.mockito.ArgumentMatchers.anyLong())).thenReturn(
+                List.of(orphan(jobId, 7L, 0))
+            );
+            when(jobRepository.requeueOrphan(jobId)).thenReturn(1);
+
+            sweeper.recoverOrphanedJobs();
+
+            // The meaningful contract: publish is gated on requeue success and carries the right workspace.
+            verify(submitter).publish(jobId, 7L);
+        }
+
+        @Test
+        @DisplayName("does not re-publish if the CAS requeue lost the race to another sweeper")
+        void skipsPublishWhenRequeueRaced() {
+            UUID jobId = UUID.randomUUID();
+            when(jobRepository.findOrphanedRunningJobs(any(), org.mockito.ArgumentMatchers.anyLong())).thenReturn(
+                List.of(orphan(jobId, 7L, 0))
+            );
+            when(jobRepository.requeueOrphan(jobId)).thenReturn(0); // another replica won
+
+            sweeper.recoverOrphanedJobs();
+
+            verify(submitter, never()).publish(any(), any());
+        }
+
+        @Test
+        @DisplayName("fails (not requeues) an orphan that hit the retry cap")
+        void failsOrphanPastRetryCap() {
+            UUID jobId = UUID.randomUUID();
+            when(jobRepository.findOrphanedRunningJobs(any(), org.mockito.ArgumentMatchers.anyLong())).thenReturn(
+                List.of(orphan(jobId, 7L, 5))
+            ); // retryCount == maxDeliver
+
+            sweeper.recoverOrphanedJobs();
+
+            verify(jobRepository, never()).requeueOrphan(any());
+            verify(submitter, never()).publish(any(), any());
+        }
+
+        @Test
+        @DisplayName("no orphans → no writes")
+        void noOrphansNoWork() {
+            when(jobRepository.findOrphanedRunningJobs(any(), org.mockito.ArgumentMatchers.anyLong())).thenReturn(
+                List.of()
+            );
+
+            sweeper.recoverOrphanedJobs();
+
+            verify(jobRepository, never()).requeueOrphan(any());
+            verify(submitter, never()).publish(any(), any());
+        }
     }
 
     @Nested
@@ -84,10 +189,9 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
         void shouldRepublishStaleQueuedJobs() {
             UUID jobId1 = UUID.randomUUID();
             UUID jobId2 = UUID.randomUUID();
-            AgentJob job1 = mockQueuedJob(jobId1, 1L);
-            AgentJob job2 = mockQueuedJob(jobId2, 2L);
-
-            when(jobRepository.findStaleQueuedJobs(any())).thenReturn(List.of(job1, job2));
+            when(jobRepository.findStaleQueuedJobs(any())).thenReturn(
+                List.of(orphan(jobId1, 1L, 0), orphan(jobId2, 2L, 0))
+            );
 
             sweeper.republishStaleQueuedJobs();
 
@@ -110,10 +214,9 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
         void shouldHandlePublishFailureGracefully() {
             UUID jobId1 = UUID.randomUUID();
             UUID jobId2 = UUID.randomUUID();
-            AgentJob job1 = mockQueuedJob(jobId1, 1L);
-            AgentJob job2 = mockQueuedJob(jobId2, 2L);
-
-            when(jobRepository.findStaleQueuedJobs(any())).thenReturn(List.of(job1, job2));
+            when(jobRepository.findStaleQueuedJobs(any())).thenReturn(
+                List.of(orphan(jobId1, 1L, 0), orphan(jobId2, 2L, 0))
+            );
             // First publish fails, second should still be attempted
             org.mockito.Mockito.doThrow(new RuntimeException("NATS down")).when(submitter).publish(jobId1, 1L);
 
@@ -134,7 +237,7 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
             UUID jobId = UUID.randomUUID();
             // Started 20 minutes ago with 600s (10min) timeout + 5min buffer = 15min
             // 20 min > 15 min → stale
-            AgentJob job = mockRunningJob(jobId, Instant.now().minusSeconds(1200), 600);
+            AgentJob job = runningJob(jobId, Instant.now().minusSeconds(1200), 600);
 
             when(jobRepository.findStaleRunningJobs(any())).thenReturn(List.of(job));
             when(jobRepository.transitionStatus(any(), any(), any(), any(), any())).thenReturn(1);
@@ -156,7 +259,7 @@ class AgentJobZombieSweeperTest extends BaseUnitTest {
             UUID jobId = UUID.randomUUID();
             // Started 5 minutes ago with 600s (10min) timeout + 5min buffer = 15min
             // 5 min < 15 min → not stale yet
-            AgentJob job = mockRunningJob(jobId, Instant.now().minusSeconds(300), 600);
+            AgentJob job = runningJob(jobId, Instant.now().minusSeconds(300), 600);
 
             when(jobRepository.findStaleRunningJobs(any())).thenReturn(List.of(job));
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentOrphanRecoveryNatsIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentOrphanRecoveryNatsIntegrationTest.java
@@ -1,0 +1,187 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.agent.AgentJobType;
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import de.tum.cit.aet.hephaestus.testconfig.NatsTestContainer;
+import de.tum.cit.aet.hephaestus.testconfig.WorkspaceTestFactory;
+import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import de.tum.cit.aet.hephaestus.workspace.WorkspaceRepository;
+import io.nats.client.Connection;
+import io.nats.client.ConsumerContext;
+import io.nats.client.FetchConsumer;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.Message;
+import io.nats.client.StreamContext;
+import io.nats.client.api.ConsumerConfiguration;
+import io.nats.client.api.RetentionPolicy;
+import io.nats.client.api.StorageType;
+import io.nats.client.api.StreamConfiguration;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * End-to-end runtime proof of multi-replica orphan recovery against REAL NATS JetStream + REAL
+ * Postgres (#1138) — the path mocks can't cover: a dead worker's RUNNING job is detected, CAS-requeued,
+ * and re-published onto the actual work queue where a live replica would claim it.
+ *
+ * <p>Runs with {@code agent.nats.enabled=true} but {@code runtime.worker.enabled=false}, so the
+ * connection + submitter + sweeper wire against the container while the executor's pull loop does NOT —
+ * keeping the republished message on the stream for deterministic verification (no sandbox needed,
+ * no consume race).
+ */
+@DisplayName("Orphan recovery over real NATS (JetStream) Integration")
+class AgentOrphanRecoveryNatsIntegrationTest extends BaseIntegrationTest {
+
+    private static final String STREAM = "AGENT";
+    private static final String SUBJECT_WILDCARD = "agent.jobs.>";
+
+    @DynamicPropertySource
+    static void natsProperties(DynamicPropertyRegistry registry) {
+        registry.add("hephaestus.agent.nats.enabled", () -> "true");
+        registry.add("hephaestus.agent.nats.server", NatsTestContainer::getServerUrl);
+        // Executor + liveness reporter stay off so the pull loop doesn't consume what we publish.
+        registry.add("hephaestus.runtime.worker.enabled", () -> "false");
+        // Webhook role off: WebhookConfiguration is @ConditionalOnBean(Connection) and would otherwise
+        // wake up (now that agentNatsConnection exists) and demand the unrelated sync "natsConnection".
+        registry.add("hephaestus.runtime.webhook.enabled", () -> "false");
+    }
+
+    @Autowired
+    @Qualifier("agentNatsConnection")
+    private Connection nats;
+
+    @Autowired
+    private AgentJobSubmitter submitter;
+
+    @Autowired
+    private AgentJobZombieSweeper sweeper;
+
+    @Autowired
+    private AgentJobRepository jobRepository;
+
+    @Autowired
+    private WorkerRegistryRepository workerRegistryRepository;
+
+    @Autowired
+    private WorkspaceRepository workspaceRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private org.springframework.transaction.support.TransactionTemplate transactionTemplate;
+
+    private Workspace workspace;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        databaseTestUtils.cleanDatabase();
+        ensureCleanStream();
+        workspace = workspaceRepository.save(WorkspaceTestFactory.activeWorkspace("nats-orphan-ws"));
+    }
+
+    @Test
+    @DisplayName("AgentJobSubmitter publishes a claimable message onto the real work queue")
+    void submitterPublishesToRealJetStream() throws Exception {
+        UUID jobId = UUID.randomUUID();
+
+        submitter.publish(jobId, workspace.getId());
+
+        assertThat(drainStream()).containsExactly(jobId.toString());
+    }
+
+    @Test
+    @DisplayName("a dead worker's RUNNING job is requeued AND re-published to NATS for a sibling to claim")
+    void orphanRecoveryRequeuesAndRepublishes() throws Exception {
+        UUID jobId = runningJobOwnedBy("dead-replica", Instant.now().minus(Duration.ofMinutes(5)));
+        registerStaleWorker("dead-replica", Instant.now().minus(Duration.ofMinutes(5)));
+
+        sweeper.recoverOrphanedJobs();
+
+        // DB: the job is back on the queue, ownership cleared, retry bumped.
+        AgentJob requeued = jobRepository.findById(jobId).orElseThrow();
+        assertThat(requeued.getStatus()).isEqualTo(AgentJobStatus.QUEUED);
+        assertThat(requeued.getWorkerId()).isNull();
+        assertThat(requeued.getRetryCount()).isEqualTo(1);
+
+        // NATS: the job is actually on the work queue, ready for a live replica to claim.
+        assertThat(drainStream()).contains(jobId.toString());
+    }
+
+    // ── helpers ──
+
+    private void ensureCleanStream() throws Exception {
+        JetStreamManagement jsm = nats.jetStreamManagement();
+        StreamConfiguration cfg = StreamConfiguration.builder()
+            .name(STREAM)
+            .subjects(SUBJECT_WILDCARD)
+            .retentionPolicy(RetentionPolicy.WorkQueue)
+            .storageType(StorageType.File)
+            .build();
+        try {
+            jsm.addStream(cfg);
+        } catch (Exception alreadyExists) {
+            jsm.purgeStream(STREAM); // drain leftovers from a prior test/run (reused container)
+        }
+    }
+
+    /** Drain every message currently on the work queue, returning their payloads (job ids). */
+    private List<String> drainStream() throws Exception {
+        JetStreamManagement jsm = nats.jetStreamManagement();
+        jsm.addOrUpdateConsumer(
+            STREAM,
+            ConsumerConfiguration.builder().durable("test-verifier").filterSubject(SUBJECT_WILDCARD).build()
+        );
+        StreamContext sc = nats.getStreamContext(STREAM);
+        ConsumerContext cc = sc.getConsumerContext("test-verifier");
+        List<String> payloads = new ArrayList<>();
+        try (
+            FetchConsumer fetch = cc.fetch(
+                io.nats.client.FetchConsumeOptions.builder()
+                    .maxMessages(20)
+                    .expiresIn(Duration.ofSeconds(3).toMillis())
+                    .build()
+            )
+        ) {
+            Message msg;
+            while ((msg = fetch.nextMessage()) != null) {
+                payloads.add(new String(msg.getData(), StandardCharsets.UTF_8));
+                msg.ack();
+            }
+        }
+        return payloads;
+    }
+
+    private UUID runningJobOwnedBy(String workerId, Instant startedAt) {
+        AgentJob job = new AgentJob();
+        job.setWorkspace(workspace);
+        job.setJobType(AgentJobType.PULL_REQUEST_REVIEW);
+        job.setStatus(AgentJobStatus.RUNNING);
+        job.setConfigSnapshot(objectMapper.createObjectNode());
+        job.setWorkerId(workerId);
+        job.setStartedAt(startedAt);
+        return jobRepository.saveAndFlush(job).getId();
+    }
+
+    private void registerStaleWorker(String workerId, Instant lastHeartbeat) {
+        WorkerRegistry w = new WorkerRegistry();
+        w.setWorkerId(workerId);
+        w.setLastHeartbeat(lastHeartbeat);
+        w.setRegisteredAt(lastHeartbeat);
+        workerRegistryRepository.saveAndFlush(w);
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/WorkerRegistryOrphanRecoveryIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/WorkerRegistryOrphanRecoveryIntegrationTest.java
@@ -1,0 +1,172 @@
+package de.tum.cit.aet.hephaestus.agent.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.agent.AgentJobType;
+import de.tum.cit.aet.hephaestus.agent.runtime.worker.WorkerProperties;
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import de.tum.cit.aet.hephaestus.testconfig.WorkspaceTestFactory;
+import de.tum.cit.aet.hephaestus.workspace.Workspace;
+import de.tum.cit.aet.hephaestus.workspace.WorkspaceRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Real-Postgres proof of the multi-replica orphan-recovery SQL (#1138) — the logic that makes
+ * running more than one worker replica safe. Mock-based unit tests cannot exercise the native
+ * liveness query (DB-clock {@code now()}, {@code NOT EXISTS} on {@code worker_registry}) or the CAS
+ * {@code requeueOrphan}, so the actual coordination guarantees live here.
+ */
+@DisplayName("Orphan recovery SQL (Postgres) Integration")
+class WorkerRegistryOrphanRecoveryIntegrationTest extends BaseIntegrationTest {
+
+    private static final long LEASE_TTL_SECONDS = 60;
+
+    @Autowired
+    private AgentJobRepository jobRepository;
+
+    @Autowired
+    private WorkerRegistryRepository workerRegistryRepository;
+
+    @Autowired
+    private WorkspaceRepository workspaceRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    // This context has worker.enabled=true and NO hephaestus.worker.control.endpoint — the exact
+    // topology where orphan recovery used to silently no-op (Gap D). required=false so a regression
+    // (identity bound only when WSS is configured) fails on the assertion, not on context load.
+    @Autowired(required = false)
+    private WorkerProperties workerProperties;
+
+    private Workspace workspace;
+
+    @BeforeEach
+    void setUp() {
+        databaseTestUtils.cleanDatabase();
+        workspace = workspaceRepository.save(WorkspaceTestFactory.activeWorkspace("orphan-ws"));
+    }
+
+    @Test
+    @DisplayName("a RUNNING job whose owner heartbeats fresh is NOT orphaned")
+    void aliveWorkerNotOrphaned() {
+        runningJob("w-alive", Instant.now().minus(Duration.ofMinutes(5)));
+        registerWorker("w-alive", Instant.now()); // fresh
+
+        assertThat(findOrphans()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a RUNNING job whose owner's heartbeat is stale IS orphaned")
+    void staleWorkerOrphaned() {
+        UUID id = runningJob("w-stale", Instant.now().minus(Duration.ofMinutes(5)));
+        registerWorker("w-stale", Instant.now().minus(Duration.ofMinutes(5))); // stale
+
+        assertThat(findOrphans()).extracting(OrphanedJobRef::getJobId).containsExactly(id);
+    }
+
+    @Test
+    @DisplayName("a RUNNING job whose owner has no registry row IS orphaned")
+    void missingWorkerOrphaned() {
+        UUID id = runningJob("w-gone", Instant.now().minus(Duration.ofMinutes(5)));
+        // no worker_registry row for w-gone
+
+        assertThat(findOrphans()).extracting(OrphanedJobRef::getJobId).containsExactly(id);
+    }
+
+    @Test
+    @DisplayName("a just-claimed job (within startup grace) is NOT orphaned even if the worker is unknown")
+    void withinStartupGraceNotOrphaned() {
+        runningJob("w-new", Instant.now().minus(Duration.ofSeconds(30))); // younger than the 2-min grace
+        // no registry row — but grace must protect it
+
+        List<OrphanedJobRef> orphans = jobRepository.findOrphanedRunningJobs(
+            Instant.now().minus(Duration.ofMinutes(2)),
+            LEASE_TTL_SECONDS
+        );
+        assertThat(orphans).isEmpty();
+    }
+
+    @Test
+    @DisplayName("requeueOrphan is a CAS: first caller wins (1), the second is a no-op (0)")
+    void requeueOrphanIsCasIdempotent() {
+        UUID id = runningJob("w-stale", Instant.now().minus(Duration.ofMinutes(5)));
+
+        // requeueOrphan is @Modifying — wrap in a tx, as the sweeper does.
+        int firstWin = transactionTemplate.execute(s -> jobRepository.requeueOrphan(id));
+        int secondWin = transactionTemplate.execute(s -> jobRepository.requeueOrphan(id));
+        assertThat(firstWin).isEqualTo(1);
+        assertThat(secondWin).isEqualTo(0); // already QUEUED — lost the race
+
+        AgentJob requeued = jobRepository.findById(id).orElseThrow();
+        assertThat(requeued.getStatus()).isEqualTo(AgentJobStatus.QUEUED);
+        assertThat(requeued.getWorkerId()).isNull();
+        assertThat(requeued.getRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("deleteStale removes long-dead registrations but keeps fresh ones")
+    void deleteStalePurgesDeadWorkers() {
+        registerWorker("w-fresh", Instant.now());
+        registerWorker("w-dead", Instant.now().minus(Duration.ofHours(2)));
+
+        int removed = transactionTemplate.execute(s ->
+            workerRegistryRepository.deleteStale(Duration.ofHours(1).toSeconds())
+        );
+
+        assertThat(removed).isEqualTo(1);
+        assertThat(workerRegistryRepository.findById("w-fresh")).isPresent();
+        assertThat(workerRegistryRepository.findById("w-dead")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("worker identity binds on the worker role WITHOUT a WSS endpoint (orphan recovery always armed)")
+    void workerIdentityBoundWithoutWssEndpoint() {
+        assertThat(workerProperties)
+            .as("WorkerProperties must bind on the worker role independent of the WSS control endpoint")
+            .isNotNull();
+        String id = workerProperties.resolvedWorkerId();
+        assertThat(id).isNotBlank();
+        // Stable per process (the instance suffix is computed once) — both the executor's job-ownership
+        // stamp and the WSS JWT subject rely on this being identical across calls.
+        assertThat(id).isEqualTo(workerProperties.resolvedWorkerId());
+    }
+
+    // ── helpers ──
+
+    private List<OrphanedJobRef> findOrphans() {
+        // graceCutoff well in the past so the 5-min-old jobs are eligible; liveness is DB-clock.
+        return jobRepository.findOrphanedRunningJobs(Instant.now().minus(Duration.ofMinutes(2)), LEASE_TTL_SECONDS);
+    }
+
+    private UUID runningJob(String workerId, Instant startedAt) {
+        AgentJob job = new AgentJob();
+        job.setWorkspace(workspace);
+        job.setJobType(AgentJobType.PULL_REQUEST_REVIEW);
+        job.setStatus(AgentJobStatus.RUNNING);
+        job.setConfigSnapshot(objectMapper.createObjectNode());
+        job.setWorkerId(workerId);
+        job.setStartedAt(startedAt);
+        return jobRepository.saveAndFlush(job).getId();
+    }
+
+    private void registerWorker(String workerId, Instant lastHeartbeat) {
+        WorkerRegistry w = new WorkerRegistry();
+        w.setWorkerId(workerId);
+        w.setLastHeartbeat(lastHeartbeat);
+        w.setRegisteredAt(lastHeartbeat);
+        workerRegistryRepository.saveAndFlush(w);
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/architecture/DataIsolationArchitectureTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/architecture/DataIsolationArchitectureTest.java
@@ -93,7 +93,8 @@ class DataIsolationArchitectureTest extends HephaestusArchitectureTest {
         "IssueType", // GitHub issue types are workspace-scoped through issue
         "GitProvider", // Global provider instances (e.g., github.com, gitlab.com)
         "ModelPricing", // Vendor list prices per LLM model — not tenant-scoped
-        "WorkerTokenDenylist" // Fleet-wide JWT revocation; worker JWTs are not workspace-scoped
+        "WorkerTokenDenylist", // Fleet-wide JWT revocation; worker JWTs are not workspace-scoped
+        "WorkerRegistry" // Fleet-wide worker liveness/capacity registry (#1138); not workspace-scoped
     );
 
     // ========================================================================

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerJobCancelDispatcherTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/runtime/hub/WorkerJobCancelDispatcherTest.java
@@ -1,0 +1,70 @@
+package de.tum.cit.aet.hephaestus.core.runtime.hub;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.CancelJob;
+import de.tum.cit.aet.hephaestus.core.runtime.worker.protocol.WorkerControlFrame;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+@DisplayName("WorkerJobCancelDispatcher")
+class WorkerJobCancelDispatcherTest extends BaseUnitTest {
+
+    @Mock
+    private WorkerSessionRegistry registry;
+
+    @Mock
+    private WorkerSession session;
+
+    private WorkerJobCancelDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() {
+        dispatcher = new WorkerJobCancelDispatcher(registry);
+    }
+
+    @Test
+    @DisplayName("sends a CancelJob to the owning worker's live session")
+    void dispatchesToLiveOwner() {
+        UUID jobId = UUID.randomUUID();
+        when(registry.findByWorkerId("worker-a")).thenReturn(Optional.of(session));
+
+        boolean dispatched = dispatcher.dispatch("worker-a", jobId, "user-cancel");
+
+        assertThat(dispatched).isTrue();
+        ArgumentCaptor<WorkerControlFrame> frame = ArgumentCaptor.forClass(WorkerControlFrame.class);
+        verify(session).send(frame.capture());
+        assertThat(frame.getValue()).isInstanceOf(CancelJob.class);
+        CancelJob cancel = (CancelJob) frame.getValue();
+        assertThat(cancel.jobId()).isEqualTo(jobId.toString());
+        assertThat(cancel.reason()).isEqualTo("user-cancel");
+    }
+
+    @Test
+    @DisplayName("returns false when the owning worker is not connected to this hub")
+    void noLiveSessionReturnsFalse() {
+        when(registry.findByWorkerId("worker-gone")).thenReturn(Optional.empty());
+
+        boolean dispatched = dispatcher.dispatch("worker-gone", UUID.randomUUID(), "user-cancel");
+
+        assertThat(dispatched).isFalse();
+    }
+
+    @Test
+    @DisplayName("returns false (no lookup) for a null/blank workerId")
+    void nullWorkerIdReturnsFalse() {
+        assertThat(dispatcher.dispatch(null, UUID.randomUUID(), "x")).isFalse();
+        assertThat(dispatcher.dispatch("  ", UUID.randomUUID(), "x")).isFalse();
+        verify(registry, never()).findByWorkerId(any());
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/testconfig/NatsTestContainer.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/testconfig/NatsTestContainer.java
@@ -1,0 +1,70 @@
+package de.tum.cit.aet.hephaestus.testconfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Singleton NATS JetStream container for integration tests, shared across all tests for speed.
+ *
+ * <p>Pins {@code nats:2.10-alpine} to match the deployed server version and starts it with
+ * {@code -js} so JetStream (the work queue the agent pipeline relies on) is enabled. Mirrors
+ * {@link PostgreSQLTestContainer}: lazy, double-checked singleton with a shutdown hook and
+ * {@code withReuse} for fast re-runs.
+ */
+public final class NatsTestContainer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NatsTestContainer.class);
+    private static final DockerImageName IMAGE = DockerImageName.parse("nats:2.10-alpine");
+    private static final int CLIENT_PORT = 4222;
+
+    private static GenericContainer<?> container;
+
+    private NatsTestContainer() {
+        // Utility class — prevent instantiation.
+    }
+
+    public static GenericContainer<?> getInstance() {
+        if (container == null) {
+            synchronized (NatsTestContainer.class) {
+                if (container == null) {
+                    container = createContainer();
+                }
+            }
+        }
+        return container;
+    }
+
+    /** {@return the {@code nats://host:port} URL of the running container}. */
+    public static String getServerUrl() {
+        GenericContainer<?> c = getInstance();
+        return "nats://" + c.getHost() + ":" + c.getMappedPort(CLIENT_PORT);
+    }
+
+    @SuppressWarnings("resource") // Lifecycle managed by the shutdown hook below.
+    private static GenericContainer<?> createContainer() {
+        GenericContainer<?> newContainer = new GenericContainer<>(IMAGE)
+            .withCommand("-js") // enable JetStream
+            .withExposedPorts(CLIENT_PORT)
+            .waitingFor(Wait.forLogMessage(".*Server is ready.*", 1))
+            .withReuse(true);
+
+        newContainer.start();
+        LOGGER.info(
+            "Started NATS JetStream Testcontainer: server=nats://{}:{}",
+            newContainer.getHost(),
+            newContainer.getMappedPort(CLIENT_PORT)
+        );
+
+        Runtime.getRuntime().addShutdownHook(
+            new Thread(() -> {
+                if (newContainer.isRunning()) {
+                    newContainer.stop();
+                }
+            })
+        );
+        return newContainer;
+    }
+}


### PR DESCRIPTION
## Description

Today the agent worker can only run as a single replica. Two things block horizontal scaling:

1. **Drain cancels the whole cluster.** When one worker drains (e.g. a rolling deploy), it transitions *every* `RUNNING` job to `CANCELLED` — not just the ones it owns.
2. **Crash recovery is slow.** If a worker dies mid-job, that job is only recovered once its full timeout expires.

This PR makes the agent worker safely horizontally scalable using **only infrastructure we already run — PostgreSQL, NATS, and the existing hub↔worker WSS channel. No new datastore or dependency.**

Fixes #1138

## How it works

- **Ownership** — a worker stamps its `worker_id` on a job when it claims it (`QUEUED → RUNNING`), and self-reports liveness into a small `worker_registry` table on a timer.
- **Fast orphan recovery** — a sweep finds `RUNNING` jobs whose owning worker's heartbeat has gone stale and requeues them onto the NATS work queue (retry-capped), so a sibling re-runs them within seconds instead of waiting out the timeout. Liveness tracks the *executing JVM*, not the WSS channel — a worker that loses WSS but keeps running jobs is never falsely orphaned.
- **Fencing** — a terminal write (`COMPLETED`/`FAILED`/…) only applies while the job is still owned by the writing worker, so a slow-then-recovered worker can neither overwrite nor double-deliver a sibling's run.
- **Job-scoped cancellation** — user/drain cancels target the single owning worker over the existing WSS channel, replacing the cluster-wide mass-cancel.

Two supporting changes ride along: the NATS settings are split into a cluster-wide unacked bound + a per-replica fetch size (documented in `AgentNatsProperties`), and a sandbox-hardening footgun is corrected (`SecurityProfile`'s `/home/agent/.local` default said `noexec` while the enforced policy already uses `exec`).

Single-replica and monolith behaviour is unchanged; multi-replica is opt-in via config (`hephaestus.agent.nats.max-ack-pending` ≈ `replicas × per-worker concurrency`).

## How to test

CI covers this. Locally (Docker required), from `server/`:

- **Unit** — `./mvnw -o test -Dtest='AgentJobExecutorTest,AgentJobZombieSweeperTest,WorkerJobCancelDispatcherTest,AgentJobServiceTest'`
- **Architecture** — `./mvnw -o test -Dsurefire.includedGroups=architecture`
- **Real Postgres + real NATS (Testcontainers)** — `./mvnw -o test -Dsurefire.includedGroups=integration -Dtest='WorkerRegistryOrphanRecoveryIntegrationTest,AgentOrphanRecoveryNatsIntegrationTest'`

The integration tests prove the orphan-detection SQL truth table (alive / stale / missing owner + startup grace), that the CAS requeue is idempotent, and that a dead worker's job is genuinely re-published onto a live NATS work queue for a sibling to claim.

## Notes

- A single consolidated `<timestamp>_changelog.xml` migration (new `worker_registry` table + `agent_job.worker_id`), additive, with preconditions + rollbacks.
- Also documents the Liquibase changelog naming + "one consolidated changelog per branch/PR" convention in `AGENTS.md`, and adds a `CLAUDE.md` → `AGENTS.md` symlink so Claude Code agents read the same handbook.
- Out of scope: a literal two-process failover test that also runs the agent sandbox (needs the agent container image). The coordination contract is proven against real Postgres + NATS; the final sandbox execution is orthogonal to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-replica worker coordination with automatic orphan job recovery
  * Remote job cancellation from hub to running workers
  * Worker heartbeat-based liveness detection

* **Improvements**
  * Jobs automatically requeued when owning worker fails, preventing job stalls

* **Documentation**
  * Updated contributor guidelines for database changelog requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Hephaestus/pull/1315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->