### PR TITLE
fix(ci): repair the Coolify preview deployment and make previews opt-in

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,29 +57,73 @@ jobs:
               - '.github/workflows/**'
               - '.github/actions/**'
 
-  # Post preview links immediately (no waiting for other jobs)
-  preview-links:
+  # Coolify's preview switch is all-or-nothing: enabled, it deploys every open PR. We leave it
+  # disabled and create a preview per PR from the Coolify UI, and this job keeps the ones that
+  # exist up to date. Coolify's deploy API only accepts a pull request that already has a preview,
+  # so a PR without one is a no-op. Instance identifiers come from repository variables; a fork or
+  # an unconfigured instance simply skips.
+  preview:
     name: "Preview / Coolify"
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && vars.COOLIFY_URL != '' && vars.COOLIFY_APP_UUID != ''
     permissions:
       statuses: write
-    timeout-minutes: 1
+    timeout-minutes: 2
+    env:
+      COOLIFY_URL: ${{ vars.COOLIFY_URL }}
+      COOLIFY_APP_UUID: ${{ vars.COOLIFY_APP_UUID }}
+      COOLIFY_PROJECT_UUID: ${{ vars.COOLIFY_PROJECT_UUID }}
+      COOLIFY_ENVIRONMENT_UUID: ${{ vars.COOLIFY_ENVIRONMENT_UUID }}
     steps:
-      - name: Post Coolify preview link
+      - name: Link the preview deployments page on the PR
+        if: vars.COOLIFY_PROJECT_UUID != '' && vars.COOLIFY_ENVIRONMENT_UUID != ''
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const sha = context.payload.pull_request.head.sha;
+            const { COOLIFY_URL, COOLIFY_PROJECT_UUID, COOLIFY_ENVIRONMENT_UUID, COOLIFY_APP_UUID } = process.env;
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: sha,
+              sha: context.payload.pull_request.head.sha,
               state: 'success',
-              target_url: 'https://coolify.hephaestus.aet.cit.tum.de/project/lc8sows0ok8g880sg4o4o84w/environment/ek8o8800g4wks84c8w8wcckc/application/wg44k0ccsoscsgcco8swc4ks/preview-deployments',
+              target_url: `${COOLIFY_URL}/project/${COOLIFY_PROJECT_UUID}/environment/${COOLIFY_ENVIRONMENT_UUID}/application/${COOLIFY_APP_UUID}/preview-deployments`,
               description: 'Click Details to view Coolify preview deployments',
-              context: 'Preview / Coolify'
+              context: 'Preview / Coolify',
             });
+
+      # Forks are skipped deliberately: a preview runs with the instance's real credentials.
+      - name: Update this PR's preview deployment, if it has one
+        if: github.event.action == 'synchronize' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${COOLIFY_TOKEN}" ]; then
+            echo "::notice::COOLIFY_API_TOKEN is not configured; skipping preview update."
+            exit 0
+          fi
+
+          body=$(mktemp)
+          status=$(curl -sS -o "${body}" -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+            -H 'Accept: application/json' \
+            --retry 3 --retry-connrefused --max-time 30 \
+            "${COOLIFY_URL}/api/v1/deploy?uuid=${COOLIFY_APP_UUID}&pr=${PR_NUMBER}")
+
+          if [ "${status}" -ge 400 ]; then
+            echo "::error::Coolify returned HTTP ${status}: $(cat "${body}")"
+            exit 1
+          fi
+
+          deployment=$(jq -r '.deployments[0].deployment_uuid // empty' "${body}")
+          if [ -z "${deployment}" ]; then
+            echo "::notice::PR #${PR_NUMBER} has no preview deployment ($(jq -r '.deployments[0].message // "no deployment queued"' "${body}"))."
+            exit 0
+          fi
+
+          echo "::notice::Queued Coolify deployment ${deployment} for PR #${PR_NUMBER}."
 
   Quality:
     uses: ./.github/workflows/ci-quality-gates.yml

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -1,52 +1,24 @@
-# =============================================================================
-# PER-PR APPLICATION STACK FOR PREVIEW DEPLOYMENTS (Coolify)
-# =============================================================================
+# Per-PR application stack for Coolify preview deployments.
 #
-# Coolify deploys this for each Pull Request automatically.
-# Each PR gets its own isolated stack with its own Postgres database.
+# Deploy as a Docker Compose application pointed at this file, with "Connect to Predefined
+# Network" enabled so the stack can reach the shared infra in compose.shared-infra.yaml.
+# Assign two domains on the base application: webapp → the SPA host, appserver → its API
+# sibling (api.<domain>). Previews inherit both with a pr<id> prefix.
 #
-# Coolify Setup (ONE-TIME on main application):
-#   1. Create Application → Docker Compose (from Git repository)
-#   2. Point to: docker/preview/compose.app.yaml
-#   3. Enable "Connect to Predefined Network" to access shared infra
-#   4. Enable Preview Deployments in the application settings
-#   5. Configure environment variables (see .env.example)
-#   6. Configure domains in Coolify UI (General tab) on the MAIN application:
-#      - webapp: https://hephaestus.example.com
-#      - application-server: https://api.hephaestus.example.com
+# Coolify injects SERVICE_FQDN_<SERVICE> (host, no scheme), SERVICE_URL_<SERVICE> and
+# SERVICE_NAME_<SERVICE> (the per-deploy container/network alias).
 #
