### PR TITLE
fix(docker): disable TLS to the internal Postgres (root cause of the JDBC direct-buffer OOM)

### DIFF
--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -96,6 +96,9 @@ services:
     ports:
       - "8080"
     environment:
+      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
+      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: prod
       APPLICATION_HOST_URL: https://${APP_HOSTNAME}
@@ -273,6 +276,9 @@ services:
   application-worker:
     image: "ghcr.io/ls1intum/hephaestus/application-server:${IMAGE_TAG}"
     environment:
+      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
+      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: prod,worker
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-}

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -107,8 +107,9 @@ services:
       # + docker/compose.core.yaml). Disable it here so the receiver beans don't load
       # in application-server (saves RAM; prevents accidental localhost traffic).
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "false"
-      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
-      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      # Internal, trusted docker-network DB: skip TLS. pgJDBC doesn't validate Postgres' self-signed cert
+      # so it adds no authentication, only the SSL handshake's NIO direct buffers that OOM the JVM off-heap
+      # default; confidentiality is fine to drop here (creds already sit in plaintext compose env).
       DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: root
@@ -298,8 +299,9 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
       # Persistence for the JPA layer the worker shares (connection-credential AttributeConverter,
       # workspace/agent context). The auth web layer is gated off this role, so no auth env is needed.
-      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
-      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      # Internal, trusted docker-network DB: skip TLS. pgJDBC doesn't validate Postgres' self-signed cert
+      # so it adds no authentication, only the SSL handshake's NIO direct buffers that OOM the JVM off-heap
+      # default; confidentiality is fine to drop here (creds already sit in plaintext compose env).
       DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: root

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -96,9 +96,6 @@ services:
     ports:
       - "8080"
     environment:
-      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
-      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
-      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: prod
       APPLICATION_HOST_URL: https://${APP_HOSTNAME}
@@ -110,7 +107,9 @@ services:
       # + docker/compose.core.yaml). Disable it here so the receiver beans don't load
       # in application-server (saves RAM; prevents accidental localhost traffic).
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "false"
-      DATABASE_URL: postgresql://postgres:5432/hephaestus
+      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
+      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: root
       NATS_SERVER: nats://nats-server:4222
@@ -276,9 +275,6 @@ services:
   application-worker:
     image: "ghcr.io/ls1intum/hephaestus/application-server:${IMAGE_TAG}"
     environment:
-      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
-      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
-      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: prod,worker
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-}
@@ -302,7 +298,9 @@ services:
       SENTRY_DSN: ${SENTRY_DSN}
       # Persistence for the JPA layer the worker shares (connection-credential AttributeConverter,
       # workspace/agent context). The auth web layer is gated off this role, so no auth env is needed.
-      DATABASE_URL: postgresql://postgres:5432/hephaestus
+      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
+      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: root
       # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -26,8 +26,9 @@ services:
       WEBHOOK_SECRET: ${WEBHOOK_SECRET}
       # DataSource for the JPA layer (the connection-credential AttributeConverter that the HMAC
       # path reads); the auth web layer and workspace-context filter are gated off this role.
-      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
-      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      # Internal, trusted docker-network DB: skip TLS. pgJDBC doesn't validate Postgres' self-signed cert
+      # so it adds no authentication, only the SSL handshake's NIO direct buffers that OOM the JVM off-heap
+      # default; confidentiality is fine to drop here (creds already sit in plaintext compose env).
       DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: root

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -11,6 +11,9 @@ services:
     expose:
       - "8080"
     environment:
+      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
+      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: "prod,webhook"
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "true"

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -11,9 +11,6 @@ services:
     expose:
       - "8080"
     environment:
-      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
-      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
-      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: "prod,webhook"
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "true"
@@ -29,7 +26,9 @@ services:
       WEBHOOK_SECRET: ${WEBHOOK_SECRET}
       # DataSource for the JPA layer (the connection-credential AttributeConverter that the HMAC
       # path reads); the auth web layer and workspace-context filter are gated off this role.
-      DATABASE_URL: postgresql://postgres:5432/hephaestus
+      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
+      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: root
       # CredentialBundleConverter (JPA AttributeConverter) decrypts connection credentials on every role.

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -198,8 +198,9 @@ services:
       HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST: ${HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST:-false}
       # URL - Coolify provides SERVICE_FQDN_WEBAPP
       APPLICATION_HOST_URL: https://${SERVICE_FQDN_WEBAPP}
-      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
-      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      # Internal, trusted docker-network DB: skip TLS. pgJDBC doesn't validate Postgres' self-signed cert
+      # so it adds no authentication, only the SSL handshake's NIO direct buffers that OOM the JVM off-heap
+      # default; confidentiality is fine to drop here (creds already sit in plaintext compose env).
       DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: hephaestus
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-hephaestus-preview}

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -190,9 +190,6 @@ services:
     hostname: application-server
     restart: unless-stopped
     environment:
