### PR TITLE
fix(server): bound the @Async executor so event handlers can't exhaust the DB pool

### DIFF
--- a/server/src/main/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfig.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfig.java
@@ -1,44 +1,58 @@
 package de.tum.cit.aet.hephaestus.config;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.support.TaskExecutorAdapter;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+/**
+ * {@code @Async} advice is ordered outside the transaction advisor (so an {@code @Async @Transactional}
+ * method opens its transaction on the pool thread, not the caller thread) and inside
+ * {@code WorkspaceAgnosticAspect} at {@code HIGHEST_PRECEDENCE}. Both otherwise default to
+ * {@code LOWEST_PRECEDENCE}, hence the explicit {@code HIGHEST_PRECEDENCE + 1}; many
+ * {@code @Async @Transactional} listeners depend on it.
+ *
+ * <p>{@link #getAsyncExecutor()} pins the default executor to the bounded
+ * {@link #applicationTaskExecutor}; with a second {@link AsyncTaskExecutor} bean present, type
+ * resolution is ambiguous and Spring would otherwise fall back to an unbounded
+ * {@code SimpleAsyncTaskExecutor}.
+ */
 @Configuration
-@EnableAsync
+@EnableAsync(order = Ordered.HIGHEST_PRECEDENCE + 1)
 @Profile("!test")
