### PR TITLE
fix(server): gate the user-facing web/auth layer to the server runtime role

### DIFF
--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -301,7 +301,8 @@ services:
       DATABASE_PASSWORD: root
       # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.
       HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
-      # ApplicationProperties.hostUrl (link building in agent context) validates on every role.
+      # application-prod.yml sets host-url=${APPLICATION_HOST_URL} (no default), so a blank value fails
+      # ApplicationProperties' @URL check at boot; the agent context also builds links from it.
       APPLICATION_HOST_URL: https://${APP_HOSTNAME}
       # thc healthcheck target: actuator liveness on the management port (still :8080 though server.port=-1).
       THC_PORT: "8080"

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -294,6 +294,15 @@ services:
       HEPHAESTUS_WORKER_CAPACITY_MENTOR_MAX: ${HEPHAESTUS_WORKER_MENTOR_MAX:-auto}
       HEPHAESTUS_WORKER_DRAIN_TIMEOUT: ${HEPHAESTUS_WORKER_DRAIN_TIMEOUT:-5m}
       SENTRY_DSN: ${SENTRY_DSN}
+      # Persistence for the JPA layer the worker shares (connection-credential AttributeConverter,
+      # workspace/agent context). The auth web layer is gated off this role, so no auth env is needed.
+      DATABASE_URL: postgresql://postgres:5432/hephaestus
+      DATABASE_USERNAME: root
+      DATABASE_PASSWORD: root
+      # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.
+      HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
+      # ApplicationProperties.hostUrl (link building in agent context) validates on every role.
+      APPLICATION_HOST_URL: https://${APP_HOSTNAME}
       # thc healthcheck target: actuator liveness on the management port (still :8080 though server.port=-1).
       THC_PORT: "8080"
       THC_PATH: /actuator/health/liveness

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -301,8 +301,8 @@ services:
       DATABASE_PASSWORD: root
       # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.
       HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
-      # application-prod.yml sets host-url=${APPLICATION_HOST_URL} (no default), so a blank value fails
-      # ApplicationProperties' @URL check at boot; the agent context also builds links from it.
+      # application-prod.yml binds host-url=${APPLICATION_HOST_URL} with no YAML default; compose always
+      # supplies it so the agent context builds links from a real origin (an unset var fails the boot).
       APPLICATION_HOST_URL: https://${APP_HOSTNAME}
       # thc healthcheck target: actuator liveness on the management port (still :8080 though server.port=-1).
       THC_PORT: "8080"

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -31,7 +31,8 @@ services:
       DATABASE_PASSWORD: root
       # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.
       HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
-      # ApplicationProperties.hostUrl validates on every role.
+      # application-prod.yml sets host-url=${APPLICATION_HOST_URL} (no default), so a blank value fails
+      # ApplicationProperties' @URL check at boot.
       APPLICATION_HOST_URL: https://${APP_HOSTNAME}
       SENTRY_DSN: ${SENTRY_DSN}
       # forward-headers=native (application-prod.yml) → ProxyTrustGuard fails the boot unless pinned.

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -24,11 +24,15 @@ services:
       # WEBHOOK_EXTERNAL_URL is only used by auto-registration (server role) and is intentionally
       # not set on the webhook-server pod.
       WEBHOOK_SECRET: ${WEBHOOK_SECRET}
-      # DataSource kept until the workspace-context filter is made optional on this profile —
-      # the receiver itself never writes to the DB. Tracked as residual debt in ADR 0008.
+      # DataSource for the JPA layer (the connection-credential AttributeConverter that the HMAC
+      # path reads); the auth web layer and workspace-context filter are gated off this role.
       DATABASE_URL: postgresql://postgres:5432/hephaestus
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: root
+      # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.
+      HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
+      # ApplicationProperties.hostUrl validates on every role.
+      APPLICATION_HOST_URL: https://${APP_HOSTNAME}
       SENTRY_DSN: ${SENTRY_DSN}
       # forward-headers=native (application-prod.yml) → ProxyTrustGuard fails the boot unless pinned.
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-}

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -31,8 +31,8 @@ services:
       DATABASE_PASSWORD: root
       # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.
       HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
-      # application-prod.yml sets host-url=${APPLICATION_HOST_URL} (no default), so a blank value fails
-      # ApplicationProperties' @URL check at boot.
+      # application-prod.yml binds host-url=${APPLICATION_HOST_URL} with no YAML default; compose always
+      # supplies it (an unset var fails the boot at placeholder resolution).
       APPLICATION_HOST_URL: https://${APP_HOSTNAME}
       SENTRY_DSN: ${SENTRY_DSN}
       # forward-headers=native (application-prod.yml) → ProxyTrustGuard fails the boot unless pinned.

--- a/docker/preview/.env.example
+++ b/docker/preview/.env.example
@@ -30,6 +30,8 @@ WEBHOOK_SECRET=
 # Auth (Hephaestus-native — no Keycloak; ADR 0017)
 # Base64 32-byte AES key for OAuth state cookies. Generate: openssl rand -base64 32
 HEPHAESTUS_AUTH_STATE_COOKIE_KEY=
+# Exactly 32 chars — AES key for credential encryption (used by every pod, incl. the webhook receiver).
+HEPHAESTUS_SECURITY_ENCRYPTION_KEY=
 # GitHub OAuth App; callback https://<preview-domain>/api/login/oauth2/code/github
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=

--- a/docker/preview/compose.shared-infra.yaml
+++ b/docker/preview/compose.shared-infra.yaml
@@ -80,7 +80,7 @@ services:
       # EncryptedStringConverter / CredentialBundleConverter are eager prod-fail-fast @Component
       # converters that load on this server-off pod too; they need the key at construction.
       HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY:?Required}
-      # application-prod.yml sets host-url=${APPLICATION_HOST_URL} (no default) → @URL validation fails on a blank value.
+      # application-prod.yml binds host-url=${APPLICATION_HOST_URL} with no YAML default; :?Required pins it.
       APPLICATION_HOST_URL: ${APPLICATION_HOST_URL:?Required}
       # prod runs forward-headers=native → ProxyTrustGuard aborts the boot unless set (Coolify ingress regex).
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:?Required}