-      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
-      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
-      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       SPRING_PROFILES_ACTIVE: prod
       # prod runs forward-headers=native, so ProxyTrustGuard aborts the boot unless this is set.
       # Coolify fronts previews with its own proxy — set its ingress regex, not staging's range.
@@ -201,7 +198,9 @@ services:
       HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST: ${HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST:-false}
       # URL - Coolify provides SERVICE_FQDN_WEBAPP
       APPLICATION_HOST_URL: https://${SERVICE_FQDN_WEBAPP}
-      DATABASE_URL: postgresql://postgres:5432/hephaestus
+      # Internal docker-network DB: skip TLS. Postgres' self-signed cert offers no real protection
+      # here, and the SSL handshake's per-connection NIO direct buffers OOM the JVM's small off-heap default.
+      DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: hephaestus
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-hephaestus-preview}
       # Shared infrastructure (must match shared-infra service names with UUID suffix)

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -190,6 +190,9 @@ services:
     hostname: application-server
     restart: unless-stopped
     environment:
+      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
+      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       SPRING_PROFILES_ACTIVE: prod
       # prod runs forward-headers=native, so ProxyTrustGuard aborts the boot unless this is set.
       # Coolify fronts previews with its own proxy — set its ingress regex, not staging's range.

--- a/docker/preview/compose.shared-infra.yaml
+++ b/docker/preview/compose.shared-infra.yaml
@@ -69,6 +69,9 @@ services:
     expose:
       - "8080"
     environment:
+      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
+      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       SPRING_PROFILES_ACTIVE: "prod,webhook"
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "true"
       HEPHAESTUS_RUNTIME_SERVER_ENABLED: "false"

--- a/docker/preview/compose.shared-infra.yaml
+++ b/docker/preview/compose.shared-infra.yaml
@@ -69,9 +69,6 @@ services:
     expose:
       - "8080"
     environment:
-      # Paketo defaults MaxDirectMemorySize to 10M — too small for the Postgres JDBC SSL pool's
-      # NIO direct buffers, which exhaust and stall DB connections. Container memory is unmanaged.
-      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=256M"
       SPRING_PROFILES_ACTIVE: "prod,webhook"
       HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED: "true"
       HEPHAESTUS_RUNTIME_SERVER_ENABLED: "false"


### PR DESCRIPTION
## Problem
On staging the login page showed **no sign-in options**. DB-dependent endpoints (`/identity-providers`) hung while every Spring pod still reported **healthy** — `OutOfMemoryError: Cannot reserve … direct buffer memory (limit 10485760)` had fired **4000+ times**.

## Root cause (corrected after review)
`DATABASE_URL` set **no `sslmode`**, so pgJDBC defaults to `sslmode=prefer` and negotiates **TLS to the internal `postgres:17`** (Debian's self-signed *snakeoil* cert). That handshake (`ConnectionFactoryImpl.enableSSL`) is what allocates the per-connection NIO direct buffers that exhaust Paketo's **10 MB** `MaxDirectMemorySize` default. `prefer` against an unverified self-signed cert on a private docker network buys **no real MITM protection** (PostgreSQL docs call it pointless) — it's the entire cause.

## Fix
**`sslmode=disable`** on the internal hop (all four committed `DATABASE_URL` sites). This removes the direct-buffer allocation **at its source** — no JVM-memory override needed.

> This supersedes the first version of this PR, which raised `-XX:MaxDirectMemorySize`. That was a symptom patch: it also contradicted `docs/admin/buildpacks-cds-decision.md` (don't hand-set JVM memory flags) and only worked because the containers are unbounded. Dropped.

## Validation (staging)
With `sslmode=disable` and the **default 10 MB** direct memory: **0 OOMs** under 8× repeated DB load, `/identity-providers` 200 in ~40 ms, GitHub + GitLab login init `302`.

## Deliberately scoped out — follow-ups (NOT bundled here)
The review surfaced three real, deeper gaps. Each is orthogonal to the SSL root cause, needs its own validation, and bundling them would be poor PR hygiene:
1. **Container memory limits.** The Spring containers run **unbounded** (`HostConfig.Memory=0`) — a Paketo misconfiguration (host-OOM blast radius; the calculator can't size against a real ceiling). Should set `deploy.resources.limits.memory` per pod and re-validate heap sizing.
2. **HikariCP `maximum-pool-size=30`** is inherited by server+worker+webhook (three 30-pools on one Postgres) — above the HikariCP formula for these pods; worth right-sizing.
3. **Readiness/observability gap (why this shipped silently):** the app-server Docker `HEALTHCHECK` and the Traefik LB probe both hit `/actuator/health/liveness` (no DB), and the readiness group excludes the datasource — so a 100%-DB-failing pod looked healthy and stayed in rotation. The webhook-server already probes readiness; app-server using liveness is an asymmetry. The durable guard is a DB health indicator in the readiness group + pointing the app-server probes at readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)