-public class SpringAsyncConfig {
+public class SpringAsyncConfig implements AsyncConfigurer {
 
-    /**
-     * Defining this bean causes {@code TaskExecutionAutoConfiguration} to back off via
-     * {@code @ConditionalOnMissingBean}, so {@code @Async} methods route here even when
-     * {@code spring.threads.virtual.enabled=true} would otherwise install a
-     * {@code SimpleAsyncTaskExecutor}. {@code waitForTasksToCompleteOnShutdown=true} is what
-     * keeps async DB work from racing the {@code EntityManagerFactory} close; the bounded pool
-     * is unrelated load-shedding.
-     */
     @Bean(name = TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
-    public AsyncTaskExecutor applicationTaskExecutor() {
+    public ThreadPoolTaskExecutor applicationTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(50);
+        // Stays below the datasource pool (spring.datasource.hikari.maximum-pool-size = 30) so an
+        // async burst can't starve web requests of connections.
+        executor.setMaxPoolSize(16);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("async-");
+        // Let in-flight async DB work finish before the EntityManagerFactory closes on shutdown.
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(30);
-        executor.initialize();
         return executor;
     }
 
-    /** Virtual-thread executor for blocking I/O monitoring tasks. No graceful shutdown — use
-     * {@link #applicationTaskExecutor} when DB access is involved. */
+    @Override
+    public Executor getAsyncExecutor() {
+        return applicationTaskExecutor();
+    }
+
+    /** Virtual-thread executor for blocking-I/O monitoring tasks. No graceful shutdown — use
+     * {@link #applicationTaskExecutor} for DB work. */
     @Bean(name = "monitoringExecutor")
     @ConditionalOnMissingBean(name = "monitoringExecutor")
     public AsyncTaskExecutor monitoringExecutor() {

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfigTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/config/SpringAsyncConfigTest.java
@@ -1,0 +1,45 @@
+package de.tum.cit.aet.hephaestus.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.Ordered;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Tag("unit")
+class SpringAsyncConfigTest {
+
+    @Test
+    void asyncMethodsRunOnTheBoundedApplicationPool() {
+        // setActiveProfiles("default") clears surefire's "test" profile so @Profile("!test") applies.
+        new ApplicationContextRunner()
+            .withInitializer(ctx -> ctx.getEnvironment().setActiveProfiles("default"))
+            .withUserConfiguration(SpringAsyncConfig.class, AsyncProbe.class)
+            .run(ctx -> {
+                String thread = ctx.getBean(AsyncProbe.class).currentThread().get(5, TimeUnit.SECONDS);
+                // async-* = the bounded pool, not the SimpleAsyncTaskExecutor fallback.
+                assertThat(thread).startsWith("async-");
+            });
+    }
+
+    @Test
+    void asyncAdviceOrderedBetweenTenancyAspectAndTransaction() {
+        // Inside WorkspaceAgnosticAspect (HIGHEST) and outside the transaction advisor (LOWEST). The
+        // tie is nondeterministic, so this can't be asserted behaviorally — check the invariant.
+        int order = SpringAsyncConfig.class.getAnnotation(EnableAsync.class).order();
+        assertThat(order).isGreaterThan(Ordered.HIGHEST_PRECEDENCE).isLessThan(Ordered.LOWEST_PRECEDENCE);
+    }
+
+    static class AsyncProbe {
+
+        @Async
+        public CompletableFuture<String> currentThread() {
+            return CompletableFuture.completedFuture(Thread.currentThread().getName());
+        }
+    }
+}


### PR DESCRIPTION
## Description

Under a burst of SCM sync events the application server would exhaust its database connection pool and **every DB-backed request — including login — would hang**. Connections piled up `active`/`idle in transaction` (some holding the per-user achievement advisory lock) until nothing could acquire one.

### Root cause (proven)

`@Async` was running on an **unbounded `SimpleAsyncTaskExecutor`**, not the bounded pool the code intended. `applicationTaskExecutor` and `monitoringExecutor` are both `AsyncTaskExecutor` beans, so Spring's type-based default-executor resolution is ambiguous and silently falls back to the per-task-thread executor (observed in production thread names: `SimpleAsyncTaskExecutor-6980`). A sync burst then spawned thousands of tasks, each opening a `REQUIRES_NEW` transaction and taking one of the 30 HikariCP connections.

The sizing compounded it: even the *intended* pool was configured at `maxPoolSize=50`, above the 30-connection datasource pool — so async work could starve web requests of connections regardless of the fallback.

### Fix

Both changes are in `SpringAsyncConfig`:

1. **Pin the default `@Async` executor** to the bounded `applicationTaskExecutor` via `AsyncConfigurer.getAsyncExecutor()`, removing the ambiguous type-lookup fallback.
2. **Cap it below the connection pool** (`maxPoolSize` 50 → 16, vs `spring.datasource.hikari.maximum-pool-size=30`) so an async burst cannot starve web/login requests. With the 500-deep queue, steady-state concurrency stays around the core size; 16 is the hard ceiling.

It also makes advisor ordering **deterministic**. `@EnableAsync` and the transaction advisor both defaulted to `LOWEST_PRECEDENCE` — an undefined tie — so an `@Async @Transactional` method's transaction could open on the caller thread instead of the async thread. Async is raised to `HIGHEST_PRECEDENCE + 1`: strictly outside the transaction advisor, and one notch inside `WorkspaceAgnosticAspect` (the only `@Aspect`, at `HIGHEST_PRECEDENCE`) so those two never tie either. This hardens the ~20 `@Async @Transactional` event listeners and, as a side effect, makes `ExportGenerationWorker.generate()`'s transaction effective for the first time (see risks).

## How to test

`SpringAsyncConfigTest` — two unit tests, each verified to go **red** on the exact regression it guards:

- `asyncMethodsRunOnTheBoundedApplicationPool` loads the real config in an `ApplicationContextRunner` and asserts an `@Async` method executes on an `async-*` thread. Drop the executor pin and it fails on `SimpleAsyncTaskExecutor-*` — a behavioral guard against the ambiguous-resolution fallback.
- `asyncAdviceOrderedBetweenTenancyAspectAndTransaction` asserts `HIGHEST_PRECEDENCE < order < LOWEST_PRECEDENCE`. Fails on both a revert to the default order and a change to `HIGHEST` (which would re-tie with the tenancy aspect).

The ordering guard is a reflection invariant on purpose: I confirmed empirically that a behavioral `isActualTransactionActive()`-on-the-async-thread assertion stays green even on the buggy default order, because when the advisors tie Spring resolves them by registration order and happens to pick async-outer. A behavioral ordering test would therefore be non-discriminating, so the invariant bounds check is the honest guard.

Operationally, the incident that surfaced this (a hung login on staging) recovered once the pool was drained; this change removes the mechanism that drained it.

## Risks and notes for reviewers

- **Behavior change worth a look:** raising async above the transaction advisor makes `ExportGenerationWorker.generate()` run its `@Transactional` on the async thread — previously the transaction committed on the caller thread before the body ran, so it was effectively inert. The method is `@WorkspaceAgnostic` and account-scoped (not workspace-scoped), and the tenancy bypass ordering is unchanged, so no new tenancy exposure — but it is the one place whose runtime transaction semantics genuinely change. An export smoke test is worth running.
- **`idle_in_transaction_session_timeout=60s` was set on the staging database** as defense-in-depth against any future connection-scoping regression. It is **not** part of this code fix and this PR does not rely on it; noted here so it isn't mistaken for the fix or removed.
- **`@Async` + `@Transactional` on the same method** (used by ~20 listeners) is now safe because the ordering is deterministic. The canonical alternative — splitting async dispatch and the transactional unit of work into separate beans — is a larger refactor left as an optional follow-up; the ordering fix is sufficient and framework-supported.
- **Scope `fix(server)`** (release-triggering): a runtime connection-pool fix, appropriately a patch release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved background task execution reliability by ensuring asynchronous operations use the application’s configured executor.
  * Limited the maximum number of concurrent background tasks to help maintain consistent resource usage.
  * Adjusted asynchronous processing order to improve compatibility with other framework features.

* **Tests**
  * Added automated coverage to verify asynchronous tasks run on the intended worker threads and use the expected processing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->