-#   Preview deployments will AUTOMATICALLY get domains like:
-#      - webapp: https://{{pr_id}}.hephaestus.example.com
-#      - application-server: https://{{pr_id}}.api.hephaestus.example.com
-#
-# Coolify Auto-Generated Variables:
-#   - SERVICE_FQDN_WEBAPP: Domain for webapp (host only, no scheme)
-#   - SERVICE_URL_WEBAPP: Full URL for webapp (with https://)
-#   - SERVICE_FQDN_APPLICATION_SERVER: Domain for API (host only)
-#   - SERVICE_URL_APPLICATION_SERVER: Full URL for API (with https://)
-#   - SERVICE_NAME_<SERVICE>: Container name (e.g., postgres-wg44k0c-pr-557)
-#   - COOLIFY_CONTAINER_NAME: Unique container identifier
-#
-# Connects to shared infrastructure services (from compose.shared-infra.yaml):
-#   - nats-server: Message queue
-#   (auth is Hephaestus-native — no Keycloak; ADR 0017)
-#
-# IMPORTANT: This preview stack does not validate the full GitLab practice-review
-# rollout by default. GitLab IdP, sandbox execution, git checkout, and agent job
-# queue wiring must be added explicitly before using preview as rollout evidence.
-#
-# =============================================================================
+# Never use `${VAR:?message}` here: Coolify's compose parser seeds its environment store from
+# these placeholders and keeps the *message* as the value, so `:?Required` becomes the literal
+# string "Required". Leave required vars bare and let the app's own fail-fast report them.
 
 services:
-  # ---------------------------------------------------------------------------
-  # PostgreSQL - Per-PR database (isolated data per preview)
-  #
-  # SEEDING HACK: Uses init container to populate via psql commands
-  # after postgres starts, rather than relying on /docker-entrypoint-initdb.d
-  # ---------------------------------------------------------------------------
+  # No `hostname:` override: every stack shares Coolify's `coolify` network, where a fixed
+  # hostname would make each preview's postgres answer to the same name and let one preview's
+  # app-server reach another's database. The service key is already a per-deploy alias —
+  # reference it through SERVICE_NAME_POSTGRES.
   postgres:
     image: ghcr.io/ls1intum/hephaestus/postgres:${IMAGE_TAG:-latest}
-    hostname: postgres
     restart: unless-stopped
     environment:
       POSTGRES_DB: hephaestus
@@ -65,14 +37,8 @@ services:
         max-size: "50m"
         max-file: "3"
 
-  # ---------------------------------------------------------------------------
-  # Seed Loader - Restores database from external named volume
-  #
-  # Loads SQL dump from `hephaestus-seed` external named volume.
-  # This volume is created/managed on the HOST and shared across deployments.
-  # Uses standard psql restore - no security issues.
-  # If dump not found, postgres starts empty and Liquibase creates schema.
-  # ---------------------------------------------------------------------------
+  # Clones the base deployment's database into a preview so it starts with real data.
+  # No-op on the base deployment and on any failure — Liquibase then builds the schema instead.
   seed-loader:
     image: postgres:17-alpine
     depends_on:
@@ -81,14 +47,14 @@ services:
     environment:
       PGPASSWORD: ${POSTGRES_PASSWORD:-hephaestus-preview}
       SERVICE_NAME_POSTGRES: ${SERVICE_NAME_POSTGRES:-}
-      SERVICE_FQDN_APPLICATION_SERVER: ${SERVICE_FQDN_APPLICATION_SERVER:-}
+      SERVICE_FQDN_APPSERVER: ${SERVICE_FQDN_APPSERVER:-}
       SERVICE_FQDN_WEBAPP: ${SERVICE_FQDN_WEBAPP:-}
     command: |
       sh -c '
         set -e
         apk add --no-cache docker-cli >/tmp/apk.log 2>&1
 
-        APP_FQDN="${SERVICE_FQDN_APPLICATION_SERVER:-${SERVICE_FQDN_WEBAPP:-}}"
+        APP_FQDN="${SERVICE_FQDN_APPSERVER:-${SERVICE_FQDN_WEBAPP:-}}"
         if ! echo "$$APP_FQDN" | grep -Eq "^pr[0-9]+"; then
           echo "Skipping seed-loader: non-PR deployment detected"
           exit 0
@@ -174,80 +140,154 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: "no"
 
-  # ---------------------------------------------------------------------------
-  # Application Server - Spring Boot backend
-  # Main app domain (set once): https://api.hephaestus.example.com
-  # Previews auto-generate: https://{{pr_id}}.api.hephaestus.example.com
+  # Docker creates named volumes as root:root; the buildpack image runs as `cnb` (1002:1001) and
+  # needs to write git checkouts and Tomcat access logs. Every deploy gets fresh volumes, so the
+  # ownership fix has to run on every deploy too.
+  volume-init:
+    image: alpine:3
+    command:
+      - sh
+      - -c
+      - chown -R 1002:1001 /data/git-repos /var/log/hephaestus && chmod 0755 /data/git-repos /var/log/hephaestus
+    volumes:
+      - git-repos:/data/git-repos
+      - appserver-logs:/var/log/hephaestus
+    restart: "no"
+
+  # The service name must stay dash-free. Coolify stores a service's configured domain under the
+  # service name but looks it up with dashes replaced by underscores, so a dashed name never
+  # matches and the domain is overwritten with an auto-generated host on every deploy.
   #
