### PR TITLE
fix(auth): re-add proxy-stripped /api prefix to browser-facing OAuth URLs

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthProperties.java
@@ -15,6 +15,16 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  * integration tests override via {@code @TestPropertySource}.
  *
  * @param issuer          Canonical issuer URI; populates the {@code iss} claim.
+ * @param apiBasePath     Public path prefix the reverse proxy strips before requests reach this app
+ *                        (e.g. {@code /api} when Traefik strips {@code /api}); empty when the app is
+ *                        served at the origin root (local dev). Prepended when building the absolute,
+ *                        browser-reachable OAuth URLs — the authorization-request {@code redirect_uri}
+ *                        and the {@code /oauth2/authorization} init redirect — so the IdP and the
+ *                        callback land back on the proxied API path, not the SPA. It cannot be inferred
+ *                        from the request: prod runs {@code forward-headers-strategy: native} (Tomcat
+ *                        {@code RemoteIpValve}, kept for the pre-auth IP rate-limit trust model — see
+ *                        {@code ProxyTrustGuard}), which restores forwarded host/proto but NOT
+ *                        {@code X-Forwarded-Prefix}. Contract: leading slash, no trailing slash.
  * @param audience        Default {@code aud} claim for SPA cookies.
  * @param accessTtl       Cookie-JWT lifetime.
  * @param cookieName      Access-token cookie name (the {@code __Host-} prefix is
@@ -69,6 +79,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 @ConfigurationProperties(prefix = "hephaestus.auth")
 public record AuthProperties(
     @DefaultValue("http://localhost:8080") URI issuer,
+    @DefaultValue("") String apiBasePath,
     @DefaultValue("hephaestus-spa") String audience,
     @DefaultValue("15m") Duration accessTtl,
     @DefaultValue(DEFAULT_COOKIE_NAME) String cookieName,

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
  *                        from the request: prod runs {@code forward-headers-strategy: native} (Tomcat
  *                        {@code RemoteIpValve}, kept for the pre-auth IP rate-limit trust model — see
  *                        {@code ProxyTrustGuard}), which restores forwarded host/proto but NOT
- *                        {@code X-Forwarded-Prefix}. Contract: leading slash, no trailing slash.
+ *                        {@code X-Forwarded-Prefix}. Normalized to leading-slash / no-trailing-slash.
  * @param audience        Default {@code aud} claim for SPA cookies.
  * @param accessTtl       Cookie-JWT lifetime.
  * @param cookieName      Access-token cookie name (the {@code __Host-} prefix is
@@ -97,6 +97,23 @@ public record AuthProperties(
      */
     public AuthProperties {
         loginProviders = loginProviders == null ? Map.of() : loginProviders;
+        apiBasePath = normalizeApiBasePath(apiBasePath);
+    }
+
+    /**
+     * Coerce {@code apiBasePath} to the leading-slash / no-trailing-slash form the OAuth-URL builders
+     * concatenate, so {@code api}, {@code /api} and {@code /api/} are equivalent and {@code /} or blank
+     * mean root — a misconfigured value can't silently produce {@code hostapi/…} or a double slash.
+     */
+    private static String normalizeApiBasePath(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim().replaceAll("/+$", "");
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+        return trimmed.startsWith("/") ? trimmed : "/" + trimmed;
     }
 
     /**

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginController.java
@@ -39,16 +39,21 @@ public class AuthBeginController {
     private final de.tum.cit.aet.hephaestus.core.auth.jwt.CookieBearerTokenResolver bearerTokenResolver;
     private final org.springframework.security.oauth2.jwt.JwtDecoder jwtDecoder;
 
+    /** Proxy-stripped API prefix re-added to the init redirect — see {@code AuthProperties#apiBasePath}. */
+    private final String apiBasePath;
+
     public AuthBeginController(
         ClientRegistrationRepository clientRegistrationRepository,
         AuthIntentCookie authIntentCookie,
         de.tum.cit.aet.hephaestus.core.auth.jwt.CookieBearerTokenResolver bearerTokenResolver,
-        de.tum.cit.aet.hephaestus.core.auth.jwt.RevocationAwareJwtDecoder jwtDecoder
+        de.tum.cit.aet.hephaestus.core.auth.jwt.RevocationAwareJwtDecoder jwtDecoder,
+        de.tum.cit.aet.hephaestus.core.auth.AuthProperties authProperties
     ) {
         this.clientRegistrationRepository = clientRegistrationRepository;
         this.authIntentCookie = authIntentCookie;
         this.bearerTokenResolver = bearerTokenResolver;
         this.jwtDecoder = jwtDecoder;
+        this.apiBasePath = authProperties.apiBasePath();
     }
 
     @GetMapping("/login")
@@ -89,8 +94,10 @@ public class AuthBeginController {
         authIntentCookie.write(response, intent);
         // 302 to Spring's standard initiation endpoint; the OAuth2AuthorizationRequestRedirectFilter
         // takes over from here, building the upstream redirect with state + PKCE (see AuthSecurityConfig).
+        // apiBasePath re-adds the proxy-stripped prefix so the browser lands on the proxied init endpoint,
+        // not the SPA. (The /auth/error targets above are SPA routes at the origin root, so they keep none.)
         String urlEncodedRegistration = URLEncoder.encode(registrationId, StandardCharsets.UTF_8);
-        return new RedirectView(OAUTH_INIT_PATH + urlEncodedRegistration, false);
+        return new RedirectView(apiBasePath + OAUTH_INIT_PATH + urlEncodedRegistration, false);
     }
 
     /**

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderClientRegistrationRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderClientRegistrationRepository.java
@@ -24,16 +24,26 @@ public class LoginProviderClientRegistrationRepository
     implements ClientRegistrationRepository, Iterable<ClientRegistration>, IdentityProviderCatalog
 {
 
-    private static final String CALLBACK_TEMPLATE = "{baseUrl}/login/oauth2/code/{registrationId}";
-
     private final LoginProviderRepository loginProviderRepository;
+
+    /**
+     * {@code redirect_uri} template. {@code {baseUrl}} expands per request to the public origin (scheme
+     * + host, restored by native forward-headers); {@code apiBasePath} re-adds the proxy-stripped prefix
+     * so the IdP redirects back to the proxied API path, not the SPA — see {@code AuthProperties#apiBasePath}.
+     */
+    private final String callbackTemplate;
+
     private final Cache<String, ClientRegistration> cache = Caffeine.newBuilder()
         .expireAfterWrite(Duration.ofSeconds(60))
         .maximumSize(256)
         .build();
 
-    public LoginProviderClientRegistrationRepository(LoginProviderRepository loginProviderRepository) {
+    public LoginProviderClientRegistrationRepository(
+        LoginProviderRepository loginProviderRepository,
+        String apiBasePath
+    ) {
         this.loginProviderRepository = loginProviderRepository;
+        this.callbackTemplate = "{baseUrl}" + apiBasePath + "/login/oauth2/code/{registrationId}";
     }
 
     @Override
@@ -79,7 +89,7 @@ public class LoginProviderClientRegistrationRepository
             .clientSecret(provider.getClientSecret())
             .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
             .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-            .redirectUri(CALLBACK_TEMPLATE)
+            .redirectUri(callbackTemplate)
             .scope(provider.getScopes().trim().split("\\s+"))
             .userNameAttributeName("id")
             .clientName(provider.getDisplayName());

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderConfiguration.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.provider;
 
+import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,8 +15,9 @@ public class LoginProviderConfiguration {
 
     @Bean
     public LoginProviderClientRegistrationRepository loginProviderClientRegistrationRepository(
-        LoginProviderRepository loginProviderRepository
+        LoginProviderRepository loginProviderRepository,
+        AuthProperties authProperties
     ) {
-        return new LoginProviderClientRegistrationRepository(loginProviderRepository);
+        return new LoginProviderClientRegistrationRepository(loginProviderRepository, authProperties.apiBasePath());
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminController.java
@@ -43,14 +43,30 @@ public class LoginProviderAdminController {
 
     private final LoginProviderService loginProviderService;
 
-    public LoginProviderAdminController(LoginProviderService loginProviderService) {
+    /** Proxy-stripped API prefix re-added to the displayed callback URL — see {@code AuthProperties#apiBasePath}. */
+    private final String apiBasePath;
+
+    public LoginProviderAdminController(
+        LoginProviderService loginProviderService,
+        de.tum.cit.aet.hephaestus.core.auth.AuthProperties authProperties
+    ) {
         this.loginProviderService = loginProviderService;
+        this.apiBasePath = authProperties.apiBasePath();
+    }
+
+    /**
+     * Public callback base the admin registers on the upstream OAuth app: the request origin (scheme +
+     * host, restored by native forward-headers) plus the proxy-stripped API prefix. The per-provider
+     * {@code /login/oauth2/code/{id}} segment is appended in {@link #toView}.
+     */
+    private String callbackBase() {
+        return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString() + apiBasePath;
     }
 
     @GetMapping
     @Operation(summary = "List login providers", operationId = "adminListLoginProviders")
     public ResponseEntity<List<LoginProviderViewDTO>> list() {
-        String callbackBase = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        String callbackBase = callbackBase();
         return ResponseEntity.ok(
             loginProviderService
                 .listAll()
@@ -75,10 +91,7 @@ public class LoginProviderAdminController {
                 body.scopes()
             )
         );
-        LoginProviderViewDTO view = toView(
-            created,
-            ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
-        );
+        LoginProviderViewDTO view = toView(created, callbackBase());
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/{registrationId}")
             .buildAndExpand(created.getRegistrationId())
@@ -103,9 +116,7 @@ public class LoginProviderAdminController {
                 body.enabled()
             )
         );
-        return ResponseEntity.ok(
-            toView(updated, ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString())
-        );
+        return ResponseEntity.ok(toView(updated, callbackBase()));
     }
 
     @DeleteMapping("/{registrationId}")

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -125,6 +125,9 @@ hephaestus:
     auth:
         issuer: ${HEPHAESTUS_AUTH_ISSUER}
         state-cookie-key: ${HEPHAESTUS_AUTH_STATE_COOKIE_KEY}
+        # Traefik strips /api before the request reaches the app (see docker/compose.app.yaml), and
+        # native forward-headers can't restore the prefix — re-add it to the browser-facing OAuth URLs.
+        api-base-path: /api
 
     # ═══════════════════════════════════════════════════════════════════════════
     # GITLAB INTEGRATION (Production)

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthPropertiesFixture.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthPropertiesFixture.java
@@ -1,0 +1,47 @@
+package de.tum.cit.aet.hephaestus.core.auth;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared {@link AuthProperties} builder for unit tests, so the 12-arg record construction lives in one
+ * place. Values are the production defaults; vary only the component under test.
+ */
+public final class AuthPropertiesFixture {
+
+    private AuthPropertiesFixture() {}
+
+    /** Production defaults (no proxy prefix, no seeded providers). */
+    public static AuthProperties defaults() {
+        return build("", Map.of());
+    }
+
+    /** Defaults with the given {@code apiBasePath} (the constructor normalizes it). */
+    public static AuthProperties withApiBasePath(String apiBasePath) {
+        return build(apiBasePath, Map.of());
+    }
+
+    /** Defaults with the given seeded login providers. */
+    public static AuthProperties withLoginProviders(Map<String, AuthProperties.LoginProviderSeed> loginProviders) {
+        return build("", loginProviders);
+    }
+
+    private static AuthProperties build(String apiBasePath, Map<String, AuthProperties.LoginProviderSeed> providers) {
+        return new AuthProperties(
+            URI.create("http://localhost:8080"),
+            apiBasePath,
+            "hephaestus-spa",
+            Duration.ofMinutes(15),
+            "__Host-HEPHAESTUS_AT",
+            "",
+            Duration.ofHours(48),
+            providers,
+            List.of(),
+            "",
+            Duration.ofHours(1),
+            Duration.ofHours(12)
+        );
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthPropertiesFixture.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthPropertiesFixture.java
@@ -34,7 +34,7 @@ public final class AuthPropertiesFixture {
             apiBasePath,
             "hephaestus-spa",
             Duration.ofMinutes(15),
-            "__Host-HEPHAESTUS_AT",
+            AuthProperties.DEFAULT_COOKIE_NAME,
             "",
             Duration.ofHours(48),
             providers,

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthPropertiesTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/AuthPropertiesTest.java
@@ -1,0 +1,33 @@
+package de.tum.cit.aet.hephaestus.core.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * {@code apiBasePath} feeds string-concatenated OAuth URLs ({@code {baseUrl}} + path + callback), so a
+ * stray missing/duplicated slash silently breaks login. Pin the constructor normalization that makes
+ * {@code api}, {@code /api} and {@code /api/} equivalent and collapses blank/{@code /} to root.
+ */
+class AuthPropertiesTest extends BaseUnitTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+            "/api | /api",
+            "api | /api",
+            "/api/ | /api",
+            "/api/v2/ | /api/v2",
+            "'' | ''",
+            "/ | ''",
+            "'  /api/  ' | /api",
+        },
+        delimiterString = "|",
+        emptyValue = ""
+    )
+    void apiBasePath_isNormalizedToLeadingSlashNoTrailingSlash(String raw, String expected) {
+        assertThat(AuthPropertiesFixture.withApiBasePath(raw).apiBasePath()).isEqualTo(expected);
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/CookieBearerTokenResolverTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/CookieBearerTokenResolverTest.java
@@ -30,6 +30,7 @@ class CookieBearerTokenResolverTest extends BaseUnitTest {
     void setUp() {
         AuthProperties properties = new AuthProperties(
             URI.create("http://localhost:8080"),
+            "",
             "hephaestus-spa",
             Duration.ofMinutes(15),
             COOKIE_NAME,

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/CookieBearerTokenResolverTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/CookieBearerTokenResolverTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
 import de.tum.cit.aet.hephaestus.core.auth.AuthPropertiesFixture;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import jakarta.servlet.http.Cookie;
@@ -18,7 +19,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
  */
 class CookieBearerTokenResolverTest extends BaseUnitTest {
 
-    private static final String COOKIE_NAME = "__Host-HEPHAESTUS_AT";
+    private static final String COOKIE_NAME = AuthProperties.DEFAULT_COOKIE_NAME;
     private static final String COOKIE_TOKEN = "cookie-token-trusted";
     private static final String HEADER_TOKEN = "attacker-token-hostile";
 
@@ -26,7 +27,6 @@ class CookieBearerTokenResolverTest extends BaseUnitTest {
 
     @BeforeEach
     void setUp() {
-        // Fixture cookie-name matches COOKIE_NAME (the value this test writes into the request cookie).
         resolver = new CookieBearerTokenResolver(AuthPropertiesFixture.defaults());
     }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/CookieBearerTokenResolverTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/jwt/CookieBearerTokenResolverTest.java
@@ -2,11 +2,9 @@ package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
+import de.tum.cit.aet.hephaestus.core.auth.AuthPropertiesFixture;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import jakarta.servlet.http.Cookie;
-import java.net.URI;
-import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -28,21 +26,8 @@ class CookieBearerTokenResolverTest extends BaseUnitTest {
 
     @BeforeEach
     void setUp() {
-        AuthProperties properties = new AuthProperties(
-            URI.create("http://localhost:8080"),
-            "",
-            "hephaestus-spa",
-            Duration.ofMinutes(15),
-            COOKIE_NAME,
-            "",
-            Duration.ofHours(48),
-            java.util.Map.of(),
-            java.util.List.of(),
-            "",
-            Duration.ofHours(1),
-            Duration.ofHours(12)
-        );
-        resolver = new CookieBearerTokenResolver(properties);
+        // Fixture cookie-name matches COOKIE_NAME (the value this test writes into the request cookie).
+        resolver = new CookieBearerTokenResolver(AuthPropertiesFixture.defaults());
     }
 
     @Test

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginControllerLinkTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginControllerLinkTest.java
@@ -6,11 +6,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.CookieBearerTokenResolver;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.RevocationAwareJwtDecoder;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import jakarta.servlet.http.Cookie;
+import java.net.URI;
 import java.security.SecureRandom;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -28,6 +31,7 @@ import org.springframework.web.servlet.view.RedirectView;
  */
 class AuthBeginControllerLinkTest extends BaseUnitTest {
 
+    private ClientRegistrationRepository registrations;
     private CookieBearerTokenResolver bearerTokenResolver;
     private RevocationAwareJwtDecoder jwtDecoder;
     private AuthIntentCookie authIntentCookie;
@@ -35,14 +39,41 @@ class AuthBeginControllerLinkTest extends BaseUnitTest {
 
     @BeforeEach
     void setUp() {
-        ClientRegistrationRepository registrations = mock(ClientRegistrationRepository.class);
+        registrations = mock(ClientRegistrationRepository.class);
         when(registrations.findByRegistrationId(any())).thenReturn(githubRegistration());
         bearerTokenResolver = mock(CookieBearerTokenResolver.class);
         jwtDecoder = mock(RevocationAwareJwtDecoder.class);
         byte[] key = new byte[32];
         new SecureRandom().nextBytes(key);
         authIntentCookie = new AuthIntentCookie(key);
-        controller = new AuthBeginController(registrations, authIntentCookie, bearerTokenResolver, jwtDecoder);
+        controller = buildController("");
+    }
+
+    private AuthBeginController buildController(String apiBasePath) {
+        return new AuthBeginController(
+            registrations,
+            authIntentCookie,
+            bearerTokenResolver,
+            jwtDecoder,
+            authProperties(apiBasePath)
+        );
+    }
+
+    private static AuthProperties authProperties(String apiBasePath) {
+        return new AuthProperties(
+            URI.create("http://localhost:8080"),
+            apiBasePath,
+            "hephaestus-spa",
+            Duration.ofMinutes(15),
+            "__Host-HEPHAESTUS_AT",
+            "",
+            Duration.ofHours(48),
+            java.util.Map.of(),
+            java.util.List.of(),
+            "",
+            Duration.ofHours(1),
+            Duration.ofHours(12)
+        );
     }
 
     private static ClientRegistration githubRegistration() {
@@ -117,5 +148,19 @@ class AuthBeginControllerLinkTest extends BaseUnitTest {
         AuthIntentCookie.Intent intent = readIntent(res);
         assertThat(intent.mode()).isEqualTo(AuthIntentCookie.Intent.Mode.LOGIN);
         verifyNoInteractions(jwtDecoder);
+    }
+
+    @Test
+    void initRedirect_carriesApiBasePath_soItLandsOnTheProxiedEndpointNotTheSpa() {
+        RedirectView view = buildController("/api").begin(
+            "github",
+            "ws",
+            "/",
+            "login",
+            new MockHttpServletRequest(),
+            new MockHttpServletResponse()
+        );
+
+        assertThat(view.getUrl()).isEqualTo("/api/oauth2/authorization/github");
     }
 }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginControllerLinkTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginControllerLinkTest.java
@@ -6,14 +6,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
+import de.tum.cit.aet.hephaestus.core.auth.AuthPropertiesFixture;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.CookieBearerTokenResolver;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.RevocationAwareJwtDecoder;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import jakarta.servlet.http.Cookie;
-import java.net.URI;
 import java.security.SecureRandom;
-import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -55,24 +53,7 @@ class AuthBeginControllerLinkTest extends BaseUnitTest {
             authIntentCookie,
             bearerTokenResolver,
             jwtDecoder,
-            authProperties(apiBasePath)
-        );
-    }
-
-    private static AuthProperties authProperties(String apiBasePath) {
-        return new AuthProperties(
-            URI.create("http://localhost:8080"),
-            apiBasePath,
-            "hephaestus-spa",
-            Duration.ofMinutes(15),
-            "__Host-HEPHAESTUS_AT",
-            "",
-            Duration.ofHours(48),
-            java.util.Map.of(),
-            java.util.List.of(),
-            "",
-            Duration.ofHours(1),
-            Duration.ofHours(12)
+            AuthPropertiesFixture.withApiBasePath(apiBasePath)
         );
     }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderClientRegistrationRepositoryTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderClientRegistrationRepositoryTest.java
@@ -51,7 +51,8 @@ class LoginProviderClientRegistrationRepositoryTest extends BaseUnitTest {
         );
 
         List<ClientRegistration> registrations = new LoginProviderClientRegistrationRepository(
-            repo
+            repo,
+            ""
         ).listRegistrations();
 
         assertThat(registrations).hasSize(2);
@@ -72,12 +73,34 @@ class LoginProviderClientRegistrationRepositoryTest extends BaseUnitTest {
             Optional.of(provider("gitlab-lrz", LoginProvider.ProviderType.GITLAB, "https://gitlab.lrz.de", "openid"))
         );
 
-        ClientRegistration reg = new LoginProviderClientRegistrationRepository(repo).findByRegistrationId("gitlab-lrz");
+        ClientRegistration reg = new LoginProviderClientRegistrationRepository(repo, "").findByRegistrationId(
+            "gitlab-lrz"
+        );
 
         assertThat(reg.getProviderDetails().getAuthorizationUri()).isEqualTo("https://gitlab.lrz.de/oauth/authorize");
         assertThat(reg.getProviderDetails().getTokenUri()).isEqualTo("https://gitlab.lrz.de/oauth/token");
         assertThat(reg.getProviderDetails().getUserInfoEndpoint().getUri()).isEqualTo(
             "https://gitlab.lrz.de/api/v4/user"
         );
+    }
+
+    @Test
+    void redirectUri_carriesTheConfiguredApiBasePath() {
+        LoginProviderRepository repo = mock(LoginProviderRepository.class);
+        when(repo.findByRegistrationId("github")).thenReturn(
+            Optional.of(provider("github", LoginProvider.ProviderType.GITHUB, "https://github.com", "read:user"))
+        );
+
+        // Behind a proxy that strips /api, the redirect_uri the IdP gets must re-add it so the callback
+        // lands on the proxied API path, not the SPA. {baseUrl} is expanded by Spring at request time.
+        ClientRegistration prefixed = new LoginProviderClientRegistrationRepository(repo, "/api").findByRegistrationId(
+            "github"
+        );
+        assertThat(prefixed.getRedirectUri()).isEqualTo("{baseUrl}/api/login/oauth2/code/{registrationId}");
+
+        ClientRegistration root = new LoginProviderClientRegistrationRepository(repo, "").findByRegistrationId(
+            "github"
+        );
+        assertThat(root.getRedirectUri()).isEqualTo("{baseUrl}/login/oauth2/code/{registrationId}");
     }
 }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
 import de.tum.cit.aet.hephaestus.core.auth.AuthPropertiesFixture;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
@@ -9,10 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
+import de.tum.cit.aet.hephaestus.core.auth.AuthPropertiesFixture;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
-import java.net.URI;
-import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -32,21 +30,11 @@ class LoginProviderServiceTest extends BaseUnitTest {
     );
 
     private LoginProviderService service(Map<String, AuthProperties.LoginProviderSeed> providers) {
-        AuthProperties props = new AuthProperties(
-            URI.create("http://localhost:8080"),
-            "",
-            "hephaestus-spa",
-            Duration.ofMinutes(15),
-            "__Host-HEPHAESTUS_AT",
-            "",
-            Duration.ofHours(48),
-            providers,
-            List.of(),
-            "",
-            Duration.ofHours(1),
-            Duration.ofHours(12)
+        return new LoginProviderService(
+            repository,
+            registrationCache,
+            AuthPropertiesFixture.withLoginProviders(providers)
         );
-        return new LoginProviderService(repository, registrationCache, props);
     }
 
     private LoginProviderService adminService() {

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderServiceTest.java
@@ -34,6 +34,7 @@ class LoginProviderServiceTest extends BaseUnitTest {
     private LoginProviderService service(Map<String, AuthProperties.LoginProviderSeed> providers) {
         AuthProperties props = new AuthProperties(
             URI.create("http://localhost:8080"),
+            "",
             "hephaestus-spa",
             Duration.ofMinutes(15),
             "__Host-HEPHAESTUS_AT",

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminControllerCallbackTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminControllerCallbackTest.java
@@ -1,0 +1,66 @@
+package de.tum.cit.aet.hephaestus.core.auth.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.hephaestus.core.auth.AuthPropertiesFixture;
+import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProvider;
+import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProviderService;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Pins the admin-facing callback URL — the value an operator copies into the upstream OAuth app — so it
+ * carries the proxy-stripped API prefix exactly like the live {@code redirect_uri} does. Without this the
+ * displayed URL silently drifts to the un-prefixed (SPA) path and every self-hosted-GitLab wiring fails.
+ */
+class LoginProviderAdminControllerCallbackTest extends BaseUnitTest {
+
+    @AfterEach
+    void clearRequestContext() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void displayedCallback_carriesApiBasePath_behindAStrippingProxy() {
+        String redirectUri = redirectUriFor("/api");
+        assertThat(redirectUri).isEqualTo("https://hephaestus.example/api/login/oauth2/code/github");
+    }
+
+    @Test
+    void displayedCallback_hasNoPrefix_whenServedAtRoot() {
+        String redirectUri = redirectUriFor("");
+        assertThat(redirectUri).isEqualTo("https://hephaestus.example/login/oauth2/code/github");
+    }
+
+    private static String redirectUriFor(String apiBasePath) {
+        LoginProviderService service = mock(LoginProviderService.class);
+        when(service.listAll()).thenReturn(List.of(provider()));
+        var controller = new LoginProviderAdminController(service, AuthPropertiesFixture.withApiBasePath(apiBasePath));
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("https");
+        request.setServerName("hephaestus.example");
+        request.setServerPort(443);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        return controller.list().getBody().getFirst().redirectUri();
+    }
+
+    private static LoginProvider provider() {
+        LoginProvider p = new LoginProvider();
+        p.setRegistrationId("github");
+        p.setType(LoginProvider.ProviderType.GITHUB);
+        p.setDisplayName("GitHub");
+        p.setBaseUrl("https://github.com");
+        p.setScopes("read:user");
+        p.setEnabled(true);
+        return p;
+    }
+}


### PR DESCRIPTION
## Problem

Behind the production reverse proxy, Traefik strips `/api` before the request reaches the app, and prod runs `forward-headers-strategy: native` (Tomcat `RemoteIpValve`) — chosen for the pre-auth IP rate-limit trust model (`ProxyTrustGuard`), which restores forwarded host/proto but **not** `X-Forwarded-Prefix`. So Spring builds the browser-facing OAuth URLs from `{baseUrl}` = `https://host` (no `/api`):

- the authorization-request **`redirect_uri`** → `https://host/login/oauth2/code/github`
- the SPA's `/api/auth/login` → `AuthBeginController` **init redirect** → `/oauth2/authorization/github`

Both land at `https://host/...` (no `/api`) → routed to the **webapp SPA**, not the app-server. Result: **GitHub/GitLab login cannot complete** in any path-stripped deployment (the callback 404s on the SPA). The admin "register this callback URL" hint had the same defect.

Found while cutting staging over to native auth.

## Fix

Add `hephaestus.auth.api-base-path` (default `""`; prod `/api`) — the public path prefix the proxy strips — and prepend it when constructing the three browser-facing OAuth URLs:

1. `LoginProviderClientRegistrationRepository` — the `redirect_uri` template (`{baseUrl}` + prefix + `/login/oauth2/code/{registrationId}`).
2. `AuthBeginController` — the `/oauth2/authorization/{id}` init redirect. (The `/auth/error` targets stay unprefixed — they're SPA routes at the origin root, like the success/failure handlers' `appBaseUrl` redirects.)
3. `LoginProviderAdminController` — the displayed callback URL (also de-duplicated three inline builders into one `callbackBase()` helper).

`{baseUrl}` is kept (per-request origin via native forward-headers); only the missing prefix is injected. Local dev (`""`) is unchanged: the SPA hits `:8080` directly with no strip.

### Why not `X-Forwarded-Prefix` / `forward-headers-strategy: framework`?
That's the usual fix, but it would swap Tomcat's `RemoteIpValve` for Spring's `ForwardedHeaderFilter`, which doesn't carry the `internal-proxies` trust-regex that `ProxyTrustGuard` + `AuthRateLimitFilter` depend on for pre-auth IP rate limiting — a security regression. The explicit configured prefix is deterministic and keeps the trust model intact.

## Tests
- `LoginProviderClientRegistrationRepositoryTest`: redirect_uri carries the configured prefix (`/api` and empty).
- `AuthBeginControllerLinkTest`: init redirect carries the prefix.
- Existing `LoginProviderAdminControllerIntegrationTest` `endsWith` assertion holds (default prefix `""`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth endpoints and initiation redirects now honor a configurable API base path so browser-facing auth URLs include the proxy path prefix.

* **Configuration**
  * Production config adds an explicit API base path setting (example: /api) for proxy deployments.

* **Tests**
  * Added/updated unit tests and fixtures to verify base-path normalization and that redirect URLs include or omit the prefix as configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->