### PR TITLE
test(ci): temporary — verify the changelog immutability guard fails as designed

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -38,6 +38,8 @@ jobs:
             display-name: "OpenAPI"
           - check: database-validation
             display-name: "Database"
+          - check: database-migrations
+            display-name: "Migrations"
     steps:
       - name: Determine if check should run
         id: should_run
@@ -46,7 +48,7 @@ jobs:
             "webapp-quality")
               echo "run=${{ inputs.webapp_changed }}" >> $GITHUB_OUTPUT
               ;;
-            "application-server-quality"|"openapi-validation"|"database-validation")
+            "application-server-quality"|"openapi-validation"|"database-validation"|"database-migrations")
               echo "run=${{ inputs.application_server_changed }}" >> $GITHUB_OUTPUT
               ;;
             *)
@@ -68,14 +70,15 @@ jobs:
         with:
           # Database checks need full history for git diff on schema/migrations
           # Other quality checks only need HEAD for faster checkout
-          fetch-depth: ${{ matrix.check == 'database-validation' && 0 || 1 }}
+          fetch-depth: ${{ contains(fromJSON('["database-validation", "database-migrations"]'), matrix.check) && 0 || 1 }}
 
       - name: Setup pnpm + Node.js
-        if: steps.should_run.outputs.run == 'true'
+        # database-migrations is a pure git check — no Node/pnpm/JDK/Maven needed.
+        if: steps.should_run.outputs.run == 'true' && matrix.check != 'database-migrations'
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Setup caches
-        if: steps.should_run.outputs.run == 'true'
+        if: steps.should_run.outputs.run == 'true' && matrix.check != 'database-migrations'
         uses: ./.github/actions/setup-caches
         with:
           cache-type: ${{ matrix.check }}
@@ -184,8 +187,10 @@ jobs:
 
           ISSUES_FOUND=()
 
-          # Check 1: Schema drift
-          scripts/db-utils.sh draft-changelog || ISSUES_FOUND+=("Schema check script failed. Run: pnpm run db:draft-changelog")
+          # Check 1: Schema drift. draft-changelog first applies the full master.xml chain to the
+          # empty DB via liquibase:update — so this step is ALSO the empty→head migration-chain
+          # replay gate (a changelog that doesn't apply fails here). Keep that apply intact.
+          scripts/db-utils.sh draft-changelog || ISSUES_FOUND+=("Schema check / migration-chain apply failed. Run: pnpm run db:draft-changelog")
           if [ -f "server/src/main/resources/db/changelog_new.xml" ]; then
             echo "::error::Schema drift detected. Run: pnpm run db:draft-changelog"
             cat server/src/main/resources/db/changelog_new.xml
@@ -215,6 +220,79 @@ jobs:
             done
             exit 1
           fi
