### PR TITLE
fix(server): run the export retention sweep in a transaction

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/AccountExportService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/AccountExportService.java
@@ -114,6 +114,22 @@ public class AccountExportService {
             .filter(payload -> payload != null && payload.length > 0);
     }
 
+    /**
+     * Hourly retention enforcement: flips every READY export past its {@code expiresAt} to EXPIRED and
+     * nulls the payload so exported PII isn't retained beyond the download window. One bulk
+     * {@code @Modifying} UPDATE — no BYTEA blobs are loaded into the persistence context.
+     *
+     * <p>{@code @Transactional} is load-bearing: the bulk {@code @Modifying(flushAutomatically = true)}
+     * query needs an active transaction, and the scheduler ({@link ExportRetentionSweeper}) calls this
+     * across a real proxy hop with none of its own.
+     *
+     * @return the number of exports expired by this run
+     */
+    @Transactional
+    public int expireRetention() {
+        return accountExportRepository.expireReadyBefore(Instant.now(clock));
+    }
+
     private ExportStatusDTO toStatus(AccountExport e) {
         return new ExportStatusDTO(
             e.getId(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeper.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeper.java
@@ -1,19 +1,21 @@
 package de.tum.cit.aet.hephaestus.core.auth.export;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
-import java.time.Clock;
-import java.time.Instant;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Hourly sweep that enforces the {@link ExportGenerationWorker#RETENTION 48h} retention window:
  * READY exports past {@code expires_at} flip to EXPIRED and have their payload nulled so the
  * exported PII isn't retained beyond the download window.
+ *
+ * <p>This bean owns only scheduling and cross-pod locking; the transactional work lives in
+ * {@link AccountExportService#expireRetention()}. Delegating across a real proxy hop (rather than a
+ * self-invoked method) is what lets that {@code @Transactional} take effect — the bulk
+ * {@code @Modifying} UPDATE requires an active transaction.
  *
  * <p>Scheduling is gated by {@code ServerSchedulingConfig} ({@code @EnableScheduling} only on the
  * server role), and wrapped in {@link SchedulerLock} so concurrent server pods don't both run the
@@ -25,29 +27,18 @@ public class ExportRetentionSweeper {
 
     private static final Logger log = LoggerFactory.getLogger(ExportRetentionSweeper.class);
 
-    private final AccountExportRepository accountExportRepository;
-    private final Clock clock;
+    private final AccountExportService accountExportService;
 
-    public ExportRetentionSweeper(AccountExportRepository accountExportRepository, Clock clock) {
-        this.accountExportRepository = accountExportRepository;
-        this.clock = clock;
+    public ExportRetentionSweeper(AccountExportService accountExportService) {
+        this.accountExportService = accountExportService;
     }
 
-    /** Runs hourly. {@code expireNow()} is also callable directly from tests. */
     @Scheduled(cron = "0 0 * * * *")
     @SchedulerLock(name = "account-export-retention-sweep", lockAtMostFor = "PT5M", lockAtLeastFor = "PT30S")
-    @Transactional
     public void sweep() {
-        int expired = expireNow();
+        int expired = accountExportService.expireRetention();
         if (expired > 0) {
             log.info("auth.export: expired {} READY export(s) past retention", expired);
         }
-    }
-
-    @Transactional
-    public int expireNow() {
-        // Single bulk UPDATE — flips status to EXPIRED and frees the payload without loading the
-        // (large) BYTEA blobs into the persistence context.
-        return accountExportRepository.expireReadyBefore(Instant.now(clock));
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeper.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeper.java
@@ -36,6 +36,7 @@ public class ExportRetentionSweeper {
     /** Runs hourly. {@code expireNow()} is also callable directly from tests. */
     @Scheduled(cron = "0 0 * * * *")
     @SchedulerLock(name = "account-export-retention-sweep", lockAtMostFor = "PT5M", lockAtLeastFor = "PT30S")
+    @Transactional
     public void sweep() {
         int expired = expireNow();
         if (expired > 0) {

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/AccountExportRetentionIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/export/AccountExportRetentionIntegrationTest.java
@@ -1,0 +1,84 @@
+package de.tum.cit.aet.hephaestus.core.auth.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
+import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
+import de.tum.cit.aet.hephaestus.testconfig.BaseIntegrationTest;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Regression coverage for {@link AccountExportService#expireRetention()} — the work behind the hourly
+ * {@link ExportRetentionSweeper}. {@code expireReadyBefore} is a bulk
+ * {@code @Modifying(flushAutomatically = true)} UPDATE that needs an active transaction, and the
+ * scheduler reaches it with none of its own, so the method's {@code @Transactional} is load-bearing.
+ *
+ * <p>The test drives {@code expireRetention()} with NO ambient transaction ({@link BaseIntegrationTest}
+ * is not {@code @Transactional}) and asserts the committed database state. Dropping {@code @Transactional}
+ * therefore resurfaces the {@code TransactionRequiredException} and fails the build, rather than letting
+ * the sweep regress silently — a {@code @Transactional} test would mask it by supplying the transaction
+ * the scheduler never does.
+ */
+class AccountExportRetentionIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private AccountExportService accountExportService;
+
+    @Autowired
+    private AccountExportRepository accountExportRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    /** The same clock the service reads — fixtures are positioned relative to it. */
+    @Autowired
+    private Clock clock;
+
+    @BeforeEach
+    void cleanState() {
+        databaseTestUtils.cleanDatabase();
+    }
+
+    @Test
+    void expireRetention_expiresReadyExportPastRetention_andNullsPayload() {
+        Long id = persistReadyExport(Instant.now(clock).minus(Duration.ofHours(1)));
+
+        int expired = accountExportService.expireRetention();
+
+        assertThat(expired).isEqualTo(1);
+        AccountExport swept = accountExportRepository.findById(id).orElseThrow();
+        assertThat(swept.getStatus()).isEqualTo(AccountExport.Status.EXPIRED);
+        assertThat(swept.getPayload()).as("PII payload freed on expiry").isNull();
+    }
+
+    @Test
+    void expireRetention_leavesReadyExportWithinRetention_untouched() {
+        Long id = persistReadyExport(Instant.now(clock).plus(Duration.ofHours(1)));
+
+        int expired = accountExportService.expireRetention();
+
+        assertThat(expired).isZero();
+        AccountExport kept = accountExportRepository.findById(id).orElseThrow();
+        assertThat(kept.getStatus()).isEqualTo(AccountExport.Status.READY);
+        assertThat(kept.getPayload()).isNotNull();
+    }
+
+    private Long persistReadyExport(Instant expiresAt) {
+        Account account = new Account("Export Retention Subject");
+        account.setPrimaryEmail("export-retention@test.local");
+        account.setPrimaryEmailVerifiedAt(clock.instant());
+        account.setStatus(Account.Status.ACTIVE);
+        Long accountId = accountRepository.save(account).getId();
+
+        AccountExport export = new AccountExport(accountId);
+        export.setStatus(AccountExport.Status.READY);
+        export.setExpiresAt(expiresAt);
+        export.setPayload("{\"pii\":true}".getBytes());
+        return accountExportRepository.save(export).getId();
+    }
+}


### PR DESCRIPTION
## Description

The hourly account-export **retention sweep** (`ExportRetentionSweeper`) crashed on every run. It runs a single bulk `UPDATE` that expires READY exports past their retention window and clears the stored payload, so exported PII isn't kept beyond the download window. That bulk update is a JPA `@Modifying` query and needs an active transaction — but the scheduler invoked the sweep without one, so it failed immediately:

```text
jakarta.persistence.TransactionRequiredException:
No EntityManager with actual transaction available for current thread - cannot reliably process 'flush' call
```

**Root cause.** Spring only opens a transaction when a `@Transactional` method is called *through its proxy*. The expiry lived in a method the sweeper invoked on itself (self-invocation), which bypasses the proxy — so the annotation never took effect and the scheduled call ran with no transaction.

**Fix.** Move the expiry into the service that already owns the export lifecycle, `AccountExportService.expireRetention()`, and put `@Transactional` there. The scheduler bean now keeps only its scheduling and cross-pod-locking concerns (`@Scheduled` + `@SchedulerLock`) and delegates to the service across a real proxy hop, so the transaction is genuinely applied. This matches the existing `AccountHardDeleteSweeper` (thin sweeper → transactional service) and the codebase convention of keeping transaction boundaries at the service layer rather than on repositories or schedulers.

Behavior is otherwise unchanged: same hourly schedule, same lock, same retention semantics — it just no longer crashes.

## How to test

A new integration test, `AccountExportRetentionIntegrationTest`, reproduces the failure and locks in the fix against a real Postgres (Testcontainers):

- A READY export whose `expiresAt` is in the past → after the sweep it is `EXPIRED` and its payload is `null`.
- A READY export still within its retention window → left untouched.

The test runs **without** an ambient transaction — the exact condition the scheduler hits — and drives the service method directly, keeping it off the ShedLock path.

```bash
cd server
./mvnw -P'!quick' test-compile failsafe:integration-test -Dit.test=AccountExportRetentionIntegrationTest
```

> The local `quick` Maven profile auto-activates once GraphQL sources exist and sets `maven.test.skip=true`, so a plain `mvn verify` silently skips tests. `-P'!quick'` runs them.

Sanity check: delete `@Transactional` from `expireRetention()` and re-run — the test fails with `TransactionRequiredException`, confirming it actually guards the behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled retention/expiration so the operation runs transactionally, reducing risk of partial or failed expirations and ensuring expired exports are properly cleared.
* **Tests**
  * Added integration tests verifying expired exports are marked expired and their stored payloads are removed, and that in-retention exports remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
