### PR TITLE
fix(webapp): stop the public landing page looping to /login under the /api base path

### DIFF
--- a/webapp/src/integrations/auth/sessionExpiry.test.ts
+++ b/webapp/src/integrations/auth/sessionExpiry.test.ts
@@ -135,8 +135,8 @@ describe("handlePossibleSessionExpiry", () => {
 	});
 
 	it("does NOT handle a 401 from the GET /api/user probe (prod /api base path)", () => {
-		// The landing page at / probes the session; under the /api base path the bare-/user exemption
-		// missed and looped logged-out visitors to /login. Regression for that.
+		// A logged-out visitor on the public landing (pathname "/") probes the session; the /api-prefixed
+		// probe must be exempt, not drive the login redirect.
 		const { assigned } = stubLocation("/");
 		const handled = handlePossibleSessionExpiry(
 			res(401, "http://localhost/api/user"),

--- a/webapp/src/integrations/auth/sessionExpiry.test.ts
+++ b/webapp/src/integrations/auth/sessionExpiry.test.ts
@@ -7,6 +7,10 @@ import { refreshAccessToken } from "./sessionRefresh";
 vi.mock("./sessionRefresh", () => ({ refreshAccessToken: vi.fn() }));
 const refreshMock = vi.mocked(refreshAccessToken);
 
+// Prod serves the API under /api (Traefik strips it); pin a base path so the exemptions are exercised
+// the way they run in prod — the GET /api/user probe must be exempt exactly like /user is locally.
+vi.mock("@/environment", () => ({ default: { serverUrl: "http://localhost/api" } }));
+
 // jsdom's window.location is not directly assignable; replace it with a stub exposing `assign` plus
 // the pathname/search/origin the handler reads.
 function stubLocation(pathname: string, search = ""): { assigned: string[] } {
@@ -123,6 +127,30 @@ describe("handlePossibleSessionExpiry", () => {
 		const { assigned } = stubLocation("/");
 		const handled = handlePossibleSessionExpiry(
 			res(401, "http://localhost:8080/user"),
+			makeQueryClient(),
+		);
+		expect(handled).toBe(false);
+		expect(refreshMock).not.toHaveBeenCalled();
+		expect(assigned).toHaveLength(0);
+	});
+
+	it("does NOT handle a 401 from the GET /api/user probe (prod /api base path)", () => {
+		// The landing page at / probes the session; under the /api base path the bare-/user exemption
+		// missed and looped logged-out visitors to /login. Regression for that.
+		const { assigned } = stubLocation("/");
+		const handled = handlePossibleSessionExpiry(
+			res(401, "http://localhost/api/user"),
+			makeQueryClient(),
+		);
+		expect(handled).toBe(false);
+		expect(refreshMock).not.toHaveBeenCalled();
+		expect(assigned).toHaveLength(0);
+	});
+
+	it("does NOT handle a 401 from /api/auth/* endpoints (prod /api base path)", () => {
+		const { assigned } = stubLocation("/");
+		const handled = handlePossibleSessionExpiry(
+			res(401, "http://localhost/api/auth/refresh"),
 			makeQueryClient(),
 		);
 		expect(handled).toBe(false);

--- a/webapp/src/integrations/auth/sessionExpiry.ts
+++ b/webapp/src/integrations/auth/sessionExpiry.ts
@@ -5,10 +5,9 @@ import { safeReturnTo } from "@/integrations/auth/guard";
 import { refreshAccessToken } from "@/integrations/auth/sessionRefresh";
 
 /**
- * Path the API client prefixes onto every request (`environment.serverUrl`, e.g. `/api` in prod where
- * Traefik strips it before the app, empty in local dev). Strip it so endpoint exemptions below match
- * regardless of the deploy's base path — otherwise the logged-out `GET /api/user` probe on a public
- * page never matches `/user` and loops to /login.
+ * The API client prefixes every request with `environment.serverUrl` (`/api` in prod where Traefik
+ * strips it, empty in local dev). Returns that base path so the endpoint exemptions below match across
+ * deploys, not just the local unprefixed shape.
  */
 function apiBasePath(): string {
 	try {

--- a/webapp/src/integrations/auth/sessionExpiry.ts
+++ b/webapp/src/integrations/auth/sessionExpiry.ts
@@ -1,7 +1,22 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { getCurrentUserQueryKey } from "@/api/@tanstack/react-query.gen";
+import environment from "@/environment";
 import { safeReturnTo } from "@/integrations/auth/guard";
 import { refreshAccessToken } from "@/integrations/auth/sessionRefresh";
+
+/**
+ * Path the API client prefixes onto every request (`environment.serverUrl`, e.g. `/api` in prod where
+ * Traefik strips it before the app, empty in local dev). Strip it so endpoint exemptions below match
+ * regardless of the deploy's base path — otherwise the logged-out `GET /api/user` probe on a public
+ * page never matches `/user` and loops to /login.
+ */
+function apiBasePath(): string {
+	try {
+		return new URL(environment.serverUrl, window.location.origin).pathname.replace(/\/$/, "");
+	} catch {
+		return "";
+	}
+}
 
 /**
  * Paths whose own 401 must NOT trigger a redirect-to-login. The `GET /user` identity probe
@@ -17,6 +32,11 @@ function isExemptFromSessionExpiry(pathname: string, url: string): boolean {
 		requestPath = new URL(url, window.location.origin).pathname;
 	} catch {
 		// Leave requestPath as-is for an unparseable URL.
+	}
+	// Strip the API base path so `/api/user` (prod) matches the same exemptions as `/user` (local dev).
+	const base = apiBasePath();
+	if (base && requestPath.startsWith(`${base}/`)) {
+		requestPath = requestPath.slice(base.length);
 	}
 	if (requestPath === "/user") return true;
 	if (requestPath.startsWith("/auth/")) return true;


### PR DESCRIPTION
## Problem
Visiting `https://staging.hephaestus.aet.cit.tum.de/` while logged out bounces straight to `/login?returnTo=%2F` — the public landing page is unreachable. Local dev is unaffected (which hid it).

## Root cause
`handlePossibleSessionExpiry` exempts the `GET /user` session probe from the 401→redirect-to-login behaviour (it legitimately 401s when signed out, and is the query the landing page itself reads). But `isExemptFromSessionExpiry` matched the request path as exactly `"/user"`. In prod the API client prefixes every request with `environment.serverUrl` (`/api`, which Traefik strips before the app), so the probe is `/api/user` — the exemption missed, and the logged-out probe on `/` drove the redirect loop. Same `/api`-prefix blind spot as the OAuth callback fix (#1330).

## Fix
Strip the configured API base path (`environment.serverUrl`'s pathname) before matching, so `/api/user` and `/api/auth/*` are exempt exactly like `/user` and `/auth/*` are locally. Added regression tests for the `/api` base path (14/14 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session expiry and authentication handling now function correctly across all deployment configurations. This ensures consistent session management behavior regardless of server routing setup or API base path configuration.

* **Tests**
  * Expanded test coverage for session expiry handling under production-like routing scenarios to verify correct behavior in all deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->