-  # Replica affinity: previews are single-replica by design, so the mentor sticky-cookie
-  # labels from docker/compose.app.yaml are intentionally omitted here — they would be a
-  # no-op. See docs/contributor/unified-pi-runtime.mdx.
-  # ---------------------------------------------------------------------------
-  application-server:
-    build:
-      context: ./server
-      dockerfile: Dockerfile
-    hostname: application-server
+  # There is no server/Dockerfile — the image comes from Paketo buildpacks (spring-boot:build-image
+  # in server/pom.xml), which also supplies the /workspace/health-check binary. ci-docker-build.yml
+  # publishes `latest` (main), `pr-<id>`, `<sha>` and `<branch>`. The webapp below builds from
+  # source, so a preview always runs the PR's frontend; set IMAGE_TAG=pr-<id> to run its server too.
+  #
+  # Previews are single-replica, so the mentor sticky-cookie labels from docker/compose.app.yaml
+  # would be a no-op and are omitted (docs/contributor/unified-pi-runtime.mdx).
+  appserver:
+    image: ghcr.io/ls1intum/hephaestus/application-server:${IMAGE_TAG:-latest}
     restart: unless-stopped
+    expose:
+      - "8080"
     environment:
       SPRING_PROFILES_ACTIVE: prod
       # prod runs forward-headers=native, so ProxyTrustGuard aborts the boot unless this is set.
-      # Coolify fronts previews with its own proxy — set its ingress regex, not staging's range.
-      HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:?Required}
+      # Write this Tomcat internal-proxies regex WITHOUT backslashes: Coolify re-escapes them when
+      # it writes the stack .env, so `172\.18\.` reaches the container doubled and matches nothing.
+      # The valve then distrusts the proxy, X-Forwarded-Proto is dropped and OAuth redirect_uris are
+      # built as http://. An unescaped '.' matches any character, which is harmless for an IP range:
+      # 172.(1[6-9]|2[0-9]|3[01]).[0-9]{1,3}.[0-9]{1,3}
+      HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES}
       # Previews run non-release images with no release-pin, so don't require a digest-pinned agent image.
       HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST: ${HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST:-false}
-      # URL - Coolify provides SERVICE_FQDN_WEBAPP
+      # The SPA's origin, not this server's: it feeds hephaestus.cors.allowed-origins,
+      # hephaestus.webapp.url and the links the app hands to users.
       APPLICATION_HOST_URL: https://${SERVICE_FQDN_WEBAPP}
-      # Internal, trusted docker-network DB: skip TLS. pgJDBC doesn't validate Postgres' self-signed cert
-      # so it adds no authentication, only the SSL handshake's NIO direct buffers that OOM the JVM off-heap
-      # default; confidentiality is fine to drop here (creds already sit in plaintext compose env).
-      DATABASE_URL: postgresql://postgres:5432/hephaestus?sslmode=disable
+      # The API is served at the ROOT of its own host (Coolify cannot route a compose service on a
+      # path — it regenerates a host-only domain — so the SPA and API get sibling hosts). Nothing
+      # strips a prefix here, so the /api base path that application-prod.yml pins for production
+      # must be cleared, or every OAuth callback is built one segment too deep and 404s.
+      HEPHAESTUS_AUTH_API_BASE_PATH: ""
+      # Internal, trusted docker-network DB: skip TLS. pgJDBC does not validate Postgres' self-signed
+      # cert, so the handshake adds no authentication — only NIO direct buffers that OOM the JVM's
+      # off-heap default.
+      DATABASE_URL: postgresql://${SERVICE_NAME_POSTGRES:-postgres}:5432/hephaestus?sslmode=disable
       DATABASE_USERNAME: hephaestus
       DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-hephaestus-preview}
-      # Shared infrastructure (must match shared-infra service names with UUID suffix)
-      # When "Connect to Predefined Network" is enabled, use the full container names
       NATS_SERVER: nats://nats-server:4222
