### PR TITLE
fix(server): correct one overflow signal and make the concurrency IT a real guard

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussion/github/GitHubDiscussionSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/discussion/github/GitHubDiscussionSyncService.java
@@ -238,7 +238,7 @@ public class GitHubDiscussionSyncService {
         final boolean incrementalSync = isIncrementalSync;
 
         int totalDiscussionsSynced = 0;
-        int discussionsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int discussionsReceived = 0;
         int totalCommentsSynced = 0;
         List<DiscussionWithCommentCursor> discussionsNeedingCommentPagination = new ArrayList<>();
         List<CommentWithReplyCursor> commentsNeedingReplyPagination = new ArrayList<>();

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issue/github/GitHubIssueSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issue/github/GitHubIssueSyncService.java
@@ -573,10 +573,11 @@ public class GitHubIssueSyncService {
             }
         }
 
-        // Full-sync only; compare raw nodes received (not the post-filter count) against totalCount.
-        // Stopped early = aborted OR hit the page cap (both leave pages unfetched).
+        // Full-sync only; compare raw issue nodes received (not the post-filter count) vs totalCount.
+        // hasMore stays true on every early break (error/rate-limit, page cap, empty/null page) and is
+        // false only after clean exhaustion — so it is the complete early-stop signal.
         if (reportedTotalCount >= 0 && !incrementalSync) {
-            boolean stoppedEarly = abortReason != null || pageCount >= MAX_PAGINATION_PAGES;
+            boolean stoppedEarly = abortReason != null || hasMore;
             GraphQlConnectionOverflowDetector.checkPaginated(
                 "issues",
                 issuesReceived,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuecomment/github/GitHubIssueCommentSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/issuecomment/github/GitHubIssueCommentSyncService.java
@@ -112,7 +112,7 @@ public class GitHubIssueCommentSyncService {
         ProcessingContext context = ProcessingContext.forSync(scopeId, repository);
 
         int totalSynced = 0;
-        int commentsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int commentsReceived = 0;
         String cursor = null;
         boolean hasMore = true;
         int pageCount = 0;
@@ -346,7 +346,7 @@ public class GitHubIssueCommentSyncService {
         ProcessingContext context = ProcessingContext.forSync(scopeId, repository);
 
         int totalSynced = 0;
-        int commentsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int commentsReceived = 0;
         String cursor = startCursor;
         boolean hasMore = true;
         int pageCount = 0;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/milestone/github/GitHubMilestoneSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/milestone/github/GitHubMilestoneSyncService.java
@@ -110,7 +110,7 @@ public class GitHubMilestoneSyncService {
             ProcessingContext context = ProcessingContext.forSync(scopeId, repository);
             Set<Integer> syncedNumbers = new HashSet<>();
             int totalSynced = 0;
-            int milestonesReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+            int milestonesReceived = 0;
             int reportedTotalCount = -1;
             String cursor = null;
             boolean hasNextPage = true;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectItemSyncService.java
@@ -149,7 +149,7 @@ public class GitHubProjectItemSyncService {
         HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
 
         int totalSynced = 0;
-        int itemsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int itemsReceived = 0;
         int reportedTotalCount = -1;
         String cursor = startCursor;
         boolean hasMore = true;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/project/github/GitHubProjectSyncService.java
@@ -214,7 +214,7 @@ public class GitHubProjectSyncService {
 
         Set<Long> syncedProjectIds = new HashSet<>();
         int totalSynced = 0;
-        int projectsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int projectsReceived = 0;
         int totalSkipped = 0;
         String cursor = null;
         boolean hasMore = true;
@@ -717,7 +717,7 @@ public class GitHubProjectSyncService {
         // Track items needing follow-up field value pagination (items with >20 field values)
         List<ItemWithFieldValueCursor> itemsNeedingFieldValuePagination = new ArrayList<>();
         int totalSynced = 0;
-        int itemsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int itemsReceived = 0;
         int totalSkipped = 0; // Items skipped due to incremental sync
         boolean hasMore = true;
         int pageCount = 0;
@@ -1035,7 +1035,6 @@ public class GitHubProjectSyncService {
             }
         }
 
-        // Check for overflow
         // Raw nodes received vs items.totalCount (totalSynced is post-process).
         if (reportedTotalCount >= 0) {
             GraphQlConnectionOverflowDetector.checkPaginated(
@@ -1166,7 +1165,7 @@ public class GitHubProjectSyncService {
 
         Long projectId = project.getId();
         List<String> allSyncedFieldIds = new ArrayList<>();
-        int fieldsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int fieldsReceived = 0;
         boolean completedNormally = false;
 
         try {
@@ -1393,7 +1392,7 @@ public class GitHubProjectSyncService {
 
         try {
             List<String> syncedStatusUpdateNodeIds = new ArrayList<>();
-            int statusUpdatesReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+            int statusUpdatesReceived = 0;
             String cursor = null;
             boolean hasMore = true;
             int pageCount = 0;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreview/github/GitHubPullRequestReviewSyncService.java
@@ -191,7 +191,7 @@ public class GitHubPullRequestReviewSyncService {
         HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
 
         int totalSynced = 0;
-        int reviewsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+        int reviewsReceived = 0;
         int reportedTotalCount = -1;
         String cursor = startCursor;
         boolean hasMore = true;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/pullrequestreviewcomment/github/GitHubPullRequestReviewCommentSyncService.java
@@ -147,7 +147,7 @@ public class GitHubPullRequestReviewCommentSyncService {
             int totalSynced = 0;
             // Threads received across all pages — the apples-to-apples count for
             // reviewThreads.totalCount. (totalSynced counts comments, a different unit.)
-            int threadsProcessed = 0;
+            int threadsReceived = 0;
             String cursor = null;
             boolean hasNextPage = true;
             int pageCount = 0;
@@ -270,7 +270,7 @@ public class GitHubPullRequestReviewCommentSyncService {
                     reportedTotalCount = response.getTotalCount();
                 }
 
-                threadsProcessed += response.getNodes().size();
+                threadsReceived += response.getNodes().size();
                 for (var graphQlThread : response.getNodes()) {
                     int synced = processThreadInternal(graphQlThread, pullRequest, client, scopeId);
                     totalSynced += synced;
@@ -286,7 +286,7 @@ public class GitHubPullRequestReviewCommentSyncService {
             if (reportedTotalCount >= 0) {
                 GraphQlConnectionOverflowDetector.checkPaginated(
                     "reviewThreads",
-                    threadsProcessed,
+                    threadsReceived,
                     reportedTotalCount,
                     hasNextPage,
                     "prNumber=" + pullRequest.getNumber()

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/collaborator/github/GitHubCollaboratorSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/repository/collaborator/github/GitHubCollaboratorSyncService.java
@@ -110,7 +110,7 @@ public class GitHubCollaboratorSyncService {
         try {
             HttpGraphQlClient client = graphQlClientProvider.forScope(scopeId);
             int totalSynced = 0;
-            int collaboratorsReceived = 0; // raw edges received, for the apples-to-apples completeness check
+            int collaboratorsReceived = 0;
             int reportedTotalCount = -1;
             String cursor = null;
             boolean hasNextPage = true;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamSyncService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/gitprovider/team/github/GitHubTeamSyncService.java
@@ -152,7 +152,7 @@ public class GitHubTeamSyncService {
             // Maps child team's native ID → parent team's native ID (from GraphQL)
             Map<Long, Long> parentNativeIdByChildNativeId = new HashMap<>();
             int totalSynced = 0;
-            int teamsReceived = 0; // raw nodes received, for the apples-to-apples completeness check
+            int teamsReceived = 0;
             int totalPermissions = 0;
             String cursor = null;
             boolean hasNextPage = true;

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/achievement/AchievementConcurrencyIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/achievement/AchievementConcurrencyIntegrationTest.java
@@ -18,31 +18,50 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.IntConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
- * Proves the per-user advisory lock actually serializes achievement evaluation against a real
- * Postgres (the unit test mocks the repository and cannot exercise {@code pg_advisory_xact_lock}).
+ * Proves the per-user advisory lock serializes achievement evaluation against a real Postgres
+ * (the unit test mocks the repository and cannot exercise {@code pg_advisory_xact_lock}).
  *
- * <p>Pre-fix, concurrent same-user events raced on the {@code @Version} column and threw
- * {@link ObjectOptimisticLockingFailureException} after retries exhausted, losing increments. With
- * the lock, same-user evaluation runs one transaction at a time, so every increment lands.
+ * <p>The guard is deterministic: {@value #THREADS} transactions hammer the same versioned
+ * {@link UserAchievement} row at <em>full</em> concurrency (the Hikari pool is widened below so the
+ * threads are not serialized by the connection pool). Without the lock, {@code @Retryable}'s 3
+ * attempts cannot absorb that contention — each retry round lets only one writer win, so most
+ * threads exhaust their retries and either throw {@link ObjectOptimisticLockingFailureException} or
+ * lose their increment. With the lock, the writers serialize cleanly: zero failures, every
+ * increment lands. So reverting {@code acquireUserLock} turns this test red.
  */
 class AchievementConcurrencyIntegrationTest extends BaseIntegrationTest {
 
-    // A high-target linear achievement so many increments are needed (and none unlock at 40 events).
-    private static final String LEGENDARY = "pr.merged.legendary"; // StandardCountEvaluator, target 50
+    // High-target linear achievement: 40 increments need many writes and never unlock (target 50).
+    private static final String LEGENDARY = "pr.merged.legendary";
     private static final int THREADS = 40;
+
+    @DynamicPropertySource
+    static void widenConnectionPool(DynamicPropertyRegistry registry) {
+        // Every worker holds a connection while blocked on the advisory lock, so the pool must fit
+        // all threads — otherwise workers fail with connection-timeouts unrelated to the behaviour
+        // under test. Disable leak detection: serialized lock holders legitimately hold connections.
+        registry.add("spring.datasource.hikari.maximum-pool-size", () -> THREADS + 4);
+        registry.add("spring.datasource.hikari.connection-timeout", () -> "30000");
+        registry.add("spring.datasource.hikari.leak-detection-threshold", () -> "0");
+    }
 
     @Autowired
     private AchievementService achievementService;
@@ -72,39 +91,33 @@ class AchievementConcurrencyIntegrationTest extends BaseIntegrationTest {
         User user = persistUser("concurrency-victim");
         ActivitySavedEvent event = mergedEvent(user, 1L);
 
-        List<Throwable> escaped = runConcurrently(THREADS, () -> achievementService.checkAndUnlock(event));
+        List<Throwable> escaped = runConcurrently(THREADS, i -> achievementService.checkAndUnlock(event));
 
         assertThat(escaped)
             .as("the advisory lock must serialize same-user evaluation; nothing should escape")
             .isEmpty();
-
-        LinearAchievementProgress progress = readProgress(user.getId(), LEGENDARY);
-        assertThat(progress.current())
-            .as("%d serialized increments must all land (no lost updates)", THREADS)
+        assertThat(readProgress(user.getId(), LEGENDARY).current())
+            .as("all %d serialized increments must land (no lost updates)", THREADS)
             .isEqualTo(THREADS);
-        // 40 < target 50, so it stays locked.
-        assertThat(readUnlockedAt(user.getId(), LEGENDARY)).isNull();
-        assertThat(userAchievementRepository.findByUserIdAndAchievementId(user.getId(), LEGENDARY)).isPresent();
+        assertThat(readUnlockedAt(user.getId(), LEGENDARY)).as("40 < target 50, so it stays locked").isNull();
     }
 
     @Test
-    @DisplayName("concurrent different-user events run in parallel and each lands exactly once")
+    @DisplayName("concurrent different-user events each land exactly once (independent per-user state)")
     void differentUsersConcurrent() throws Exception {
-        int userCount = 20;
+        int userCount = THREADS;
         List<User> users = new ArrayList<>();
         for (int i = 0; i < userCount; i++) {
             users.add(persistUser("parallel-user-" + i));
         }
 
-        List<Throwable> escaped = runConcurrentlyEach(users, user ->
-            achievementService.checkAndUnlock(mergedEvent(user, (long) user.hashCode()))
+        List<Throwable> escaped = runConcurrently(userCount, i ->
+            achievementService.checkAndUnlock(mergedEvent(users.get(i), (long) i))
         );
 
-        assertThat(escaped).as("per-user locks must not serialize different users into failures").isEmpty();
+        assertThat(escaped).as("per-user locks must not turn different users into failures").isEmpty();
         for (User user : users) {
-            assertThat(readProgress(user.getId(), LEGENDARY).current())
-                .as("each user's single event must produce exactly one increment")
-                .isEqualTo(1);
+            assertThat(readProgress(user.getId(), LEGENDARY).current()).isEqualTo(1);
         }
     }
 
@@ -121,39 +134,37 @@ class AchievementConcurrencyIntegrationTest extends BaseIntegrationTest {
         );
     }
 
-    /** Run the same task on {@code threads} threads released together, returning any escaped throwables. */
-    private List<Throwable> runConcurrently(int threads, Runnable task) throws InterruptedException {
-        return runConcurrentlyEach(Collections.nCopies(threads, (Void) null), ignored -> task.run());
-    }
-
-    /** Run one task per item concurrently (all released together), returning any escaped throwables. */
-    private <T> List<Throwable> runConcurrentlyEach(List<T> items, java.util.function.Consumer<T> task)
-        throws InterruptedException {
+    /**
+     * Run {@code parallelism} tasks released together (via a start latch) to maximise transaction
+     * overlap, and collect any throwable each task escaped with.
+     */
+    private List<Throwable> runConcurrently(int parallelism, IntConsumer task) throws InterruptedException {
         List<Throwable> escaped = Collections.synchronizedList(new ArrayList<>());
-        ExecutorService pool = Executors.newFixedThreadPool(items.size());
-        CountDownLatch ready = new CountDownLatch(items.size());
+        ExecutorService pool = Executors.newFixedThreadPool(parallelism);
+        CountDownLatch ready = new CountDownLatch(parallelism);
         CountDownLatch start = new CountDownLatch(1);
         List<Future<?>> futures = new ArrayList<>();
         try {
-            for (T item : items) {
+            for (int i = 0; i < parallelism; i++) {
+                int index = i;
                 futures.add(
                     pool.submit(() -> {
                         ready.countDown();
                         try {
                             start.await();
-                            task.accept(item);
+                            task.accept(index);
                         } catch (Throwable t) {
                             escaped.add(t);
                         }
                     })
                 );
             }
-            ready.await(); // every worker parked on `start` → maximize overlap
+            ready.await(); // every worker parked on `start` → release together for maximum overlap
             start.countDown();
             for (Future<?> f : futures) {
-                f.get(30, TimeUnit.SECONDS);
+                f.get(60, TimeUnit.SECONDS);
             }
-        } catch (java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
+        } catch (ExecutionException | TimeoutException e) {
             escaped.add(e);
         } finally {
             pool.shutdownNow();


### PR DESCRIPTION
## Description

Follow-up to #1314 (already merged). A second, more adversarial review pass — including an empirical revert experiment — surfaced one real correctness bug and a test that wasn't yet a reliable guard. Both are fixed here.

### 🔴 Overflow detector: one site suppressed a real truncation signal

In `GitHubIssueSyncService`, the completeness check used `stoppedEarly = abortReason != null || pageCount >= MAX_PAGINATION_PAGES`. But the loop's **empty/null-page break** sets *neither* of those, so if GitHub returns an empty page mid-pagination (a [documented pagination anomaly](https://github.com/orgs/community/discussions/30687)) with `totalCount > fetched`, the gap was misclassified **benign → DEBUG** — silently hiding a real truncation, and inconsistent with every sibling loop (which read `hasMore`, still `true` at that break).

Fixed to `abortReason != null || hasMore`, which is `true` on every early break (error / rate-limit / page cap / empty page) and `false` only after clean exhaustion — matching the sibling loops.

### 🟢 Concurrency integration test: now a deterministic guard

`AchievementConcurrencyIntegrationTest` was inconclusive: at the shared Hikari pool size of 10, only ~10 of the 40 threads ran concurrently, so `@Retryable` could absorb the contention and the test could pass **even without the advisory lock** (false confidence), while also risking `SQLTransientConnectionException` flakes.

- The pool is now widened for this test (via `@DynamicPropertySource`) so all 40 threads run *truly* concurrently. At that contention, retries cannot absorb the collisions, so reverting the lock makes the test **deterministically red**. I verified this empirically: with `acquireUserLock` removed, the test fails with `ObjectOptimisticLockingFailureException: Batch update returned unexpected row count` — exactly the pre-fix failure; restoring the lock makes it green again.
- Simplified the concurrency harness (`IntConsumer`, no `Void`/`nCopies` trick), tightened the assertions, and corrected a `@DisplayName` that overclaimed parallelism.

### 🧹 Comment cleanup

- Dropped the 12 repeated `// raw nodes received …` trailing comments (the `xReceived` name + the call-site comment already say it).
- Removed a stale `// Check for overflow` leftover.
- Renamed `threadsProcessed` → `threadsReceived` for accumulator-naming consistency.

### Validation

Full unit suite (2,870) + both integration tests green. The lock SQL keyspace-disjointness and all 24 migrated overflow sites were re-verified.

Refs #1313.

## How to test

```bash
cd server
./mvnw test -Dsurefire.includedGroups=unit -Dtest='GraphQlConnectionOverflowDetectorTest,AchievementServiceTest'
./mvnw verify -Dit.test=AchievementConcurrencyIntegrationTest   # real Postgres via Testcontainers
```
To see the test's guard value: comment out `acquireUserLock(...)` in `AchievementService.checkAndUnlock` and re-run the IT — `sameUserConcurrentEvents` goes red with an escaped `ObjectOptimisticLockingFailureException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
