### PR TITLE
fix(docker): source GitHub OAuth creds from GH_OAUTH_* (GITHUB_ prefix is reserved)

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -37,8 +37,10 @@ HEPHAESTUS_AUTH_STATE_COOKIE_KEY=
 
 # GitHub OAuth App (https://github.com/settings/developers).
 # Callback: https://<hostname>/api/login/oauth2/code/github
-GITHUB_OAUTH_CLIENT_ID=
-GITHUB_OAUTH_CLIENT_SECRET=
+# Named GH_OAUTH_* (not GITHUB_OAUTH_*) because GitHub Actions reserves the GITHUB_ prefix for
+# secret/variable names; compose maps these onto the GITHUB_OAUTH_* the server actually reads.
+GH_OAUTH_CLIENT_ID=
+GH_OAUTH_CLIENT_SECRET=
 
 # GitLab OAuth application (gitlab.com or self-hosted; scope: read_user — OAuth2 flow, not OIDC).
 # Callback: https://<hostname>/api/login/oauth2/code/gitlab. Leave the client id blank to disable.

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -117,8 +117,10 @@ services:
       # <provider>:<subject>. Optional break-glass token enables POST /auth/bootstrap-admin.
       HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS: ${HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS:-}
       HEPHAESTUS_AUTH_BOOTSTRAP_TOKEN: ${HEPHAESTUS_AUTH_BOOTSTRAP_TOKEN:-}
-      GITHUB_OAUTH_CLIENT_ID: ${GITHUB_OAUTH_CLIENT_ID}
-      GITHUB_OAUTH_CLIENT_SECRET: ${GITHUB_OAUTH_CLIENT_SECRET}
+      # Sourced from GH_OAUTH_* — GitHub Actions reserves the GITHUB_ prefix for secret/variable
+      # names, so the deploy can't provide GITHUB_OAUTH_*; the container still presents it to Spring.
+      GITHUB_OAUTH_CLIENT_ID: ${GH_OAUTH_CLIENT_ID:-}
+      GITHUB_OAUTH_CLIENT_SECRET: ${GH_OAUTH_CLIENT_SECRET:-}
       GITLAB_OAUTH_CLIENT_ID: ${GITLAB_OAUTH_CLIENT_ID:-}
       GITLAB_OAUTH_CLIENT_SECRET: ${GITLAB_OAUTH_CLIENT_SECRET:-}
       GITLAB_OAUTH_BASE_URL: ${GITLAB_OAUTH_BASE_URL:-https://gitlab.com}

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -208,8 +208,9 @@ services:
       # Public URL for issuer validation (must match token's iss claim).
       HEPHAESTUS_AUTH_ISSUER: https://${PREVIEW_DOMAIN:?Required}
       HEPHAESTUS_AUTH_STATE_COOKIE_KEY: ${HEPHAESTUS_AUTH_STATE_COOKIE_KEY:?Required}
-      GITHUB_OAUTH_CLIENT_ID: ${GITHUB_OAUTH_CLIENT_ID}
-      GITHUB_OAUTH_CLIENT_SECRET: ${GITHUB_OAUTH_CLIENT_SECRET}
+      # Sourced from GH_OAUTH_* — GitHub Actions reserves the GITHUB_ prefix for secret/variable names.
+      GITHUB_OAUTH_CLIENT_ID: ${GH_OAUTH_CLIENT_ID:-}
+      GITHUB_OAUTH_CLIENT_SECRET: ${GH_OAUTH_CLIENT_SECRET:-}
       GITLAB_OAUTH_CLIENT_ID: ${GITLAB_OAUTH_CLIENT_ID:-}
       GITLAB_OAUTH_CLIENT_SECRET: ${GITLAB_OAUTH_CLIENT_SECRET:-}
       GITLAB_OAUTH_BASE_URL: ${GITLAB_OAUTH_BASE_URL:-https://gitlab.com}


### PR DESCRIPTION
## Blocker found during the staging auth cutover

`application.yml` binds the native-auth login client from `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET`:
```yaml
client-id: ${GITHUB_OAUTH_CLIENT_ID:}
client-secret: ${GITHUB_OAUTH_CLIENT_SECRET:}
```
But the deploy builds the server `.env` entirely from GitHub **Actions secrets + variables**, and GitHub **forbids any secret/variable name starting with `GITHUB_`** (HTTP 422: *"Variable names must not start with GITHUB_."* — same rule for secrets). So those two values can never be provided by the deploy → the OAuth client ships blank and **GitHub login is silently disabled** in any GH-Actions-deployed environment.

## Fix

Map the container's `GITHUB_OAUTH_*` (what Spring reads) from deploy-safe `GH_OAUTH_*` names:
```yaml
GITHUB_OAUTH_CLIENT_ID: ${GH_OAUTH_CLIENT_ID:-}
GITHUB_OAUTH_CLIENT_SECRET: ${GH_OAUTH_CLIENT_SECRET:-}
```
Operators now set `GH_OAUTH_CLIENT_ID` / `GH_OAUTH_CLIENT_SECRET` (allowed as GH secrets); Spring still binds `GITHUB_OAUTH_*` unchanged. Applied to `compose.app.yaml` and `docker/preview/compose.app.yaml`, and `.env.example` updated. `GITLAB_OAUTH_*` is unaffected (only the `GITHUB_` prefix is reserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub OAuth configuration variable naming conventions. Users deploying the application with GitHub OAuth will need to adjust their environment variable names accordingly. Default empty values have been added for improved configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->