+      # hephaestus.sync.nats.server and hephaestus.agent.nats.server BOTH default to ${NATS_SERVER}
+      # and must be pinned separately. The integration consumer may point at an upstream NATS (e.g.
+      # staging's) to consume events a shared GitHub App delivers there; the agent job queue must
+      # stay local, or this stack's jobs land in that environment's queue and its workers run them.
+      HEPHAESTUS_SYNC_NATS_SERVER: ${HEPHAESTUS_SYNC_NATS_SERVER:-nats://nats-server:4222}
+      HEPHAESTUS_AGENT_NATS_SERVER: nats://nats-server:4222
       NATS_ENABLED: ${NATS_ENABLED:-true}
-      NATS_DURABLE_CONSUMER_NAME: ${COOLIFY_CONTAINER_NAME:-preview}-consumer
-      # Auth (Hephaestus-native; ADR 0017).
-      # Public URL for issuer validation (must match token's iss claim).
-      HEPHAESTUS_AUTH_ISSUER: https://${PREVIEW_DOMAIN:?Required}
-      HEPHAESTUS_AUTH_STATE_COOKIE_KEY: ${HEPHAESTUS_AUTH_STATE_COOKIE_KEY:?Required}
-      # Sourced from GH_OAUTH_* — GitHub Actions reserves the GITHUB_ prefix for secret/variable names.
+      # Per-deploy durable name, so base and previews get their own JetStream consumers instead of
+      # competing for one and stealing each other's messages.
+      NATS_DURABLE_CONSUMER_NAME: ${SERVICE_NAME_APPSERVER:-appserver}-consumer
+      # Issuer is this deploy's own origin, so a preview's tokens validate against the deploy that
+      # issued them (Hephaestus-native auth, ADR 0017).
+      HEPHAESTUS_AUTH_ISSUER: https://${SERVICE_FQDN_WEBAPP}
+      HEPHAESTUS_AUTH_STATE_COOKIE_KEY: ${HEPHAESTUS_AUTH_STATE_COOKIE_KEY}
+      # The admin UI is admin-gated, so the first super-admin has to come from operator config.
+      HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS: ${HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS:-}
+      # AES-256-GCM key (exactly 32 chars) for credentials encrypted at rest. Required wherever
+      # Liquibase runs — its backfill re-encrypts on boot.
+      HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
+      # Sourced from GH_OAUTH_* — GitHub Actions reserves the GITHUB_ prefix for secret names.
       GITHUB_OAUTH_CLIENT_ID: ${GH_OAUTH_CLIENT_ID:-}
       GITHUB_OAUTH_CLIENT_SECRET: ${GH_OAUTH_CLIENT_SECRET:-}
       GITLAB_OAUTH_CLIENT_ID: ${GITLAB_OAUTH_CLIENT_ID:-}
       GITLAB_OAUTH_CLIENT_SECRET: ${GITLAB_OAUTH_CLIENT_SECRET:-}
       GITLAB_OAUTH_BASE_URL: ${GITLAB_OAUTH_BASE_URL:-https://gitlab.com}
       GITLAB_OAUTH_DISPLAY_NAME: ${GITLAB_OAUTH_DISPLAY_NAME:-GitLab}
-      # GitHub integration
-      GH_APP_ID: ${GH_APP_ID:?Required}
-      GH_APP_PRIVATE_KEY: ${GH_APP_PRIVATE_KEY:?Required}
+      GH_APP_ID: ${GH_APP_ID}
+      GH_APP_PRIVATE_KEY: ${GH_APP_PRIVATE_KEY}
       GH_APP_INSTALLATION_URL: ${GH_APP_INSTALLATION_URL:-}
-      GH_AUTH_TOKEN: ${GH_AUTH_TOKEN:?Required}
-      # Monitoring (relaxed for previews)
+      GH_AUTH_TOKEN: ${GH_AUTH_TOKEN}
+      GITLAB_ENABLED: ${GITLAB_ENABLED:-false}
+      GITLAB_DEFAULT_SERVER_URL: ${GITLAB_DEFAULT_SERVER_URL:-https://gitlab.lrz.de}
+      HEPHAESTUS_FEATURES_FLAGS_GITLAB_WORKSPACE_CREATION: ${GITLAB_WORKSPACE_CREATION:-false}
+      # Slack OAuth/admin and mentor replies run here; inbound Events API and interactivity are
+      # verified on webhook-server, which needs the same signing secret.
+      HEPHAESTUS_INTEGRATION_SLACK_ENABLED: ${HEPHAESTUS_INTEGRATION_SLACK_ENABLED:-false}
+      HEPHAESTUS_INTEGRATION_SLACK_CLIENT_ID: ${HEPHAESTUS_INTEGRATION_SLACK_CLIENT_ID:-}
+      HEPHAESTUS_INTEGRATION_SLACK_CLIENT_SECRET: ${HEPHAESTUS_INTEGRATION_SLACK_CLIENT_SECRET:-}
+      HEPHAESTUS_INTEGRATION_SLACK_SIGNING_SECRET: ${HEPHAESTUS_INTEGRATION_SLACK_SIGNING_SECRET:-}
+      HEPHAESTUS_INTEGRATION_SLACK_REDIRECT_URI: ${HEPHAESTUS_INTEGRATION_SLACK_REDIRECT_URI:-}
+      PRACTICE_REVIEW_FOR_ALL: ${PRACTICE_REVIEW_FOR_ALL:-false}
+      HEPHAESTUS_FEATURES_FLAGS_PRACTICE_REVIEW_FOR_ALL: ${PRACTICE_REVIEW_FOR_ALL:-false}
+      AGENT_NATS_ENABLED: ${AGENT_NATS_ENABLED:-false}
+      GIT_CHECKOUT_ENABLED: ${GIT_CHECKOUT_ENABLED:-false}
+      GIT_STORAGE_PATH: /data/git-repos
+      # There is no separate worker container: hephaestus.runtime.worker.enabled defaults to true,
+      # so this pod runs the worker role in-process and executes agent runs itself. That needs the
+      # host Docker daemon — hence the docker.sock mount below.
+      SANDBOX_DOCKER_HOST: ${SANDBOX_DOCKER_HOST:-unix:///var/run/docker.sock}
+      # Previews share one host — keep the sandbox footprint small.
+      SANDBOX_MAX_CONCURRENT: ${SANDBOX_MAX_CONCURRENT:-2}
+      SANDBOX_MEMORY_BYTES: ${SANDBOX_MEMORY_BYTES:-4294967296}
+      SANDBOX_CPUS: ${SANDBOX_CPUS:-2.0}
+      # Verbatim path passthrough: the sandbox appends its own request path, so this is the API
+      # root, not a /v1 endpoint (same convention as the https://api.openai.com default).
+      LLM_PROXY_OPENAI_URL: ${LLM_PROXY_OPENAI_URL:-https://api.openai.com}
+      LLM_PROXY_OPENAI_AUTH_HEADER: ${LLM_PROXY_OPENAI_AUTH_HEADER:-Authorization}
+      LLM_PROXY_OPENAI_USE_BEARER: ${LLM_PROXY_OPENAI_USE_BEARER:-true}
+      # The LLM key and model live per-workspace in AgentConfig, encrypted at rest. A preview starts
+      # from a seeded DB with nobody to fill that in, so seed a default config at boot — without a
+      # model name the Pi provider is never registered and the mentor silently has no LLM.
+      AGENT_DEFAULT_CONFIG_ENABLED: ${AGENT_DEFAULT_CONFIG_ENABLED:-false}
+      AGENT_DEFAULT_CONFIG_NAME: ${AGENT_DEFAULT_CONFIG_NAME:-Default}
+      AGENT_DEFAULT_CONFIG_PROVIDER: ${AGENT_DEFAULT_CONFIG_PROVIDER:-OPENAI}
+      AGENT_DEFAULT_CONFIG_MODEL_NAME: ${AGENT_DEFAULT_CONFIG_MODEL_NAME:-}
+      AGENT_DEFAULT_CONFIG_API_KEY: ${AGENT_DEFAULT_CONFIG_API_KEY:-}
+      AGENT_DEFAULT_CONFIG_BASE_URL: ${AGENT_DEFAULT_CONFIG_BASE_URL:-}
       MONITORING_TIMEFRAME: ${MONITORING_TIMEFRAME:-14}
       MONITORING_RUN_ON_STARTUP: ${MONITORING_RUN_ON_STARTUP:-false}
       MONITORING_SYNC_CRON: ${MONITORING_SYNC_CRON:-0 0 2 * * *}
       MONITORING_BACKFILL_ENABLED: "false"
-      # Notifications disabled for previews
       LEADERBOARD_NOTIFICATION_ENABLED: "false"
-      # Observability (optional)
       SENTRY_DSN: ${SENTRY_DSN:-}
-      # Webhook auto-registration. Override (not the APPLICATION_HOST_URL default) because previews
-      # route webhooks via PREVIEW_DOMAIN, not the webapp's SERVICE_FQDN_WEBAPP. Bare origin:
-      # GitLabWebhookService appends /webhooks/gitlab itself.
+      # Auto-registration target for GitLab webhooks: the shared-infra receiver's own host, not this
+      # deploy's origin. Bare origin — GitLabWebhookService appends /webhooks/gitlab itself.
       WEBHOOK_SECRET: ${WEBHOOK_SECRET:-}
-      WEBHOOK_EXTERNAL_URL: https://${PREVIEW_DOMAIN:?Required}
-      # thc healthcheck target: actuator liveness on the management port.
+      WEBHOOK_EXTERNAL_URL: ${WEBHOOK_EXTERNAL_URL:-https://${PREVIEW_DOMAIN}}
       THC_PORT: "8080"
       THC_PATH: /actuator/health/liveness
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - git-repos:/data/git-repos
+      - appserver-logs:/var/log/hephaestus
     depends_on:
       postgres:
         condition: service_healthy
       seed-loader:
         condition: service_completed_successfully
-    # thc healthcheck (see docker/compose.app.yaml).
+      volume-init:
+        condition: service_completed_successfully
+    # The distroless image has no shell; the probe is the static thc binary the health-checker
+    # buildpack adds at /workspace/health-check.
     healthcheck:
       test: ["CMD", "/workspace/health-check"]
       interval: 15s
@@ -260,10 +300,6 @@ services:
         max-size: "50m"
         max-file: "5"
 
-  # ---------------------------------------------------------------------------
-  # Webapp - React frontend served by nginx
-  # Assign domain in Coolify: pr-{id}.preview.example.com → port 80
-  # ---------------------------------------------------------------------------
   webapp:
     build:
       context: .
@@ -271,24 +307,22 @@ services:
       args:
         COOLIFY_BRANCH: ${COOLIFY_BRANCH:-}
         SOURCE_COMMIT: ${SOURCE_COMMIT:-}
-    hostname: webapp
     restart: unless-stopped
     environment:
       APPLICATION_VERSION: preview
-      # Coolify provides SERVICE_FQDN_WEBAPP automatically
       APPLICATION_CLIENT_URL: https://${SERVICE_FQDN_WEBAPP}
       GIT_BRANCH: ${COOLIFY_BRANCH:-}
       GIT_COMMIT: ${SOURCE_COMMIT:-}
-      # Coolify provides SERVICE_FQDN_APPLICATION_SERVER (e.g., {{pr_id}}.api.example.com)
-      APPLICATION_SERVER_URL: https://${SERVICE_FQDN_APPLICATION_SERVER}
+      # The API's sibling host under the same registrable domain, so the session cookie is same-site
+      # and rides XHR normally; CORS admits this origin via APPLICATION_HOST_URL above.
+      APPLICATION_SERVER_URL: https://${SERVICE_FQDN_APPSERVER}
       TANSTACK_DEVTOOLS_ENABLED: ${TANSTACK_DEVTOOLS_ENABLED:-true}
-      # Optional
       SENTRY_ENVIRONMENT: preview
       SENTRY_DSN: ${SENTRY_DSN:-}
       POSTHOG_ENABLED: "false"
     depends_on:
-      application-server:
-        # Gate on app-server readiness so the SPA isn't served before the API answers.
+      appserver:
+        # Don't serve the SPA before the API answers.
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:80/"]
@@ -302,8 +336,7 @@ services:
         max-size: "50m"
         max-file: "3"
 
-# =============================================================================
-# VOLUMES (per-deployment, isolated)
-# =============================================================================
 volumes:
   postgres-data:
+  git-repos:
+  appserver-logs:

--- a/docker/preview/compose.shared-infra.yaml
+++ b/docker/preview/compose.shared-infra.yaml
@@ -1,40 +1,22 @@
-# =============================================================================
-# SHARED INFRASTRUCTURE FOR PREVIEW DEPLOYMENTS (Coolify)
-# =============================================================================
+# Shared infrastructure for Coolify preview deployments: NATS JetStream and the inbound webhook
+# receiver. Deploy ONCE as a Docker Compose application with "Connect to Predefined Network"
+# enabled; the base stack and every PR preview reach these services over the `coolify` network.
 #
-# Deploy ONCE as a Docker Compose service in Coolify.
-# All PR preview stacks will connect to these shared services.
+# Give webhook-server its OWN host with no path (https://webhooks.<base-domain>), so delivery URLs
+# are https://webhooks.<base-domain>/webhooks/{github,gitlab,slack}. The receiver owns the full
+# /webhooks/** path — controller, payload-size filter and security chain all bind to it — and
+# Coolify appends a strip-prefix middleware to any service domain that carries a path, which would
+# 404 every delivery. Hand-written Traefik labels are not an alternative: Coolify does not
+# interpolate ${VARS} inside `labels:`.
 #
-# Services:
-#   - nats-server: Message queue for webhook + sync events
-#   - webhook-server: Java inbound webhook receiver (application-server image with
-#     SPRING_PROFILES_ACTIVE=prod,webhook so only integration.core.webhook beans load — see ADR 0008)
-#   (Authentication is Hephaestus-native — no Keycloak; ADR 0017. The app server federates
-#    to GitHub / gitlab.lrz.de directly and issues its own cookie-session JWT.)
+# Webhooks are delivered to this single host, so webhook-server is bound to the BASE stack's
+# database. Previews receive no deliveries of their own; they consume the events from NATS.
 #
-# Coolify Setup:
-#   1. Create new Service → Docker Compose
-#   2. Point to this file in the repo: docker/preview/compose.shared-infra.yaml
-#   3. Enable "Connect to Predefined Network"
-#   4. Configure environment variables (see .env.example)
-#   5. In Coolify UI, set domains for each service (with Strip Prefix ENABLED):
-#      - webhook-server: https://example.com:8080/webhooks
-#
-# IMPORTANT: This shared preview infrastructure does not, by itself, prove that
-# GitLab workspace creation or GitLab practice review will work in production.
-# If you want preview to validate that rollout, add the GitLab IdP and the same
-# application-server practice-review wiring used in the production stack.
-#
-# Domain format: https://domain.com:PORT/path
-# The :PORT tells Coolify which container port to proxy to.
-# Strip Prefix removes /webhooks before forwarding.
-#
-# =============================================================================
+# Never use `${VAR:?message}` here: Coolify's compose parser seeds its environment store from
+# these placeholders and keeps the *message* as the value, so `:?Required` becomes the literal
+# string "Required". Leave required vars bare and let the app's own fail-fast report them.
 
 services:
-  # ---------------------------------------------------------------------------
-  # NATS Server - Message queue for webhook events (internal only)
-  # ---------------------------------------------------------------------------
   nats-server:
     image: nats:2.10-alpine
     restart: unless-stopped
@@ -56,13 +38,9 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  # ---------------------------------------------------------------------------
-  # Webhook Server - Java inbound webhook receiver. Same image as application-server
-  # but with SPRING_PROFILES_ACTIVE=prod,webhook so only integration.core.webhook beans load.
-  # Restart-independent from application-server (push events on GitHub/GitLab are
-  # not manually redeliverable). See ADR 0008.
-  # Configure domain in Coolify UI: https://example.com/webhooks:8080
-  # ---------------------------------------------------------------------------
+  # The application-server image with SPRING_PROFILES_ACTIVE=prod,webhook, so only the
+  # integration.core.webhook beans load. Deliberately restart-independent from application-server:
+  # push events are not redeliverable (ADR 0008).
   webhook-server:
     image: ghcr.io/ls1intum/hephaestus/application-server:${IMAGE_TAG:-latest}
     restart: unless-stopped
@@ -76,26 +54,37 @@ services:
       SPRING_LIQUIBASE_ENABLED: "false"
       HEPHAESTUS_SYNC_NATS_ENABLED: "true"
       HEPHAESTUS_SYNC_NATS_SERVER: "nats://nats-server:4222"
-      WEBHOOK_SECRET: ${WEBHOOK_SECRET:?Required}
-      # EncryptedStringConverter / CredentialBundleConverter are eager prod-fail-fast @Component
-      # converters that load on this server-off pod too; they need the key at construction.
-      HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY:?Required}
-      # application-prod.yml binds host-url=${APPLICATION_HOST_URL} with no YAML default; :?Required pins it.
-      APPLICATION_HOST_URL: ${APPLICATION_HOST_URL:?Required}
-      # prod runs forward-headers=native → ProxyTrustGuard aborts the boot unless set (Coolify ingress regex).
-      HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:?Required}
+      # JPA stays active on this pod (application-webhook.yml, ddl-auto: none) and the HMAC path
+      # reads per-connection credentials through it, so the datasource is real. application-prod.yml
+      # binds spring.datasource.url to jdbc:${DATABASE_URL} with no default — unset, the pod cannot
+      # start. `postgres` is the BASE stack's alias on the `coolify` network (previews are
+      # `postgres-pr-<id>`), so this cannot bind to a preview database.
+      DATABASE_URL: ${WEBHOOK_DATABASE_URL:-postgresql://postgres:5432/hephaestus?sslmode=disable}
+      DATABASE_USERNAME: ${WEBHOOK_DATABASE_USERNAME:-hephaestus}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:-hephaestus-preview}
+      WEBHOOK_SECRET: ${WEBHOOK_SECRET}
+      # The encrypted-field converters are eager prod-fail-fast components and load on this pod too,
+      # so the key must be present even with the server role off.
+      HEPHAESTUS_SECURITY_ENCRYPTION_KEY: ${HEPHAESTUS_SECURITY_ENCRYPTION_KEY}
+      APPLICATION_HOST_URL: ${APPLICATION_HOST_URL}
+      # prod runs forward-headers=native, so ProxyTrustGuard aborts the boot unless this is set.
+      HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES}
+      # Slack Events API and interactivity arrive here under /webhooks/slack* and are verified with
+      # the signing secret; OAuth/admin and mentor replies stay on application-server.
+      HEPHAESTUS_INTEGRATION_SLACK_ENABLED: ${HEPHAESTUS_INTEGRATION_SLACK_ENABLED:-false}
+      HEPHAESTUS_INTEGRATION_SLACK_SIGNING_SECRET: ${HEPHAESTUS_INTEGRATION_SLACK_SIGNING_SECRET:-}
       # Previews run non-release images with no release-pin, so don't require a digest-pinned agent image.
       HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST: ${HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST:-false}
-      # thc healthcheck target: actuator readiness on the management port.
       THC_PORT: "8080"
       THC_PATH: /actuator/health/readiness
     depends_on:
       nats-server:
         condition: service_healthy
-    # Spring drains HTTP (20s) THEN WebhookGracefulShutdown drains NATS (up to 15s).
-    # Docker must allow ≥35s before SIGKILL, or the JVM is cut mid-drain.
+    # Spring drains HTTP (20s), then WebhookGracefulShutdown drains NATS (up to 15s). Docker must
+    # allow ≥35s before SIGKILL, or the JVM is cut mid-drain.
     stop_grace_period: 40s
-    # thc healthcheck (see docker/compose.app.yaml).
+    # The distroless image has no shell; the probe is the static thc binary the health-checker
+    # buildpack adds at /workspace/health-check.
     healthcheck:
       test: ["CMD", "/workspace/health-check"]
       interval: 15s
@@ -111,18 +100,14 @@ services:
 volumes:
   nats-data:
 
-# =============================================================================
-# CONFIGS
-# =============================================================================
 configs:
   nats-config:
     content: |
       listen: "0.0.0.0:4222"
       http_port: 8222
-      
+
       jetstream {
         store_dir: "/data"
         max_mem: 1G
         max_file: 10G
       }
-


### PR DESCRIPTION
## Description

The Coolify preview deployment has been broken for months. `docker/preview/*` was never updated for the native-auth cutover (#1317) or the Java webhook receiver (#1300, #1306), and had drifted far enough that **no stack could boot** — the app resource sat at `exited:unhealthy` while shared infra still ran six-month-old Keycloak, `webhook-ingest` and postfix containers.

This restores it end to end, and makes previews opt-in rather than automatic. Every item below is one independently fatal bug, found by deploying to `hephaestus-test.aet.cit.tum.de` and reading the failures.

### Why nothing could boot

- **`${VAR:?Required}` became the literal string `Required`.** Coolify seeds its own env store from these placeholders and keeps the *error message* as the value. The stack therefore ran with `HEPHAESTUS_AUTH_STATE_COOKIE_KEY=Required`, which base64-decodes to 6 bytes; `AuthSecurityConfig` requires 32 and aborts the boot. All `:?` defaults are gone.
- **`HEPHAESTUS_SECURITY_ENCRYPTION_KEY` was never set.** `JwtSigningKeySealer` fail-fasts without it in prod.
- **`webhook-server` had no datasource.** `application-prod.yml` binds `spring.datasource.url` to `jdbc:${DATABASE_URL}` with no default and `application-webhook.yml` keeps JPA active, so an unset value failed placeholder resolution before the context started.
- **The server image was built from a Dockerfile that does not exist.** `build: context: ./server` has never been valid — the image comes from Paketo buildpacks (`spring-boot:build-image`), which is also what supplies the `/workspace/health-check` binary the healthchecks invoke. Every build died with `failed to read dockerfile`. It is now pulled from GHCR.

### Why login could not have worked

`application-prod.yml` pins `hephaestus.auth.api-base-path=/api`, which is correct for production, where Traefik strips that prefix. Nothing strips it here, so every OAuth callback was built as `https://<api-host>/api/login/oauth2/code/<provider>` and 404'd. The prefix is now cleared for this stack.

Separately, the trusted-proxies regex reached the container double-escaped (Coolify re-escapes backslashes when it writes the stack `.env`), so `\.` arrived as `\\.` — which as a Java regex matches a literal backslash and therefore never matches an IP. Tomcat silently distrusted Traefik, ignored `X-Forwarded-Proto`, and built every `redirect_uri` as `http://`, which the IdP rejects. The value must be written without backslashes, and there is an inline comment saying so.

### Preview isolation

- **`hostname: postgres` let previews reach each other's databases.** Coolify attaches every stack to the shared `coolify` network, where a fixed hostname made *every* preview's Postgres answer to the same `postgres` name. Services are now addressed through the per-deploy `SERVICE_NAME_*` aliases.
- **The NATS durable consumer name was shared**, so the base deploy and every preview competed for the same JetStream consumer. It is now per-deploy.
- **`sync.nats.server` and `agent.nats.server` both default to `${NATS_SERVER}`.** They are now pinned separately, so pointing the integration consumer at another environment's NATS cannot also submit this stack's agent jobs into that environment's `AGENT` queue for its workers to execute.

### Volume ownership

Named volumes are created `root:root` but the buildpack image runs as `cnb` (`1002:1001`), so `GitRepositoryManager` could not `mkdir` under `/data/git-repos` (every checkout failed) and Tomcat's `AccessLogValve` could not open `/var/log/hephaestus/access` — which was never mounted here at all. A `volume-init` step now hands both mounts to the runtime user. It has to live in the compose file: previews get fresh root-owned volumes on every deploy, so a one-off `chown` would silently regress.

### Routing

Coolify generates the Traefik routers itself from the per-service domains, so the stack is served as:

| | |
|---|---|
| SPA | `https://<domain>` |
| API | `https://api.<domain>` |
| Webhooks | `https://webhooks.<domain>/webhooks/{github,gitlab,slack}` |

Two constraints are worth recording, because both silently produce a *working-looking* but wrong deployment:

1. **Hand-written Traefik labels do not work.** Coolify does not interpolate `${VARS}` inside `labels:`, so the rule reaches Traefik with a literal `${APP_HOSTNAME}` host and never matches.
2. **The receiver needs a path-less host.** Coolify appends a strip-prefix middleware whenever a service domain carries a path, and that is a per-application UI toggle. The receiver owns the full `/webhooks/{kind}` path, so a stripped `/webhooks` 404s every delivery; a path-less domain is never stripped.

The API service is named `appserver`, not `application-server`, and the name is load-bearing — see the inline comment.

### Preview lifecycle: opt in, then stay current

Coolify's preview switch is all-or-nothing: enabled, it deploys *every* opened PR. We don't want a stack per PR, but we do want the previews that exist to stay current. So the switch is now **off**, a preview is created from the Coolify UI when a PR actually needs one, and the `Preview / Coolify` job refreshes it on each push. Coolify's deploy API only accepts a pull request that already has a preview, so a PR without one is a no-op:

```
notice: PR #1348 has no preview deployment (Pull request 1348 not found for this resource.)
```

The job is configured entirely through repository variables (`COOLIFY_URL`, `COOLIFY_APP_UUID`, `COOLIFY_PROJECT_UUID`, `COOLIFY_ENVIRONMENT_UUID`) plus a `COOLIFY_API_TOKEN` secret scoped to Coolify's `deploy` ability. No instance identifiers are hardcoded, so a fork — or anyone running their own Coolify — skips the job cleanly instead of posting links into someone else's instance. Fork PRs are skipped by design: a preview runs with the instance's real credentials.

## How to test

Deployed and verified on `hephaestus-test.aet.cit.tum.de` (Coolify): 5/5 containers healthy, 0 `ERROR` lines in the app log.

```
SPA       https://hephaestus.felixdietrich.com               200
API       https://api.hephaestus.felixdietrich.com           200 (readiness UP)
webhooks  POST /webhooks/github  no signature   → 401
                                 valid HMAC     → 202
                                 bad signature  → 401
OAuth     redirect_uri = https://api.hephaestus.felixdietrich.com/login/oauth2/code/github
```

GitHub and GitLab (`gitlab.lrz.de`, scope `read_user`) both resolve to the correct authorize URL, and Liquibase migrates cleanly against the existing database. The `Preview / Coolify` job on this PR exercises the no-preview path shown above and passes.

## Notes for reviewers

- **Title scope.** This is `fix(ci)`, not `fix(docker)`: nothing in the shipped application changed — only preview deployment config and the preview job — and `docker` is a release-triggering scope in `.releaserc`, so it would cut a patch release and publish new production images for an unchanged app. (Separately: the PR template's header comment lists `docker` under "NO RELEASE" while `.releaserc` does not. The template is wrong; follow-up.)
- **Not verified end to end:** the LLM/mentor path, and Slack. A default `AgentConfig` is seeded, but exercising the mentor needs a real workspace and PR.
- **Previews pull the server image rather than building it.** The webapp still builds from source, so a preview always exercises the PR's frontend; set `IMAGE_TAG=pr-<id>` to exercise its server too (that tag exists only when the PR touched `server/`).
- **Unrelated latent bug, not fixed here:** changeset `1772284124265-7` does `RESTART WITH (MAX(id) + 1)`, which Postgres rejects when the max id is negative. GitLab-synced milestones carry hashed negative ids, so this fails on any database that has them (it did on the test box). `GREATEST(…, 1)` would make it safe, but the changeset is very likely already applied on staging and prod, and editing it would break their Liquibase checksums — so it needs its own follow-up.
