### PR TITLE
fix(server): default the auth issuer so non-server roles bind it under CDS

### DIFF
--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -123,7 +123,11 @@ hephaestus:
     # AUTH (Production) — Hephaestus-native, see ADR 0017
     # ═══════════════════════════════════════════════════════════════════════════
     auth:
-        issuer: ${HEPHAESTUS_AUTH_ISSUER}
+        # Default keeps the URI valid when HEPHAESTUS_AUTH_ISSUER is unset. The auth web layer is
+        # server-only (gated off worker/webhook), but the CDS build binds this @ConfigurationProperties
+        # record eagerly on every role — without a default the worker/webhook crash on the bare
+        # ${...} placeholder. The server always sets the env var, so it gets the real issuer.
+        issuer: ${HEPHAESTUS_AUTH_ISSUER:http://localhost:8080}
         state-cookie-key: ${HEPHAESTUS_AUTH_STATE_COOKIE_KEY}
         # Traefik strips /api before the request reaches the app (see docker/compose.app.yaml), and
         # native forward-headers can't restore the prefix — re-add it to the browser-facing OAuth URLs.


### PR DESCRIPTION
After PR #1332, staging worker + webhook still crash-loop on `hephaestus.auth.issuer` binding to a bare `${HEPHAESTUS_AUTH_ISSUER}` placeholder. Root cause: the auth web layer is correctly gated off those roles, but `AuthProperties` is a `@ConfigurationPropertiesScan` record and **the CDS build binds it eagerly on every role** (verified: with `-Xshare:off` it binds lazily and never needs the issuer; with CDS on the bare placeholder fails URI conversion). Fix: default the placeholder to the value the record already declares — `issuer: ${HEPHAESTUS_AUTH_ISSUER:http://localhost:8080}`. Server still gets the real issuer; worker/webhook bind a valid, unused value and boot. No auth env added to those pods. Reproduced + validated against the actual latest CDS image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application stability by implementing fallback configuration values, preventing startup failures when environment variables are not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->