+
+      # database-migrations: git-level guard that released changelog files never change. The
+      # empty→head chain replay already lives in the database-validation leg; this leg adds the
+      # one thing replay can't — immutability. Why git, not Liquibase checksums:
+      # docs/contributor/database-migration.mdx.
+      - name: Resolve released-chain baseline
+        id: baseline
+        if: steps.should_run.outputs.run == 'true' && matrix.check == 'database-migrations'
+        env:
+          PUSH_BEFORE: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Baseline = the released state this branch descends from. For a PR that is the base
+          # commit (an ancestor of the checked-out merge ref, so `git diff BASE HEAD` is exactly
+          # the PR's net change); for a main push it is the previous tip. checkout does NOT expose
+          # origin/<base> as a ref, so use the SHA the event gives us directly.
+          BASE=""
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            BASE="$PR_BASE_SHA"
+          elif [ -n "$PUSH_BEFORE" ]; then
+            BASE="$PUSH_BEFORE"
+          fi
+          # Skip (don't fail) if the baseline commit isn't in local history — branch creation,
+          # force push, or a shallow fetch. There is nothing released to enforce against.
+          if [ -n "$BASE" ] && ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            echo "Baseline $BASE is not in local history; skipping immutability guard."
+            BASE=""
+          fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "Baseline: ${BASE:-<none — nothing released to enforce against>}"
+
+      - name: Changelog immutability guard
+        if: steps.should_run.outputs.run == 'true' && matrix.check == 'database-migrations' && steps.baseline.outputs.base != ''
+        env:
+          BASE: ${{ steps.baseline.outputs.base }}
+          RELEASED_REF: ${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+          CHANGELOG_DIR="server/src/main/resources/db/changelog"
+          MASTER="server/src/main/resources/db/master.xml"
+          FAILED=false
+
+          # 1. No released changelog file may be modified, deleted, or renamed.
+          VIOLATIONS=$(git diff --name-only --diff-filter=MDR "$BASE" HEAD -- "$CHANGELOG_DIR")
+          if [ -n "$VIOLATIONS" ]; then
+            FAILED=true
+            echo "::error::Released Liquibase changesets were modified, renamed, or deleted. Ship a new follow-up changelog instead:"
+            echo "$VIOLATIONS"
+          fi
+
+          # 2. master.xml is append-only: every <include> line the baseline had must survive
+          #    unchanged, in order, as a prefix of the current list. Comparing whole lines (not
+          #    just paths) also catches edits to a released include's attributes. Order is NOT
+          #    asserted beyond the prefix — the historical list is not monotonic by timestamp.
+          #    `|| true` keeps the `-s` guard live: an include-less baseline (never happens today)
+          #    skips the check instead of aborting under pipefail.
+          git show "$BASE:$MASTER" 2>/dev/null | grep '<include ' > /tmp/includes-base || true
+          grep '<include ' "$MASTER" > /tmp/includes-head || true
+          if [ -s /tmp/includes-base ] && ! diff /tmp/includes-base <(head -n "$(wc -l < /tmp/includes-base)" /tmp/includes-head) >/dev/null; then
+            FAILED=true
+            echo "::error::master.xml is append-only: an existing <include> was removed, reordered, or edited. New changelogs go at the end of the list."
+          fi
+
+          if [ "$FAILED" = "true" ]; then
+            {
+              echo "### Changelog immutability"
+              echo "Changesets that reached \`$RELEASED_REF\` may already be applied to production databases — editing or removing them breaks the upgrade path (checksum errors or silently orphaned changesets)."
+              echo "Fix forward with a **new** changelog appended to \`master.xml\`. See \`docs/contributor/database-migration.mdx\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "No released changeset was touched; master.xml stays append-only."
 
   # Needle built at runtime so this guard file doesn't self-match.
   legacy-cleanup-guard:

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -69,8 +69,10 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Database checks need full history for git diff on schema/migrations
-          # Other quality checks only need HEAD for faster checkout
-          fetch-depth: ${{ contains(fromJSON('["database-validation", "database-migrations"]'), matrix.check) && 0 || 1 }}
+          # Other quality checks only need HEAD for faster checkout.
+          # NOTE: the depths are QUOTED. Unquoted, `cond && 0 || 1` always yields 1, because the
+          # number 0 is falsy in GitHub expressions; the non-empty string '0' is truthy.
+          fetch-depth: ${{ contains(fromJSON('["database-validation", "database-migrations"]'), matrix.check) && '0' || '1' }}
 
       - name: Setup pnpm + Node.js
         # database-migrations is a pure git check — no Node/pnpm/JDK/Maven needed.
@@ -239,18 +241,21 @@ jobs:
           # origin/<base> as a ref, so use the SHA the event gives us directly.
           BASE=""
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            # A PR always has a base commit, and it is always an ancestor of the merge ref. If it
+            # is missing, the checkout is too shallow — fail loudly rather than let the guard
+            # silently no-op, which would report a vacuous green.
+            if ! git cat-file -e "$PR_BASE_SHA^{commit}" 2>/dev/null; then
+              echo "::error::PR base commit $PR_BASE_SHA is not in local history — this job needs fetch-depth: 0. Refusing to pass without checking."
+              exit 1
+            fi
             BASE="$PR_BASE_SHA"
-          elif [ -n "$PUSH_BEFORE" ]; then
+          elif [ -n "$PUSH_BEFORE" ] && git cat-file -e "$PUSH_BEFORE^{commit}" 2>/dev/null; then
+            # Branch creation and force pushes leave no reachable previous tip; nothing released
+            # to enforce against, so the guard is skipped.
             BASE="$PUSH_BEFORE"
           fi
-          # Skip (don't fail) if the baseline commit isn't in local history — branch creation,
-          # force push, or a shallow fetch. There is nothing released to enforce against.
-          if [ -n "$BASE" ] && ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
-            echo "Baseline $BASE is not in local history; skipping immutability guard."
-            BASE=""
-          fi
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
-          echo "Baseline: ${BASE:-<none — nothing released to enforce against>}"
+          echo "Baseline: ${BASE:-<none — no reachable previous tip, nothing to enforce>}"
 
       - name: Changelog immutability guard
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'database-migrations' && steps.baseline.outputs.base != ''

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,10 +81,11 @@ Regeneration is destructive; stash local edits before running these commands. Ch
   2. Snapshot the schema, run Liquibase diff, and create a timestamped changelog file.
   3. Tear down the temporary container.
 - Trim the generated changelog to only the real schema deltas (e.g., new columns). Never commit the raw diff wholesale—prune back to the minimal change set before renaming it into `db/changelog/`.
-- **Filename convention (required):** the committed file MUST be `<epoch-ms-timestamp>_changelog.xml` — a real millisecond timestamp (`date +%s%3N`, i.e. what the draft tool emits), strictly greater than the latest existing changelog so `master.xml` stays monotonic. Do NOT invent a round number and do NOT use a descriptive suffix; keep the `_changelog.xml` name. `changeSet` ids follow `<timestamp>-1`, `<timestamp>-2`, …
+- **Filename convention (required):** the committed file MUST be `<epoch-ms-timestamp>_changelog.xml` — a real millisecond timestamp (`date +%s%3N`, i.e. what the draft tool emits), strictly greater than the latest existing changelog. Do NOT invent a round number and do NOT use a descriptive suffix; keep the `_changelog.xml` name. New `<include>` entries are **appended** to `master.xml` — the committed list is append-only (CI-enforced), not globally timestamp-sorted. `changeSet` ids follow `<timestamp>-1`, `<timestamp>-2`, …
 - **One consolidated changelog per branch/PR (required):** add every schema change for a branch as additional `<changeSet>` entries inside that single file. Never open a PR with more than one new changelog file — consolidate. Each `changeSet` should be preconditioned (`onFail="MARK_RAN"`) with a `<rollback>`, matching the existing files.
 - After drafting a changelog, run `pnpm run db:generate-erd-docs` to keep ERD docs in sync.
 - Never manually edit generated Liquibase diff sections unless you fully understand the implications. Prefer creating a follow-up changelog to fix mistakes.
+- **Released changesets are immutable (CI-enforced):** once a changelog file reaches `main` it must never be edited, renamed, or deleted, and `master.xml` is append-only — the `Migrations` quality gate fails otherwise. Fix mistakes forward with a new changelog. Destructive schema changes (drop/rename of released tables/columns) follow deprecate-then-remove across two releases — see `docs/contributor/database-migration.mdx`.
 
 ## 6. Frontend (webapp) expectations
 
@@ -111,7 +112,7 @@ Regeneration is destructive; stash local edits before running these commands. Ch
 - Group new tests under the proper JUnit tag so CI picks them up (`@Tag("unit")`, `@Tag("integration")`, or `@Tag("live")`). Follow AAA structure, single assertion focus, deterministic data. See `server/AGENTS.md` for testing patterns.
 - Reuse existing DTO converters/mappers instead of duplicating mapping logic. Look at `integration.scm.domain.team` for established patterns.
 - Security: new endpoints must enforce permissions using the existing security utilities (`EnsureAdminUser`, etc.).
-- Keep Liquibase changelog IDs monotonic and descriptive. Align entity annotations with the generated change sets.
+- Give each new changelog a fresh millisecond-timestamp ID greater than the previous one and append its `<include>` to the end of `master.xml` (append-only; the historical list is not globally sorted). Align entity annotations with the generated change sets.
 - Annotate record components in DTOs with `org.jspecify.annotations.NonNull` when the API requires a value; leave optional fields bare so the OpenAPI spec stays minimal without extra schema annotations.
 - Prefer resource-oriented workspace endpoints: express lifecycle transitions via HTTP methods (for example `PATCH /workspaces/{workspaceSlug}/status`) instead of RPC-style verbs and return consistent `ProblemDetail` payloads for errors.
 - When adding or changing REST endpoints, follow the centralized exception-handling rules in `docs/contributor/api-error-handling.md` so every controller returns RFC-7807 `ProblemDetail` responses via `@RestControllerAdvice`.

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -65,9 +65,10 @@ Every merge to `main` with releasable changes (`feat:`, `fix:`, `perf:`, `revert
 
 Before any release, code must pass:
 
-| Gate            | Tool        | Purpose              |
+| Gate (leg)      | Tool        | Purpose              |
 | --------------- | ----------- | -------------------- |
-| Database drift  | Liquibase   | JPA ↔ Schema sync    |
+| Migration chain + drift (`Database`) | Liquibase | Full chain applies empty → head, then schema is diffed against JPA entities |
+| Changelog immutability (`Migrations`) | git diff | Released changesets + `master.xml` are append-only |
 | OpenAPI sync    | Diff check  | Client ↔ Server sync |
 | Java formatting | Spotless    | Code style           |
 | TypeScript      | Biome + tsc | Lint + typecheck     |
@@ -208,7 +209,7 @@ The Docker build workflow will automatically use these credentials if present, f
 ### Parallel Execution
 
 - 6 test types run in parallel (3 app-server, 3 webapp). Webhook reception is part of the app-server test surface since ADR 0008.
-- 8 quality gate checks run in parallel
+- 5 quality-gate legs run in parallel (App Server, Webapp, OpenAPI, Database, Migrations), plus a legacy-cleanup guard
 - 4 Docker builds × 2 architectures (amd64 + arm64)
 - `fail-fast: false` ensures all jobs complete for full feedback
 

--- a/docs/contributor/database-migration.mdx
+++ b/docs/contributor/database-migration.mdx
@@ -58,12 +58,52 @@ Generated migrations can drop or rename columns unexpectedly. Double-check each 
 <renameColumn tableName="user" oldColumnName="first_name" newColumnName="firstName"/>
 ```
 
+## Changelog immutability policy
+
+The Liquibase changelog chain **is** the upgrade path: every production and self-hosted
+instance upgrades by replaying exactly these files, in `master.xml` order. That works only
+if history never changes underneath an instance that already ran part of it.
+
+1. **Released changesets are never edited.** A changeset is *released* once it reaches
+   `main` — from that moment it may already be applied to a production database. Editing it
+   causes checksum errors at boot on upgraded instances while fresh installs silently get a
+   different schema. Fix mistakes **forward** with a new changelog file. (Also note that
+   Liquibase [excludes preconditions, contexts, and labels from checksums](https://www.liquibase.com/blog/what-affects-changeset-checksums)
+   and silently ignores deleted changesets — so even "harmless" edits can desynchronize
+   installed instances without any error.)
+2. **`master.xml` is append-only.** Never remove or reorder existing `<include>` entries;
+   new changelogs go at the end.
+3. **Destructive changes follow deprecate-then-remove across two releases.** Renaming or
+   dropping a table/column that shipped in a release happens in two steps: release *N*
+   stops writing/reading it (and migrates data if needed), release *N+1* drops it. A single
+   release must stay bootable against the schema left behind by the previous one.
+
+CI enforces 1 and 2 mechanically (see below); 3 is a review responsibility.
+
 ## CI validation
 
-Two GitHub Actions guard against drift:
+Three GitHub Actions checks guard the database (all in `ci-quality-gates.yml`):
 
-1. **Database schema validation** – Applies migrations to a fresh DB and compares it with current entities. Failure produces a new `changelog_new.xml`.
-2. **Database documentation validation** – Generates an ERD from migrations and compares it with the committed diagram.
+1. **Migration-chain replay** (`Database` gate) – Applies the full `master.xml` chain via
+   `liquibase:update` to an empty pg_partman PostgreSQL (the production image). A changelog that
+   doesn't parse or apply fails here. This runs as the first half of the schema-drift check, so
+   it exercises the same empty→head path a fresh install boots through.
+2. **Schema-drift + ERD validation** (`Database` gate) – After applying the chain, diffs the
+   resulting schema against the JPA entities (drift produces a `changelog_new.xml`) and against
+   the committed ERD. Reproduce locally with `pnpm run db:draft-changelog`.
+3. **Changelog immutability** (`Migrations` gate) – Enforces the policy above with a pure git
+   diff against the merge-base: fails if any released file under `db/changelog/` was modified,
+   renamed, or deleted, or if an existing `master.xml` `<include>` line was removed, reordered,
+   or edited. This catches exactly the edits Liquibase checksums miss (preconditions, contexts,
+   labels, comments, and deleted changesets).
+
+The replay applies **every** changeset (the Maven plugin sets no context filter), so it validates
+that the whole chain is well-formed — it does **not** reproduce a specific instance's boot (a real
+`dev`/`prod` boot filters by `spring.liquibase.contexts`) and, running against an empty database,
+does **not** catch data-incompatible migrations (a `NOT NULL` add or a `CHECK` that existing rows
+violate). The replay is also forward-only, so `<rollback>` blocks and `onFail="MARK_RAN"`
+preconditions are never exercised. Those remain a review responsibility, enforced through the
+deprecate-then-remove discipline above.
 
 ## Entity change tips
 
@@ -103,17 +143,21 @@ flowchart TD
     subgraph CI [CI quality gates]
         D[Schema validation]
         E[ERD validation]
+        F[Changelog immutability]
     end
 
     A -.-> D
     B -.-> D
     B -.-> E
     C -.-> E
+    B -.-> F
 
     D -->|❌ Drift| G[Missing migration]
     D -->|✅| H[Schema OK]
     E -->|❌ Outdated| I[Update ERD]
     E -->|✅| J[Docs OK]
+    F -->|❌ Released file edited| K[Ship a new changelog]
+    F -->|✅| L[History intact]
 
     style CI fill:#fff3e0,stroke:#ff9800,stroke-width:2px
 ```

--- a/server/src/main/resources/db/changelog/1731511193057_changelog.xml
+++ b/server/src/main/resources/db/changelog/1731511193057_changelog.xml
@@ -66,3 +66,4 @@
         <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="team_members" constraintName="FKrk1tw9123clx7w5wjx6b58qch" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="user" validate="true"/>
     </changeSet>
 </databaseChangeLog>
+<!-- temporary CI guard verification, revert -->


### PR DESCRIPTION
Temporary draft PR that deliberately edits a released changelog to prove the new `Migrations` gate from #1390 actually fails on a violation (rather than silently skipping). Will be closed immediately once the check reports red. Do not review.