--- a/docker/preview/compose.shared-infra.yaml
+++ b/docker/preview/compose.shared-infra.yaml
@@ -77,6 +77,11 @@ services:
       HEPHAESTUS_SYNC_NATS_ENABLED: "true"
       HEPHAESTUS_SYNC_NATS_SERVER: "nats://nats-server:4222"
       WEBHOOK_SECRET: ${WEBHOOK_SECRET:?Required}
+      # EncryptedStringConverter / CredentialBundleConverter are eager prod-fail-fast @Component
+      # converters that load on this server-off pod too; they need the key at construction.
+      HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY:?Required}
+      # application-prod.yml sets host-url=${APPLICATION_HOST_URL} (no default) → @URL validation fails on a blank value.
+      APPLICATION_HOST_URL: ${APPLICATION_HOST_URL:?Required}
       # prod runs forward-headers=native → ProxyTrustGuard aborts the boot unless set (Coolify ingress regex).
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:?Required}
       # Previews run non-release images with no release-pin, so don't require a digest-pinned agent image.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/SecurityConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/SecurityConfig.java
@@ -145,7 +145,7 @@ public class SecurityConfig {
         ObjectProvider<BearerTokenResolver> bearerTokenResolverProvider,
         ObjectProvider<StaleAuthCookieFilter> staleAuthCookieFilterProvider,
         Converter<Jwt, AbstractAuthenticationToken> authenticationConverter,
-        AuthRateLimitFilter authRateLimitFilter,
+        ObjectProvider<AuthRateLimitFilter> authRateLimitFilterProvider,
         tools.jackson.databind.ObjectMapper objectMapper
     ) throws Exception {
         http
@@ -233,8 +233,12 @@ public class SecurityConfig {
         // Token-bucket rate limiting on the hot auth endpoints (/auth/refresh, /auth/impersonate,
         // DELETE /user). Registered after authentication so the account principal is resolvable;
         // it no-ops on every other path. /oauth2/authorization/* is rate-limited on the oauth2Login
-        // chain (AuthSecurityConfig), which owns that path.
-        http.addFilterBefore(authRateLimitFilter, AuthorizationFilter.class);
+        // chain (AuthSecurityConfig), which owns that path. Resolved via ObjectProvider: the filter
+        // is server-role-gated, so a non-server pod refreshes this chain without it.
+        AuthRateLimitFilter authRateLimitFilter = authRateLimitFilterProvider.getIfAvailable();
+        if (authRateLimitFilter != null) {
+            http.addFilterBefore(authRateLimitFilter, AuthorizationFilter.class);
+        }
 
         // Read-only-by-default enforcement for impersonation sessions (JWT carries an `act`
         // claim). Registered AFTER the AuthorizationFilter so the SecurityContext already holds

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountBootstrapService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountBootstrapService.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEvent;
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEventLogger;
 import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import org.springframework.web.server.ResponseStatusException;
  * it covers the case where the operator cannot predict an identity ahead of time, and guards against
  * zero-admin lockout.
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("Instance-admin bootstrap is account-scoped; not workspace-scoped")
 public class AccountBootstrapService {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountHardDeleteSweeper.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountHardDeleteSweeper.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.springframework.stereotype.Component;
  * row is no longer {@code DELETING}, and the child deletes are unconditional {@code DELETE ... WHERE
  * account_id = ?}.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("Account hard-delete is account-scoped; the sweep is global, not tenant data")
 public class AccountHardDeleteSweeper {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountPurger.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountPurger.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.core.auth;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
 import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
  * reason {@code AuthEventWriter} is split from {@code AuthEventLogger}). Each account purges in its own
  * transaction so one bad row never blocks the rest of the GDPR erasure backlog.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("Account hard-delete is account-scoped; the sweep is global, not tenant data")
 public class AccountPurger {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AccountService.java
@@ -9,6 +9,7 @@ import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLink;
 import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLinkRepository;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwt;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwtRepository;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
@@ -24,6 +25,7 @@ import org.springframework.web.server.ResponseStatusException;
  * controllers. Owns the data-layer access so the controllers stay thin and never touch a
  * repository directly (enforced by {@code ArchitectureTest.controllersDoNotAccessRepositories}).
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("Account operations are user/system-scoped, not workspace-scoped")
 public class AccountService {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/AuthSessionService.java
@@ -11,6 +11,7 @@ import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwt.RevokedReason;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwtRepository;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtPrincipalFactory;
 import de.tum.cit.aet.hephaestus.core.auth.metrics.AuthMetrics;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Timer;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
  * set/clear of the {@code __Host-} cookie. Extracted from {@code AuthLifecycleController}
  * so the controller stays thin (≤5 deps) and the cookie/JWT mechanics live in one place.
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("Session lifecycle is account-scoped, not workspace-scoped")
 public class AuthSessionService {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthAuditService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthAuditService.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.core.auth.audit;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
 import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.Map;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * so the viewer shows names/emails rather than bare primary keys. Audit rows outlive accounts (deletion,
  * GDPR redaction), so a missing account resolves to {@code null} and the UI falls back to the id.
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("Auth audit events are account/system-scoped, not workspace-scoped")
 public class AuthAuditService {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventLogger.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventLogger.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.audit;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
  * authEventLogger.event(LOGIN, SUCCESS).account(accountId).gitProvider(providerId).record();
  * }</pre>
  */
+@ConditionalOnServerRole
 @Component
 public class AuthEventLogger {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventPartitionMaintenance.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventPartitionMaintenance.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.audit;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
  * {@code @Scheduled} (via {@code ServerSchedulingConfig}) + ShedLock so one replica runs it. Replaces
  * the bespoke {@code AuthEventPartitionManager} (ADR 0018).
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("auth_event is account/system-scoped; partition maintenance is global, not tenant data")
 public class AuthEventPartitionMaintenance {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventSequence.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventSequence.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.audit;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@code (id, occurred_at)} means Hibernate can't auto-generate the id, so we pull from the
  * sequence explicitly and assign client-side.
  */
+@ConditionalOnServerRole
 @Component
 public class AuthEventSequence {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventWriter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/audit/AuthEventWriter.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.audit;
 
 import de.tum.cit.aet.hephaestus.core.auth.metrics.AuthMetrics;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import org.jspecify.annotations.Nullable;
@@ -20,6 +21,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  * <p>Allocates the id from the sequence, captures request IP + user agent, persists.
  * Swallows its own failures: an audit write must never break the business flow.
  */
+@ConditionalOnServerRole
 @Component
 public class AuthEventWriter {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthJwtConfig.java
@@ -5,6 +5,7 @@ import de.tum.cit.aet.hephaestus.core.auth.jwt.CookieBearerTokenResolver;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwtRepository;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtSigningKeyService;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.RevocationAwareJwtDecoder;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.security.StaleAuthCookieFilter;
 import jakarta.annotation.PostConstruct;
 import java.time.Clock;
@@ -28,6 +29,7 @@ import org.springframework.security.oauth2.server.resource.web.BearerTokenResolv
  * <h2>{@link Clock} bean</h2>
  * A local {@code @Bean} so the issuer/decoder can be tested against a fixed {@link Clock}.
  */
+@ConditionalOnServerRole
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
 public class AuthJwtConfig {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthSecurityConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/config/AuthSecurityConfig.java
@@ -7,6 +7,7 @@ import de.tum.cit.aet.hephaestus.core.auth.oauth.GitHubEmailOAuth2UserService;
 import de.tum.cit.aet.hephaestus.core.auth.oauth.HephaestusAuthFailureHandler;
 import de.tum.cit.aet.hephaestus.core.auth.oauth.HephaestusAuthSuccessHandler;
 import de.tum.cit.aet.hephaestus.core.auth.ratelimit.AuthRateLimitFilter;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.security.SecurityHeaders;
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -57,6 +58,7 @@ import org.springframework.security.web.access.intercept.AuthorizationFilter;
  * validates our own ES256 JWTs via {@code RevocationAwareJwtDecoder} (replaces the former
  * Keycloak setup; ADR 0017).
  */
+@ConditionalOnServerRole
 @Configuration
 public class AuthSecurityConfig {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/AccountExportService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/AccountExportService.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEvent;
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEventLogger;
 import de.tum.cit.aet.hephaestus.core.auth.export.dto.ExportStatusDTO;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
  * request returns 202 immediately; the client polls {@link #status}. The post-commit handoff
  * guarantees the worker (a new transaction) sees the committed row.
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("GDPR exports are account-scoped, spanning a principal's data across workspaces")
 public class AccountExportService {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportBundleAssembler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportBundleAssembler.java
@@ -9,6 +9,7 @@ import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLink;
 import de.tum.cit.aet.hephaestus.core.auth.spi.AccountPreferencesQuery;
 import de.tum.cit.aet.hephaestus.core.auth.spi.AccountWorkspaceMembershipQuery;
 import de.tum.cit.aet.hephaestus.core.auth.spi.GitProviderRegistry;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -40,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
  * blobs, JWT signing keys, password-equivalents (there are none in this system), and any other
  * account's data are structurally excluded — there is no code path here that reads them.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("GDPR export aggregates an account's own data across workspaces; not workspace-scoped")
 public class ExportBundleAssembler {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorker.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportGenerationWorker.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.export;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -22,6 +23,7 @@ import tools.jackson.databind.ObjectMapper;
  * waits for in-flight DB work on shutdown — see {@code SpringAsyncConfig}); under
  * {@code spring.threads.virtual.enabled} each task still runs on a managed thread.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("GDPR export generation operates on a single account's data; not workspace-scoped")
 public class ExportGenerationWorker {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeper.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/export/ExportRetentionSweeper.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.export;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
 import java.time.Instant;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
  * server role), and wrapped in {@link SchedulerLock} so concurrent server pods don't both run the
  * sweep — the same pattern as {@code OAuthStateNonceCleanupJob}.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("Pruning account-scoped, workspace-agnostic export rows")
 public class ExportRetentionSweeper {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/impersonation/ImpersonationService.java
@@ -9,6 +9,7 @@ import de.tum.cit.aet.hephaestus.core.auth.jwt.HephaestusJwtIssuer;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwt;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.IssuedJwtRepository;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtPrincipalFactory;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.Instant;
@@ -35,6 +36,7 @@ import tools.jackson.databind.ObjectMapper;
  * acting_account_id=operator)} pair so every action taken under impersonation is
  * attributable to the operator.
  */
+@ConditionalOnServerRole
 @Service
 public class ImpersonationService {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/HephaestusJwtIssuer.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/HephaestusJwtIssuer.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -43,6 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
  * same transaction. The {@code jti} is committed before the cookie is set on the response —
  * if the DB write fails, no JWT escapes.
  */
+@ConditionalOnServerRole
 @Service
 public class HephaestusJwtIssuer {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/IssuedJwtCleanupJob.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/IssuedJwtCleanupJob.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Clock;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
  * DELETE — same pattern as {@code OAuthStateNonceCleanupJob}. The {@code ix_issued_jwt_expires_at}
  * index backs the range delete.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("The revocation list is account-scoped, not workspace-scoped")
 public class IssuedJwtCleanupJob {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtPrincipalFactory.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtPrincipalFactory.java
@@ -6,6 +6,7 @@ import de.tum.cit.aet.hephaestus.core.auth.domain.AccountFeatureRepository;
 import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
 import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLink;
 import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLinkRepository;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.util.HashSet;
 import java.util.Set;
 import org.springframework.http.HttpStatus;
@@ -31,6 +32,7 @@ import org.springframework.web.server.ResponseStatusException;
  * discovery doc and {@code SecurityUtils.isSuperAdmin}) — deliberately distinct from the
  * per-workspace "admin" role, which is membership-derived and never appears in this token.
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("JWT principal assembly is account-scoped")
 public class JwtPrincipalFactory {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeySealer.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeySealer.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.jwt;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.security.EncryptionException;
 import de.tum.cit.aet.hephaestus.core.security.SecurityProperties;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +41,7 @@ import org.springframework.stereotype.Component;
  * absent key disables sealing so a local boot still works (writing raw {@code v0-unsealed}
  * rows). A non-32-char key is always rejected.
  */
+@ConditionalOnServerRole
 @Component
 public class JwtSigningKeySealer {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeyService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/jwt/JwtSigningKeyService.java
@@ -10,6 +10,7 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.security.KeyFactory;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
@@ -56,6 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
  * encode/decode. We resolve from an {@link AtomicReference}-cached {@link JWKSet}, refreshed from DB
  * on TTL expiry ({@value #CACHE_TTL_MILLIS} ms).
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("JWT signing keys are system-wide; get() returns the global JWK set, not tenant data")
 public class JwtSigningKeyService implements JWKSource<SecurityContext> {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthLoginEventMetrics.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthLoginEventMetrics.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.metrics;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
 import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
  * bearer-token filter — yields exactly the login-only success/failure signal with zero extra wiring
  * on the existing 6-dependency auth beans.
  */
+@ConditionalOnServerRole
 @Component
 public class AuthLoginEventMetrics {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthMetrics.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/metrics/AuthMetrics.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.metrics;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Component;
  * bounded tag. {@code auth.token.refresh} times the token-rotation critical section in
  * {@code AuthSessionService.refresh}.
  */
+@ConditionalOnServerRole
 @Component
 public class AuthMetrics {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AccountJitCreator.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AccountJitCreator.java
@@ -5,6 +5,7 @@ import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
 import de.tum.cit.aet.hephaestus.core.auth.domain.AccountRepository;
 import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLink;
 import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLinkRepository;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
  * DISTINCT bean (a self-invocation would bypass the proxy and NOT open a new tx), only the inner tx
  * rolls back; the caller's tx survives and can read-after-conflict for the winner's row.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("JIT account creation is user-scoped, keyed by (provider, subject)")
 public class AccountJitCreator {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AccountProvisioningService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AccountProvisioningService.java
@@ -8,6 +8,7 @@ import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLinkRepository;
 import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProvider;
 import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProviderRepository;
 import de.tum.cit.aet.hephaestus.core.auth.spi.GitProviderRegistry;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.time.Clock;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link IdentityLinkRepository#findActiveByProviderSubject}. Email is captured for
  * forensics only, never used to resolve an account.
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("Account provisioning is user-scoped, keyed by (provider, subject)")
 public class AccountProvisioningService {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AdminBootstrapPolicy.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AdminBootstrapPolicy.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.oauth;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -35,6 +36,7 @@ import org.springframework.stereotype.Component;
  * owns the (idempotent, promote-only) mutation inside the login transaction, so the role lands before
  * the JWT is minted. Empty/unset allowlist → fail-closed (no admin path exists).
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("Instance-admin bootstrap is keyed by (provider, identity); not workspace-scoped")
 public class AdminBootstrapPolicy {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/AuthBeginController.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.oauth;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,6 +28,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * to the IdP and is read by the success handler (later commit) to decide where to land
  * the user post-login.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/auth")
 public class AuthBeginController {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/HephaestusAuthFailureHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/HephaestusAuthFailureHandler.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.oauth;
 
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEvent;
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEventLogger;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
  * recorded reason is the exception TYPE only, never PII. Extracted from {@code AuthSecurityConfig}
  * (mirroring {@link HephaestusAuthSuccessHandler}) so the chain bean stays under the parameter limit.
  */
+@ConditionalOnServerRole
 @Component
 public class HephaestusAuthFailureHandler implements AuthenticationFailureHandler {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/HephaestusAuthSuccessHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/HephaestusAuthSuccessHandler.java
@@ -6,6 +6,7 @@ import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEventLogger;
 import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.HephaestusJwtIssuer;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtPrincipalFactory;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * <p>Account lookup is always {@code (provider, subject)} — never email (nOAuth defence).
  */
+@ConditionalOnServerRole
 @Component
 public class HephaestusAuthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/VerifiedEmailResolver.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/oauth/VerifiedEmailResolver.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.oauth;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
@@ -25,6 +26,7 @@ import org.springframework.stereotype.Component;
  * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html">OIDC Core §5.1</a>
  * @see <a href="https://docs.github.com/en/rest/users/emails">GitHub /user/emails</a>
  */
+@ConditionalOnServerRole
 @Component
 public class VerifiedEmailResolver {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderConfiguration.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.provider;
 
 import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
  * (Spring Security's {@code oauth2Login}), {@code IdentityProviderCatalog} (the discovery controller),
  * and {@code Iterable<ClientRegistration>}.
  */
+@ConditionalOnServerRole
 @Configuration
 public class LoginProviderConfiguration {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/provider/LoginProviderService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.provider;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import de.tum.cit.aet.hephaestus.core.auth.AuthProperties;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.security.ServerUrlValidator;
 import java.util.HashSet;
 import java.util.List;
@@ -34,6 +35,7 @@ import org.springframework.web.server.ResponseStatusException;
  * <p>Every mutation evicts the {@link LoginProviderClientRegistrationRepository} cache so an admin's
  * edit/enable/disable takes effect immediately rather than after the 60s TTL.
  */
+@ConditionalOnServerRole
 @Service
 @WorkspaceAgnostic("Login providers are instance-global, not workspace-scoped")
 public class LoginProviderService {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/ratelimit/AuthRateLimitConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/ratelimit/AuthRateLimitConfig.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.core.auth.ratelimit;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
 import io.github.bucket4j.distributed.jdbc.PrimaryKeyMapper;
 import io.github.bucket4j.distributed.proxy.ProxyManager;
@@ -36,6 +37,7 @@ import tools.jackson.databind.ObjectMapper;
  * acceptable for those non-production contexts but would be a regression in a multi-replica
  * production deployment — production MUST run Postgres-backed. The active mode is logged at startup.
  */
+@ConditionalOnServerRole
 @Configuration
 public class AuthRateLimitConfig {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountAdminController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountAdminController.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import de.tum.cit.aet.hephaestus.core.auth.AccountService;
 import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
  * adapter over {@link AccountService}. Access JWTs are short-lived (~15m) and refresh re-derives
  * roles from the DB, so no legacy-authority grace is carried in code.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/admin/users")
 @Tag(name = "Admin", description = "Instance-admin account management")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountBootstrapController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountBootstrapController.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import de.tum.cit.aet.hephaestus.core.auth.AccountBootstrapService;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
  * OpenAPI spec — it is an operator lever, not part of the public client surface.
  */
 @Hidden
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/auth")
 public class AccountBootstrapController {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountExportController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountExportController.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.hephaestus.core.auth.export.AccountExport;
 import de.tum.cit.aet.hephaestus.core.auth.export.AccountExportService;
 import de.tum.cit.aet.hephaestus.core.auth.export.dto.ExportCreatedDTO;
 import de.tum.cit.aet.hephaestus.core.auth.export.dto.ExportStatusDTO;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
@@ -29,6 +30,7 @@ import org.springframework.web.server.ResponseStatusException;
  * read is scoped to that account, and a foreign export id yields 404 (never 403) to avoid
  * enumeration.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/user/exports")
 @Tag(name = "Account", description = "GDPR Art. 20 self-service data export")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountWebController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AccountWebController.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.hephaestus.core.auth.AccountService;
 import de.tum.cit.aet.hephaestus.core.auth.domain.Account;
 import de.tum.cit.aet.hephaestus.core.auth.domain.IdentityLink;
 import de.tum.cit.aet.hephaestus.core.auth.spi.GitProviderRegistry;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -26,6 +27,7 @@ import org.springframework.web.server.ResponseStatusException;
  * The current-user singleton: identity, linked accounts, and GDPR account deletion.
  * Thin HTTP adapter — all data access lives in {@link AccountService}.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/user")
 @Tag(name = "Account", description = "Current user identity, linked accounts, deletion")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthAuditController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthAuditController.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthAuditService;
 import de.tum.cit.aet.hephaestus.core.auth.audit.AuthEvent;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Guarded by the namespaced {@code app_admin} authority. Surfaces the {@code (account_id,
  * acting_account_id)} pair so impersonated actions stay attributable to their operator.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/admin/audit")
 @Tag(name = "Admin", description = "Instance-admin account management")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthLifecycleController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/AuthLifecycleController.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import de.tum.cit.aet.hephaestus.core.auth.AuthSessionService;
 import de.tum.cit.aet.hephaestus.core.auth.impersonation.ImpersonationService;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
  * session control — identity reads live on {@code /user}. Cookie + JWT mechanics are
  * delegated to {@link AuthSessionService} so this controller stays thin.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/auth")
 @Tag(name = "Auth", description = "Session lifecycle")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/IdentityProviderDiscoveryController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/IdentityProviderDiscoveryController.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import de.tum.cit.aet.hephaestus.core.auth.spi.IdentityProviderCatalog;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>Lists every enabled instance-scoped {@code login_provider} (GitHub, GitLab.com, self-hosted
  * GitLab) — one shared registration per provider, reused across all workspaces.
  */
+@ConditionalOnServerRole
 @RestController
 @Tag(name = "Auth discovery", description = "Identity provider discovery (public)")
 public class IdentityProviderDiscoveryController {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/LoginProviderAdminController.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProvider;
 import de.tum.cit.aet.hephaestus.core.auth.provider.LoginProviderService;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -35,6 +36,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
  * {@code redirectUri} the admin must register on the upstream OAuth app — the single most error-prone
  * step when wiring a self-hosted GitLab.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/admin/login-providers")
 @Tag(name = "Admin", description = "Instance-admin login provider management")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/SessionWebController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/SessionWebController.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import de.tum.cit.aet.hephaestus.core.auth.AuthSessionService;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Active-session inventory + revocation. Each non-revoked, non-expired issued JWT for the
  * current account is a "session". Thin adapter over {@link AuthSessionService}.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/user/sessions")
 @Tag(name = "Account", description = "Active sessions")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/WellKnownController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/auth/web/WellKnownController.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.hephaestus.core.auth.web;
 
 import com.nimbusds.jose.jwk.JWKSet;
 import de.tum.cit.aet.hephaestus.core.auth.jwt.JwtSigningKeyService;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Map;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  * {@code /.well-known/openid-configuration} discovery document will be added if/when a relying
  * party — Spring Authorization Server, a worker/CLI verifier — is actually mounted.)
  */
+@ConditionalOnServerRole
 @RestController
 @Tag(name = "Auth discovery", description = "Public JWK set for verifying Hephaestus session JWTs")
 public class WellKnownController {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/ConditionalOnServerRole.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/ConditionalOnServerRole.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.hephaestus.core.runtime;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * Gates a bean to the SERVER runtime role. Composed from
+ * {@code @ConditionalOnProperty(name = hephaestus.runtime.server.enabled, havingValue = "true",
+ * matchIfMissing = true)} so the {@code matchIfMissing} invariant (ADR 0005/0008) is declared once,
+ * at the source, instead of being repeated — and re-verified — on every gated class.
+ *
+ * <p>Applied to the user-facing web/auth surface (the whole {@code core.auth} module and
+ * {@link de.tum.cit.aet.hephaestus.workspace.context.WorkspaceContextFilter}). The worker and
+ * webhook pods set {@code hephaestus.runtime.server.enabled=false} and must not load any of it.
+ *
+ * <p>See {@link RuntimeRole#SERVER_PROPERTY} and {@code RuntimeRoleBoundaryTest}, which enforces that
+ * every {@code core.auth} stereotype bean carries this gate.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ConditionalOnProperty(name = RuntimeRole.SERVER_PROPERTY, havingValue = "true", matchIfMissing = true)
+public @interface ConditionalOnServerRole {}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/RuntimeRole.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/runtime/RuntimeRole.java
@@ -22,10 +22,11 @@ public final class RuntimeRole {
     /**
      * Wired property key for the server-role gate. Gates {@code ServerSchedulingConfig}
      * ({@code @EnableScheduling}), {@code IntegrationNatsConsumer} (the unified
-     * integration-framework NATS pull consumer), and {@code WorkspaceStartupListener}.
-     * Authoritative list lives in
-     * {@code RuntimeRoleBoundaryTest}; setting this flag {@code false} removes those bean
-     * clusters from this JVM while the rest of the monolith continues to load. See ADR 0008.
+     * integration-framework NATS pull consumer), {@code WorkspaceStartupListener}, the entire
+     * user-facing {@code core.auth} web/auth surface and {@code WorkspaceContextFilter} (both via
+     * {@link ConditionalOnServerRole}). Authoritative list lives in {@code RuntimeRoleBoundaryTest};
+     * setting this flag {@code false} removes those bean clusters from this JVM while the rest of the
+     * monolith continues to load. See ADR 0008.
      */
     public static final String SERVER_PROPERTY = PROPERTY_PREFIX + ".server.enabled";
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/ConnectionAdminService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/ConnectionAdminService.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection.api;
 
 import de.tum.cit.aet.hephaestus.core.exception.EntityNotFoundException;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.connection.Connection;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionAudit;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionAuditRepository;
@@ -40,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
  * orchestration (list, lookup, audit projection, inline-credentials Connection
  * creation) and is only called from the REST surface.
  */
+@ConditionalOnServerRole
 @Service
 public class ConnectionAdminService {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/ConnectionController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/connection/api/ConnectionController.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.core.connection.api;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.connection.Connection;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionService;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionService.TransitionRequest;
@@ -52,6 +53,7 @@ import tools.jackson.databind.ObjectMapper;
  * {@link RequireAtLeastWorkspaceAdmin} runs. The resolved {@link WorkspaceContext} supplies
  * the numeric workspace id to the service layer.
  */
+@ConditionalOnServerRole
 @WorkspaceScopedController
 @RequestMapping("/connections")
 @RequireAtLeastWorkspaceAdmin

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/OAuthCallbackController.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/OAuthCallbackController.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.core.oauth;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.connection.Connection;
 import de.tum.cit.aet.hephaestus.integration.core.oauth.state.OAuthStateService;
 import de.tum.cit.aet.hephaestus.integration.core.oauth.state.OAuthStateService.StateBinding;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RestController;
  * on both success and failure; only {@code Accept: application/json} requests get
  * 4xx JSON.
  */
+@ConditionalOnServerRole
 @RestController
 @RequestMapping("/oauth/callback")
 public class OAuthCallbackController {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/HmacOAuthStateService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/HmacOAuthStateService.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.core.oauth.state;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.webhook.WebhookProperties;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import java.nio.charset.StandardCharsets;
@@ -39,6 +40,7 @@ import org.springframework.stereotype.Component;
  * <p>{@link OAuthStateNonceStore} is optional in the constructor so the
  * unit-test overloads (no DB) still work; production wiring always supplies it.
  */
+@ConditionalOnServerRole
 @Component
 public class HmacOAuthStateService implements OAuthStateService {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/OAuthStateNonceCleanupJob.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/OAuthStateNonceCleanupJob.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.oauth.state;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
  * means a vendor callback that took DAYS to arrive, which is well past every
  * sensible TTL. Shorten in tests via the property.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("Pruning a workspace-agnostic table")
 public class OAuthStateNonceCleanupJob {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/OAuthStateNonceStore.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/oauth/state/OAuthStateNonceStore.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.oauth.state;
 
 import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import java.time.Instant;
 import org.slf4j.Logger;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
  * {@link HmacOAuthStateService}) so the store can be unit-tested with mock
  * repositories without dragging in the HMAC machinery and vice-versa.
  */
+@ConditionalOnServerRole
 @Component
 @WorkspaceAgnostic("Operates on a global pre-workspace nonce table")
 public class OAuthStateNonceStore {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/connect/GithubConnectionStrategy.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/connect/GithubConnectionStrategy.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.scm.github.connect;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.oauth.state.OAuthStateService;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.InstallationCredential;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ConnectionStrategy;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Component;
  * side; we observe {@code installation.deleted} via the lifecycle webhook and
  * transition our row to {@code UNINSTALLED} from there.
  */
+@ConditionalOnServerRole
 @Component
 public class GithubConnectionStrategy implements ConnectionStrategy {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/package-info.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/github/package-info.java
@@ -28,6 +28,8 @@
         // a NamedInterface so ProjectIntegrityService can subscribe.
         "integration.scm::events",
         "core",
+        // Runtime-role gate (@ConditionalOnServerRole) on the connection-OAuth strategy.
+        "core::runtime",
         "core::webhook",
         "workspace",
         // Activity ledger write path consumed by the Projects v2 listener under

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/connect/GitlabConnectionStrategy.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/connect/GitlabConnectionStrategy.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.scm.gitlab.connect;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.BearerToken;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider.CredentialBundle;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ConnectionStrategy;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Component;
  * tokens the user issued themselves. Local state transitions are handled by the
  * caller via {@code ConnectionService.transition()}.
  */
+@ConditionalOnServerRole
 @Component
 public class GitlabConnectionStrategy implements ConnectionStrategy {
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/package-info.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/scm/gitlab/package-info.java
@@ -22,6 +22,8 @@
         "integration.core::webhook",
         "integration.scm",
         "core",
+        // Runtime-role gate (@ConditionalOnServerRole) on the connection-OAuth strategy.
+        "core::runtime",
         // GitLabWebhookService uses WebhookProperties; GitLabPreflightService validates URLs.
         "core::webhook",
         "core::security",

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/connect/SlackConnectionStrategy.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/connect/SlackConnectionStrategy.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.slack.connect;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionConfig;
 import de.tum.cit.aet.hephaestus.integration.core.oauth.state.OAuthStateService;
 import de.tum.cit.aet.hephaestus.integration.core.spi.ApiCredentialProvider;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Component;
  * Slack OAuth v2 connection strategy. Token-rotation apps are rejected at finalize because
  * token refresh is not yet implemented.
  */
+@ConditionalOnServerRole
 @Component
 @ConditionalOnProperty(name = "hephaestus.integration.slack.enabled", havingValue = "true", matchIfMissing = false)
 public class SlackConnectionStrategy implements ConnectionStrategy {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/package-info.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/package-info.java
@@ -33,6 +33,8 @@
         "leaderboard",
         "leaderboard::spi",
         "integration.scm",
+        // Runtime-role gate (@ConditionalOnServerRole) on the connection-OAuth strategy.
+        "core::runtime",
     }
 )
 package de.tum.cit.aet.hephaestus.integration.slack;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextFilter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/workspace/context/WorkspaceContextFilter.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.workspace.context;
 
 import de.tum.cit.aet.hephaestus.core.LoggingUtils;
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.core.security.CurrentScmIdentityHolder;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionConfig;
 import de.tum.cit.aet.hephaestus.integration.core.connection.ConnectionService;
@@ -47,6 +48,7 @@ import tools.jackson.databind.ObjectMapper;
  * Filter order is set to -5 to ensure it runs after Spring Security filters (typically -10)
  * but before controller execution.
  */
+@ConditionalOnServerRole
 @Component
 @Order(-5)
 @Profile("!specs")

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/architecture/RuntimeRoleBoundaryTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/architecture/RuntimeRoleBoundaryTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.stereotype.Component;
 
 /**
  * Pins two invariants for {@code hephaestus.runtime.*} gates:
@@ -42,31 +43,82 @@ class RuntimeRoleBoundaryTest extends HephaestusArchitectureTest {
     private static final String CONDITIONAL_ON_EXPRESSION =
         "org.springframework.boot.autoconfigure.condition.ConditionalOnExpression";
 
+    /** Composed server-role gate; resolved to its meta {@code @ConditionalOnProperty} when scanning. */
+    private static final String CONDITIONAL_ON_SERVER_ROLE =
+        "de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole";
+
     /**
      * Single property-gated config per role. Controllers inside {@code integration.webhook} are
      * implicitly gated via {@code @ConditionalOnBean(JetStreamPublisher.class)} — they auto-load
      * iff {@link de.tum.cit.aet.hephaestus.integration.core.webhook.WebhookConfiguration} loads, so
      * listing them here would just duplicate the WebhookConfiguration gate.
      */
-    private static final Map<String, String> EXPECTED_GATES = Map.of(
-        "de.tum.cit.aet.hephaestus.integration.core.webhook.WebhookConfiguration",
-        RuntimeRole.WEBHOOK_PROPERTY,
-        "de.tum.cit.aet.hephaestus.core.runtime.ServerSchedulingConfig",
-        RuntimeRole.SERVER_PROPERTY,
-        "de.tum.cit.aet.hephaestus.integration.core.consumer.IntegrationNatsConsumer",
-        RuntimeRole.SERVER_PROPERTY,
-        "de.tum.cit.aet.hephaestus.workspace.WorkspaceStartupListener",
-        RuntimeRole.SERVER_PROPERTY,
-        "de.tum.cit.aet.hephaestus.agent.runtime.worker.WorkerConfiguration",
-        RuntimeRole.WORKER_PROPERTY,
-        "de.tum.cit.aet.hephaestus.agent.sandbox.docker.DockerSandboxConfiguration",
-        RuntimeRole.WORKER_PROPERTY,
-        "de.tum.cit.aet.hephaestus.agent.sandbox.docker.AgentImagePullBootstrapper",
-        RuntimeRole.WORKER_PROPERTY,
-        "de.tum.cit.aet.hephaestus.core.runtime.hub.HubConfiguration",
-        RuntimeRole.SERVER_PROPERTY,
-        "de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerTokenExchangeController",
-        RuntimeRole.SERVER_PROPERTY
+    private static final Map<String, String> EXPECTED_GATES = Map.ofEntries(
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.webhook.WebhookConfiguration",
+            RuntimeRole.WEBHOOK_PROPERTY
+        ),
+        Map.entry("de.tum.cit.aet.hephaestus.core.runtime.ServerSchedulingConfig", RuntimeRole.SERVER_PROPERTY),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.consumer.IntegrationNatsConsumer",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry("de.tum.cit.aet.hephaestus.workspace.WorkspaceStartupListener", RuntimeRole.SERVER_PROPERTY),
+        Map.entry("de.tum.cit.aet.hephaestus.agent.runtime.worker.WorkerConfiguration", RuntimeRole.WORKER_PROPERTY),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.agent.sandbox.docker.DockerSandboxConfiguration",
+            RuntimeRole.WORKER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.agent.sandbox.docker.AgentImagePullBootstrapper",
+            RuntimeRole.WORKER_PROPERTY
+        ),
+        Map.entry("de.tum.cit.aet.hephaestus.core.runtime.hub.HubConfiguration", RuntimeRole.SERVER_PROPERTY),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.core.runtime.hub.auth.WorkerTokenExchangeController",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        // WorkspaceContextFilter lives outside core.auth, so allAuthStereotypeBeansAreServerGated()
+        // doesn't cover it — pin it here. (The core.auth beans are covered by that structural test.)
+        Map.entry("de.tum.cit.aet.hephaestus.workspace.context.WorkspaceContextFilter", RuntimeRole.SERVER_PROPERTY),
+        // Connection-management OAuth surface — server-only (the worker/webhook never run the OAuth
+        // connect dance). Gating these is what unblocks those pods past HmacOAuthStateService.
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.oauth.state.HmacOAuthStateService",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.oauth.state.OAuthStateNonceStore",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.oauth.state.OAuthStateNonceCleanupJob",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.oauth.OAuthCallbackController",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.connection.api.ConnectionController",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.core.connection.api.ConnectionAdminService",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.scm.github.connect.GithubConnectionStrategy",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.scm.gitlab.connect.GitlabConnectionStrategy",
+            RuntimeRole.SERVER_PROPERTY
+        ),
+        Map.entry(
+            "de.tum.cit.aet.hephaestus.integration.slack.connect.SlackConnectionStrategy",
+            RuntimeRole.SERVER_PROPERTY
+        )
     );
 
     /**
@@ -176,6 +228,45 @@ class RuntimeRoleBoundaryTest extends HephaestusArchitectureTest {
         });
     }
 
+    /**
+     * The two {@code core.auth.spi} read-only query impls are the cross-role data-access part of auth
+     * (account identity/role lookups), consumed by the connection-identity service and the workspace /
+     * notification modules on every role. They carry no hard prod env and must stay ungated — unlike the
+     * web/OAuth/issuance layer.
+     */
+    private static final List<String> CROSS_ROLE_AUTH_SPI_IMPLS = List.of(
+        "de.tum.cit.aet.hephaestus.core.auth.AccountIdentityQueryService",
+        "de.tum.cit.aet.hephaestus.core.auth.AccountRoleQueryService"
+    );
+
+    @Test
+    void allAuthStereotypeBeansAreServerGated() {
+        // The whole core.auth module is the user-facing web/auth surface — server-role only, EXCEPT the
+        // cross-role SPI query impls (see CROSS_ROLE_AUTH_SPI_IMPLS). This is the real drift guard: any new
+        // auth stereotype bean added without @ConditionalOnServerRole would re-break the worker/webhook
+        // pods (server.enabled=false). Repositories (interfaces, JPA-only) and @ConfigurationProperties
+        // records are not stereotypes.
+        List<String> ungated = classes
+            .stream()
+            .filter(c -> c.getPackageName().startsWith("de.tum.cit.aet.hephaestus.core.auth"))
+            .filter(c -> !c.isInterface())
+            .filter(c -> !CROSS_ROLE_AUTH_SPI_IMPLS.contains(c.getFullName()))
+            .filter(c -> c.isMetaAnnotatedWith(Component.class))
+            .filter(clazz ->
+                conditionalOnPropertyAnnotations(clazz)
+                    .map(ann -> new ConditionalRef(clazz, ann))
+                    .noneMatch(ref -> ref.propertyNames().anyMatch(name -> name.equals(RuntimeRole.SERVER_PROPERTY)))
+            )
+            .map(JavaClass::getFullName)
+            .collect(Collectors.toList());
+
+        assertThat(ungated)
+            .as(
+                "Every core.auth stereotype bean must carry @ConditionalOnServerRole — the auth web/auth surface is server-role only"
+            )
+            .isEmpty();
+    }
+
     @Test
     void mentorBeansWireUnconditionally() {
         List<String> stillGated = UNCONDITIONAL_MENTOR_BEANS.stream()
@@ -237,6 +328,15 @@ class RuntimeRoleBoundaryTest extends HephaestusArchitectureTest {
             .flatMap(ann -> {
                 if (ann.getRawType().isEquivalentTo(ConditionalOnProperty.class)) {
                     return Stream.of(ann);
+                }
+                // @ConditionalOnServerRole composes @ConditionalOnProperty(SERVER_PROPERTY, matchIfMissing=true);
+                // ArchUnit sees only the direct meta-annotation, so resolve its own @ConditionalOnProperty.
+                if (ann.getRawType().getFullName().equals(CONDITIONAL_ON_SERVER_ROLE)) {
+                    return ann
+                        .getRawType()
+                        .getAnnotations()
+                        .stream()
+                        .filter(meta -> meta.getRawType().isEquivalentTo(ConditionalOnProperty.class));
                 }
                 if (ann.getRawType().getFullName().equals(CONDITIONAL_CONTAINER)) {
                     Object value = ann.getProperties().get("value");


### PR DESCRIPTION
## Problem
The `worker` and `webhook-server` pods (`hephaestus.runtime.server.enabled=false`) crash-loop in prod: the entire user-facing web/auth surface loads on **every** runtime role and trips prod fail-fast guards those pods have no env for (auth issuer, state-cookie key, OAuth-state secret). Discovered during the staging cutover — the webhook receiver and worker never booted.

## Root cause
That surface was never role-gated; only role-specific bean clusters (scheduling, consumers, sandbox, webhook ingest) were.

## Fix (root cause, not env band-aids)
- New composed `@ConditionalOnServerRole` (`@ConditionalOnProperty(server.enabled, matchIfMissing=true)` — monolith default unchanged) applied to:
  - the whole `core.auth` module, **except** the two cross-role SPI query impls (`AccountIdentityQueryService`, `AccountRoleQueryService`);
  - `WorkspaceContextFilter`;
  - the connection-management OAuth cluster (`HmacOAuthStateService`, OAuth-state nonce store/cleanup, `OAuthCallbackController`, `ConnectionController`/`AdminService`, the GitHub/GitLab/Slack connect strategies).
- **Lynchpin:** `SecurityConfig` hard-injected `AuthRateLimitFilter` → now `ObjectProvider` + null-guard (the app chain already degrades to deny-all without a `JwtDecoder`).
- **Genuine cross-role needs stay env, not gating** (JPA loads on every role): worker + webhook compose set `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` + `APPLICATION_HOST_URL`; worker also `DATABASE_URL`. No auth env on those pods anymore.

## Guards
`RuntimeRoleBoundaryTest` is now meta-annotation-aware and adds a structural test that every `core.auth` stereotype bean carries the gate. Modulith: `scm.github`/`scm.gitlab`/`slack` declare `core::runtime` as allowed.

## Validation
Booted all three prod profiles locally: **worker** + **webhook** start with **no auth env**, **server** starts with auth. Architecture (170) + unit (3434) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker compose configurations with required environment variables for database credentials, encryption keys, and application host URL
  * Implemented conditional component loading based on server runtime role, ensuring components only register when running in appropriate deployment mode
  * Enhanced architecture validation tests to enforce server-role gating requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->