### PR TITLE
feat(docker): supported single-host self-hosting stack and install guide

### DIFF
--- a/.changeset/blessed-self-host-install.md
+++ b/.changeset/blessed-self-host-install.md
@@ -1,0 +1,13 @@
+---
+"hephaestus": minor
+---
+
+You can now self-host Hephaestus on a single Linux server. `docker/self-host/` adds one
+supported Docker Compose stack — application server, webhook receiver, PostgreSQL and NATS
+behind a TLS reverse proxy — that reuses the maintainers' service definitions, so it has no
+second copy to fall out of date. Follow the new [install guide](https://ls1intum.github.io/Hephaestus/admin/install);
+GitHub App setup, manual webhook creation, and backup/restore each have a companion page.
+
+Existing deployments are unaffected: the reference Compose files are unchanged apart from two
+safe additions — the NATS JetStream limits become overridable (defaults unchanged), and a
+release-pin sanity check that rejected every valid pin is fixed.

--- a/.changeset/fix-release-pin-grep.md
+++ b/.changeset/fix-release-pin-grep.md
@@ -1,0 +1,6 @@
+---
+"hephaestus": patch
+---
+
+Fixes the release-image pin check rejecting every valid pinned digest, which stopped the
+application server from starting on a fresh deploy that enforces the digest pin.

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -1,0 +1,102 @@
+name: Validate Compose
+
+# The self-hosted stack (docker/self-host/) composes the reference deployment's
+# service definitions via `include`, so a change to docker/compose.*.yaml can
+# break a stranger's install without touching a single self-host file. Rendering
+# both stacks here turns interpolation- and merge-level breakage into a red check
+# instead of a bad first boot. (Semantic breakage — a renamed service silently
+# joining the stack, an inherited runtime bug — still needs a real boot.)
+#
+# Runs on every PR (not just docker/ changes) so it can be a required check,
+# matching how verify-changesets.yml is wired. It is cheap: only `docker compose
+# config`, no image pulls.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: "Render compose stacks"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Render the self-hosted stack
+        working-directory: docker/self-host
+        run: |
+          set -euo pipefail
+          # Fill the required values the way an operator would; `docker compose
+          # config` fails on any variable the stack requires but .env.example
+          # does not carry, which is exactly the drift we want to catch.
+          cp .env.example .env
+          sed -i \
+            -e 's|^APP_HOSTNAME=$|APP_HOSTNAME=hephaestus.example.com|' \
+            -e 's|^ACME_EMAIL=$|ACME_EMAIL=operator@example.com|' \
+            -e 's|^POSTGRES_PASSWORD=$|POSTGRES_PASSWORD=ci-not-a-real-password|' \
+            -e 's|^HEPHAESTUS_SECURITY_ENCRYPTION_KEY=$|HEPHAESTUS_SECURITY_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef|' \
+            -e 's|^HEPHAESTUS_AUTH_STATE_COOKIE_KEY=$|HEPHAESTUS_AUTH_STATE_COOKIE_KEY=Y2ktbm90LWEtcmVhbC1zdGF0ZS1jb29raWUta2V5|' \
+            -e 's|^WEBHOOK_SECRET=$|WEBHOOK_SECRET=ci000000000000000000000000000000000|' \
+            .env
+          docker compose config > /dev/null
+          echo "Rendered services:"
+          docker compose config --services | sort
+
+      - name: Fail on unset variables
+        working-directory: docker/self-host
+        run: |
+          set -euo pipefail
+          # `config` only warns about variables missing from .env; a warning here
+          # means .env.example has fallen behind the stack it renders.
+          if docker compose config 2>&1 >/dev/null | grep "variable is not set"; then
+            echo "::error::docker/self-host/.env.example is missing variables the stack references (see warnings above)"
+            exit 1
+          fi
+
+      - name: Assert the merged stack matches single-host intent
+        working-directory: docker/self-host
+        run: |
+          set -euo pipefail
+          services=$(docker compose config --services)
+          for unwanted in application-worker maintenance; do
+            grep -qx "$unwanted" <<< "$services" && {
+              echo "::error::'$unwanted' is a reference-deployment service and must not run on a single host"; exit 1; } || true
+          done
+          for required in application-server webhook-server postgres nats-server webapp reverse-proxy; do
+            grep -qx "$required" <<< "$services" || {
+              echo "::error::'$required' is missing from the self-hosted stack"; exit 1; }
+          done
+          # Compose 2.21-2.23 parse `!override` but silently ignore it, which would
+          # publish the reference's dashboard port and keep the maintainers' ACME
+          # email. Assert the merged result rather than trust the runner's version.
+          rendered=$(docker compose config)
+          grep -q "admin@tum.de" <<< "$rendered" && {
+            echo "::error::the maintainers' ACME email survived the override — Compose is too old to honour !override"; exit 1; } || true
+          published=$(docker compose config --format json \
+            | jq -r '.services["reverse-proxy"].ports[].published' | sort -n | tr '\n' ' ')
+          [ "$published" = "80 443 " ] || {
+            echo "::error::reverse-proxy publishes '$published', expected '80 443 ' — !override was ignored"; exit 1; }
+
+      - name: Assert the pinned release version has not drifted
+        run: |
+          set -euo pipefail
+          # scripts/sync-selfhost-version.mjs keeps these equal to the release on
+          # every Version PR; a mismatch means someone edited one by hand.
+          pkg=$(node -p "require('./package.json').version")
+          env_tag=$(grep -m1 '^IMAGE_TAG=' docker/self-host/.env.example | cut -d= -f2)
+          [ "$pkg" = "$env_tag" ] || {
+            echo "::error::IMAGE_TAG=$env_tag in .env.example != package.json $pkg (run scripts/sync-selfhost-version.mjs)"; exit 1; }
+
+      - name: Render the reference deployment
+        working-directory: docker
+        run: |
+          set -euo pipefail
+          # Values mirror what the deploy workflow supplies; only proves the files
+          # still render, not that they are correct for production.
+          docker compose \
+            -f compose.proxy.yaml -f compose.core.yaml -f compose.app.yaml \
+            --env-file self-host/.env config --quiet

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Maintain Version PR
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          version: pnpm changeset version
+          # Also syncs the self-host IMAGE_TAG / install-guide version to the new
+          # release (scripts/sync-selfhost-version.mjs), so those literals never
+          # drift. The changesets action commits whatever the version step writes.
+          version: pnpm run changeset:version
           # No `publish:` — tagging, GitHub Release, and deploys are release.yml's
           # job (it uses `v`-prefixed tags to stay consistent with existing tags,
           # docker IMAGE_TAG, and the release-pin asset; `changeset tag` would emit

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ celerybeat.pid
 .env
 .venv
 env/
+
+# Self-host: Traefik writes cert material here inside the operator's checkout
+docker/self-host/letsencrypt/
 venv/
 ENV/
 env.bak/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,10 @@
+# Installing Hephaestus
+
+There is exactly **one supported install**: the Docker Compose stack in
+[`docker/self-host/`](docker/self-host/) on one 64-bit Linux host
+(4 vCPUs / 8 GB RAM / 40 GB SSD recommended). Other setups may work but are unsupported.
+
+**→ Follow the install guide: <https://ls1intum.github.io/Hephaestus/admin/install>**
+
+For contributor/development setup, see the
+[contributor docs](https://ls1intum.github.io/Hephaestus/contributor/local-development) instead.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ UI component docs: [Storybook](https://main--66a8981a27ced8fef3190d41.chromatic.
 
 ### Setup
 
-Read the [local development guide](https://ls1intum.github.io/Hephaestus/contributor/local-development) for the Spring Boot application server (with the in-process Pi mentor agent) and the React client in `webapp`.
+- **Self-hosting:** follow the [install guide](https://ls1intum.github.io/Hephaestus/admin/install) ([INSTALL.md](INSTALL.md)) — one supported Docker Compose path.
+- **Development:** read the [local development guide](https://ls1intum.github.io/Hephaestus/contributor/local-development) for the Spring Boot application server (with the in-process Pi mentor agent) and the React client in `webapp`.
 
 ## Contributing
 

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -78,7 +78,7 @@ services:
           --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
           --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
           "$$TMP/pin.yaml"
-        grep -Eq '^[[:space:]]+reference:[[:space:]]+[a-z0-9][a-z0-9.\-_/:]+@sha256:[a-f0-9]{64}$$' "$$TMP/pin.yaml" \
+        grep -Eq '^[[:space:]]+reference:[[:space:]]+[a-z0-9][a-z0-9._/:-]+@sha256:[a-f0-9]{64}$$' "$$TMP/pin.yaml" \
           || { echo "pin asset is missing a digest-pinned reference" >&2; exit 1; }
         install -m 0644 "$$TMP/pin.yaml" /pin/release-pin.yaml.new
         mv /pin/release-pin.yaml.new /pin/release-pin.yaml

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -143,6 +143,6 @@ configs:
 
       jetstream {
         store_dir: "/data"
-        max_mem: 4G
-        max_file: 50G
+        max_mem: ${NATS_JS_MAX_MEM:-4G}
+        max_file: ${NATS_JS_MAX_FILE:-50G}
       }

--- a/docker/self-host/.env.example
+++ b/docker/self-host/.env.example
@@ -1,0 +1,131 @@
+# =============================================================================
+# Hephaestus self-hosted — environment
+# =============================================================================
+#
+#   cp .env.example .env    # then fill in every REQUIRED value below
+#   docker compose up -d
+#
+# Full guide (read it first): https://ls1intum.github.io/Hephaestus/admin/install
+#
+# Hardware honesty: 4 vCPUs / 8 GB RAM / 40 GB SSD recommended. The stack runs
+# two JVM services plus Postgres and NATS; 4 GB RAM is the absolute floor and
+# only without AI practice review. Each concurrent AI review sandbox may use
+# up to 4 GiB on top.
+# =============================================================================
+
+# --- General (REQUIRED) ------------------------------------------------------
+
+# Public hostname the instance is served on (DNS A record -> this host).
+# No scheme, no trailing slash. Example: hephaestus.example.com
+APP_HOSTNAME=
+
+# Release to run: an exact version, no leading `v`, never `latest`.
+# Must match the release you checked out. See the install guide.
+IMAGE_TAG=0.73.2
+
+# Email for Let's Encrypt certificate-expiry notices.
+ACME_EMAIL=
+
+# --- Secrets (REQUIRED — generate once, then never change) -------------------
+
+# Database password. Applied only when the data volume is first initialized.
+# Generate: openssl rand -hex 16
+POSTGRES_PASSWORD=
+
+# AES-256 key encrypting credentials at rest (and sealing the JWT signing key).
+# EXACTLY 32 characters. Losing or changing it makes every stored provider
+# token unreadable — treat it like the database itself and back it up.
+# Generate: openssl rand -base64 24 | cut -c1-32
+HEPHAESTUS_SECURITY_ENCRYPTION_KEY=
+
+# Base64-encoded 32-byte AES key sealing the short-lived OAuth state cookies.
+# Generate: openssl rand -base64 32
+HEPHAESTUS_AUTH_STATE_COOKIE_KEY=
+
+# Shared secret verifying inbound GitHub/GitLab webhooks (min 32 chars).
+# You will enter this same value on the GitHub side — see the install guide.
+# Generate: openssl rand -hex 32
+WEBHOOK_SECRET=
+
+# --- Login (at least one provider REQUIRED, or nobody can sign in) -----------
+
+# GitHub OAuth App (https://github.com/settings/developers -> "New OAuth App").
+# Authorization callback URL: https://<APP_HOSTNAME>/api/login/oauth2/code/github
+# Named GH_OAUTH_* (not GITHUB_OAUTH_*) because GitHub Actions reserves the
+# GITHUB_ prefix; the container still presents the right name to the server.
+GH_OAUTH_CLIENT_ID=
+GH_OAUTH_CLIENT_SECRET=
+
+# GitLab OAuth application (optional; gitlab.com or self-hosted; scope: read_user).
+# Callback: https://<APP_HOSTNAME>/api/login/oauth2/code/gitlab
+#GITLAB_OAUTH_CLIENT_ID=
+#GITLAB_OAUTH_CLIENT_SECRET=
+#GITLAB_OAUTH_BASE_URL=https://gitlab.com
+#GITLAB_OAUTH_DISPLAY_NAME=GitLab
+
+# --- First admin (REQUIRED — set BEFORE first boot) ---------------------------
+
+# Who becomes instance admin on their first sign-in. Comma-separated
+# <provider>:@<username> or <provider>:<numeric-id>, e.g. github:@octocat
+# On public github.com prefer the numeric id (from
+# https://api.github.com/users/<login>) — handles can be reclaimed.
+HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=
+
+# Break-glass fallback: enables one-time POST /auth/bootstrap-admin while no
+# admin exists. Leave unset unless you need it; unset again after use.
+#HEPHAESTUS_AUTH_BOOTSTRAP_TOKEN=
+
+# --- GitHub App (optional — PAT-only mode works without any of these) --------
+# Needed for posting AI review feedback back to GitHub and higher rate limits.
+# Setup guide: https://ls1intum.github.io/Hephaestus/admin/github-integration
+GH_APP_PRIVATE_KEY=
+#GH_APP_ID=
+#GH_APP_INSTALLATION_URL=
+
+# Legacy GitHub token used for contributor metadata only. Leave blank.
+GH_AUTH_TOKEN=
+
+# --- Optional integrations ----------------------------------------------------
+# GitLab sync, Slack, Outline, AI practice review: enable by uncommenting here.
+# See https://ls1intum.github.io/Hephaestus/admin/production-setup for each bundle.
+#GITLAB_ENABLED=false
+#GITLAB_WORKSPACE_CREATION=false
+# Default GitLab instance for sync + workspace creation (compose otherwise defaults
+# this to the maintainers' gitlab.lrz.de). Point it at your instance.
+#GITLAB_DEFAULT_SERVER_URL=https://gitlab.com
+#HEPHAESTUS_INTEGRATION_SLACK_ENABLED=false
+#HEPHAESTUS_INTEGRATION_SLACK_CLIENT_ID=
+#HEPHAESTUS_INTEGRATION_SLACK_CLIENT_SECRET=
+#HEPHAESTUS_INTEGRATION_SLACK_SIGNING_SECRET=
+#HEPHAESTUS_INTEGRATION_OUTLINE_ENABLED=false
+
+# AI practice review bundle (enable all three together + an LLM upstream), plus
+# a model and API key per workspace in the UI. Budget ~4 GiB RAM per sandbox.
+#AGENT_NATS_ENABLED=false
+#GIT_CHECKOUT_ENABLED=false
+#PRACTICE_REVIEW_FOR_ALL=false
+#SANDBOX_MAX_CONCURRENT=1
+#LLM_PROXY_OPENAI_URL=https://api.openai.com
+
+# --- Misc (optional) -----------------------------------------------------------
+
+# Imprint/privacy pages (required for public instances in e.g. Germany):
+# see https://ls1intum.github.io/Hephaestus/admin/legal-pages
+#LEGAL_PROFILE=
+
+# Sentry error tracking. Leave blank to disable.
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=production
+# PostHog product analytics — disabled unless POSTHOG_ENABLED=true; the keys below
+# do nothing on their own. Leave the two keys present (blank is fine) either way.
+#POSTHOG_ENABLED=false
+POSTHOG_PROJECT_API_KEY=
+POSTHOG_API_HOST=
+
+# NATS JetStream limits, sized for a single host (reference deployment uses 4G/50G).
+NATS_JS_MAX_MEM=1G
+NATS_JS_MAX_FILE=10G
+
+# Proxy-trust regex; the default matches reverse-proxy's fixed IP (172.29.47.2).
+# Only set when you changed that IP or the subnet in compose.single-host.yaml.
+#HEPHAESTUS_TRUSTED_PROXIES=172\.29\.47\.2

--- a/docker/self-host/compose.single-host.yaml
+++ b/docker/self-host/compose.single-host.yaml
@@ -1,0 +1,135 @@
+# =============================================================================
+# Single-host overlay — merged on top of ../compose.{proxy,core,app}.yaml
+# by ./compose.yaml. Never used on its own.
+#
+# Everything here is a deliberate difference from the maintainers' multi-host
+# reference deployment. If a setting is NOT in this file, the self-hosted stack
+# intentionally uses the reference value.
+#
+# Merge rules that matter (docs.docker.com/reference/compose-file/merge/):
+#   mappings (environment, depends_on) merge per key — list them individually
+#   sequences (command, ports, volumes) append — use !override to replace
+# =============================================================================
+
+services:
+  # ── Services the reference runs that a single host must not ────────────────
+  # A profile no one activates: `docker compose up -d` skips these, and the
+  # reference files stay untouched (adding profiles there would risk the
+  # maintainers' deploy, which runs `up -d --remove-orphans` without profiles).
+
+  # The worker runs in-process inside application-server here (the worker
+  # runtime role defaults to enabled); the reference splits it into its own pod.
+  application-worker:
+    profiles: ["reference-deployment-only"]
+
+  # Traefik error page for the maintainers' multi-replica rollouts.
+  maintenance:
+    profiles: ["reference-deployment-only"]
+
+  reverse-proxy:
+    ports: !override
+      - "80:80"
+      - "443:443"
+    command: !override
+      # Keep --ping: the healthcheck inherited from the reference probes /ping.
+      # The ping@internal router outranks the redirect below, so it still answers
+      # on plain HTTP.
+      - "--ping=true"
+      - "--ping.entrypoint=http"
+      - "--entrypoints.http.address=:80"
+      - "--entrypoints.https.address=:443"
+      # HTTP/2 rapid-reset hardening, same as the reference (default is 250).
+      - "--entryPoints.http.http2.maxConcurrentStreams=50"
+      - "--entryPoints.https.http2.maxConcurrentStreams=50"
+      # Global HTTP->HTTPS redirect. ACME HTTP-01 challenges are still answered
+      # on :80 ahead of the redirect (Traefik handles them internally).
+      - "--entrypoints.http.http.redirections.entrypoint.to=https"
+      - "--entrypoints.http.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.http.http.encodequerysemicolons=true"
+      - "--entrypoints.https.http.encodequerysemicolons=true"
+      # Mentor chat is a long-lived SSE stream kept alive by a 20s heartbeat;
+      # 300s leaves margin above Traefik's 180s default.
+      - "--entryPoints.http.transport.respondingTimeouts.idleTimeout=300s"
+      - "--entryPoints.https.transport.respondingTimeouts.idleTimeout=300s"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?Set ACME_EMAIL in .env (Let's Encrypt expiry notices)}"
+    # The reference's labels drive its dashboard router (no rule here) and the
+    # maintenance error page (profiled out); left in place they make Traefik log
+    # errors on every start. The routers this stack needs come from the app,
+    # webapp and webhook services.
+    labels: !override []
+    networks:
+      # Fixed address so proxy trust below can name exactly this container.
+      shared-network:
+        ipv4_address: 172.29.47.2
+
+  application-server:
+    environment:
+      # The reference hardcodes root/root for its managed database; require a
+      # real password here. DATABASE_USERNAME stays `root` to match the value
+      # the postgres image bakes in when it first initialises the volume.
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      # Same value the reference builds, but fail fast instead of rendering
+      # `https://` and a Host(``) routing rule when APP_HOSTNAME is blank.
+      APPLICATION_HOST_URL: https://${APP_HOSTNAME:?Set APP_HOSTNAME in .env}
+      # One concurrent agent sandbox (up to ~4 GiB) suits the recommended 8 GB
+      # host; the reference defaults to 5 across dedicated machines.
+      SANDBOX_MAX_CONCURRENT: ${SANDBOX_MAX_CONCURRENT:-1}
+      # The reference leaves this empty on purpose so its deploy must set the
+      # ingress address explicitly (a blank value fails the boot). Here the
+      # proxy has a fixed IP, so it can simply be correct by default.
+      HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-172\.29\.47\.2}
+    ports: !override []
+    # The in-process worker drains running agent jobs on SIGTERM (up to 5m).
+    # The reference's 30s only has to cover HTTP drain on its worker-less pod.
+    stop_grace_period: 6m
+
+  webhook-server:
+    environment:
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      APPLICATION_HOST_URL: https://${APP_HOSTNAME:?Set APP_HOSTNAME in .env}
+      HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-172\.29\.47\.2}
+    depends_on:
+      # Both live in this one project, so ordering can be expressed here — the
+      # reference deploys them as separate projects and cannot.
+      postgres:
+        condition: service_healthy
+      # Liquibase runs on application-server only, so wait for it rather than
+      # querying a pre-migration schema on a cold start.
+      application-server:
+        condition: service_healthy
+      release-pin-fetcher:
+        condition: service_completed_successfully
+    volumes:
+      # AgentImagePinGuard loads in every prod container and fails the boot
+      # unless the digest pin is readable.
+      - release-pin:/pin:ro
+
+  postgres:
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    ports: !override []
+
+  webapp:
+    ports: !override []
+
+  nats-server:
+    # The reference publishes 127.0.0.1:4222 for operator access from the host.
+    # Here everything reaches NATS over the compose network, and publishing it
+    # makes `up` fail outright on a host that already runs something on 4222.
+    # JetStream is sized down via NATS_JS_MAX_MEM / NATS_JS_MAX_FILE in .env.
+    ports: !override []
+
+networks:
+  shared-network:
+    # Pinned so reverse-proxy can hold 172.29.47.2. The dynamic pool is the
+    # upper half, so no other container can take that address first. Change
+    # both halves together if this subnet collides with something on your host.
+    ipam:
+      config:
+        - subnet: 172.29.47.0/24
+          ip_range: 172.29.47.128/25

--- a/docker/self-host/compose.yaml
+++ b/docker/self-host/compose.yaml
@@ -1,0 +1,37 @@
+# =============================================================================
+# Hephaestus — the one blessed self-hosted deployment
+# =============================================================================
+#
+#   cp .env.example .env   # fill in the values
+#   docker compose up -d
+#
+# This file composes the same service definitions the maintainers deploy
+# (../compose.{proxy,core,app}.yaml) and applies `compose.single-host.yaml` on top, which
+# adapts them to a single host: no separate worker pod, no maintenance page,
+# secrets required instead of defaulted, and a proxy trust anchor that works
+# out of the box.
+#
+# There is deliberately no second copy of the service definitions, so most
+# changes to the reference (a new env var, a changed image, a fixed healthcheck)
+# reach this install with no edit here. Two things still need attention when the
+# reference changes: reverse-proxy's command/ports are pinned via `!override` and
+# must be re-synced by hand, and a service renamed in or added to the reference
+# can silently join or leave this stack. The Validate Compose CI job renders both
+# stacks on every change to catch the interpolation- and merge-level cases.
+#
+# Requires Docker Compose >= 2.24.4 (`include` + the `!override` merge tag; 2.21-2.23
+# parse this file but silently ignore `!override`). Check with:
+#   docker compose version
+#
+# See docs/admin/install.mdx for the full guide.
+# =============================================================================
+
+name: hephaestus
+
+include:
+  - path:
+      - ../compose.proxy.yaml
+      - ../compose.core.yaml
+      - ../compose.app.yaml
+      - ./compose.single-host.yaml
+    project_directory: .

--- a/docs/admin/backup-restore.mdx
+++ b/docs/admin/backup-restore.mdx
@@ -1,0 +1,69 @@
+---
+id: backup-restore
+sidebar_position: 3
+title: Backup & Restore
+description: What to back up on a self-hosted instance, and how to restore it.
+---
+
+For the [self-host compose stack](./install). The database holds irreplaceable derived data
+(observations, the feedback ledger); everything else is re-creatable.
+
+## What to back up
+
+| Data | Where | Priority |
+| --- | --- | --- |
+| PostgreSQL database | `postgresql-data` volume | **Everything.** Accounts, workspaces, observations, feedback, encrypted provider tokens, JWT signing keys. |
+| `.env` | `/opt/hephaestus/docker/self-host/.env` | **Equal priority.** `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` encrypts the tokens *inside* the database backup — a database backup without the key is partially unreadable (all stored provider credentials are lost, and all sessions invalidate). |
+| TLS certificates | `./letsencrypt/` | Optional — Let's Encrypt re-issues on first boot (rate limits permitting). |
+| Git checkout cache | `git-repos` volume | Skip — re-cloned on demand. |
+| NATS JetStream | `nats-data` volume | Skip — a transient event buffer, not a source of truth. |
+
+## Backup
+
+Logical dump while everything runs (safe — Postgres MVCC gives a consistent snapshot):
+
+```bash
+cd /opt/hephaestus/docker/self-host
+docker compose exec -T postgres pg_dump -U root -Fc hephaestus \
+  > hephaestus-$(date +%F).dump
+cp .env hephaestus-$(date +%F).env
+```
+
+Ship both files **off the host**, encrypted. Cron it daily; test-restore it at least once (below).
+
+## Restore
+
+On a fresh host, complete install steps 1–2 first, restoring the saved `.env` (same
+`POSTGRES_PASSWORD`, same `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` — non-negotiable). Then:
+
+```bash
+cd /opt/hephaestus/docker/self-host
+docker compose up -d postgres                      # database only
+docker compose stop application-server webhook-server 2>/dev/null || true
+
+docker compose exec -T postgres dropdb   -U root --if-exists hephaestus
+docker compose exec -T postgres createdb -U root hephaestus
+docker compose exec -T postgres pg_restore -U root -d hephaestus --no-owner \
+  < hephaestus-YYYY-MM-DD.dump
+
+docker compose up -d                               # full stack
+```
+
+Verify: sign in, open a workspace, check recent activity is present up to the backup
+timestamp.
+
+### After a point-in-time restore
+
+- **Sessions:** users signed in after the backup was taken must sign in again. If the
+  restored `jwt_signing_key` table is unusable, truncate it and restart — a fresh key is
+  auto-seeded and everyone re-logs-in. No data loss beyond sessions.
+- **NATS JetStream:** the stream on `nats-data` may hold events the restored database has
+  already processed (or never saw). Webhook ingest deduplicates by delivery id and
+  idempotency keys, so replays are absorbed on ingest; the end-to-end redelivery-safety
+  drill (including whether to reset consumers after a restore) is part of
+  [#1370](https://github.com/ls1intum/Hephaestus/issues/1370). The conservative option
+  after a restore from an old backup: `docker compose down`,
+  `docker volume rm hephaestus_nats-data`, `docker compose up -d` — events in the gap are
+  re-fetched by the scheduled sync.
+- **Restore into an older app version:** don't. Restore with the same `IMAGE_TAG` the
+  backup was taken from, then upgrade.

--- a/docs/admin/compatibility-policy.mdx
+++ b/docs/admin/compatibility-policy.mdx
@@ -20,7 +20,7 @@ Semantic versioning applies to the surfaces an operator or API consumer depends 
 | **Database migration chain** | Each startup applies any not-yet-applied Liquibase changesets in changelog order, so a newer release builds on the previous release's schema. Migrations run automatically when the application server starts. |
 | **Runtime prerequisites** | The minimum PostgreSQL major version, the required outbound network destinations, and any required external services. Adding one is a breaking change. |
 | **Configuration keys** | Environment variables and `hephaestus.*` properties documented in the [Production Setup](./production-setup.mdx) guide. Renames and removals are breaking changes. |
-| **Docker Compose interface** | Service names, image names, the `IMAGE_TAG` convention, and required environment variables of the published compose files (`docker/compose.app.yaml`, `docker/compose.core.yaml`, `docker/compose.proxy.yaml`). |
+| **Docker Compose interface** | Service names, image names, the `IMAGE_TAG` convention, and required environment variables of the published compose files — the self-hosted stack (`docker/self-host/compose.yaml`, see the [Install guide](./install.mdx)) and the reference deployment (`docker/compose.app.yaml`, `docker/compose.core.yaml`, `docker/compose.proxy.yaml`). |
 | **REST API** | The endpoints described by the published [OpenAPI specification](https://github.com/ls1intum/Hephaestus/blob/main/server/openapi.yaml). |
 
 Everything else — Java and TypeScript internals, the database schema itself (as opposed to the migration

--- a/docs/admin/github-integration.mdx
+++ b/docs/admin/github-integration.mdx
@@ -1,0 +1,137 @@
+---
+id: github-integration
+sidebar_position: 2
+title: GitHub Integration
+description: OAuth App for login, PAT or GitHub App for data access, and manual webhook setup.
+---
+
+Hephaestus talks to GitHub through **three separate mechanisms** — easy to confuse, so
+here is the map:
+
+| Mechanism | Purpose | Required? |
+| --- | --- | --- |
+| **OAuth App** | "Sign in with GitHub" | Yes (unless you use GitLab login only) |
+| **PAT** *or* **GitHub App** | Reading repository data (per workspace) | One of the two |
+| **Webhook** | Live event ingestion (PRs, reviews, pushes, …) | Strongly recommended — without it you only get the hourly sync poll |
+
+The OAuth App is covered in the [install guide](./install#3-create-the-github-oauth-app-login--mandatory).
+This page covers the other two.
+
+## Choosing PAT vs GitHub App
+
+**PAT mode is fully supported** and is the right starting point for a single-org install:
+
+| | PAT | GitHub App |
+| --- | --- | --- |
+| Setup effort | Paste a token in the workspace UI | Create + install an App, manage a private key |
+| Environment variables | None | `GH_APP_ID`, `GH_APP_PRIVATE_KEY`, `GH_APP_INSTALLATION_URL` |
+| Rate limits | 5,000 req/h, shared across all of that user's tokens | 5,000+ req/h **per installation**, scaling with org size (up to 12,500) |
+| AI-review feedback posted back to GitHub (PR comments, inline findings, approvals) | Posted as the token's user | Posted as the App (recommended) |
+| Webhooks | Create manually (below) | Configured once on the App |
+
+Tokens are stored encrypted (AES-256-GCM) per workspace in the database.
+
+### PAT mode
+
+1. Create a token: **classic PAT** with `repo` + `read:org` (the `repo` scope already
+   grants PR/issue write for feedback delivery), or a **fine-grained PAT** whose *resource
+   owner* is the organization, with repository permissions Contents, Issues, Pull requests
+   and Discussions (Read — add Write on Issues and Pull requests to deliver AI-review
+   feedback) plus organization permissions Members and Projects (Read). Omitting
+   Discussions or Projects leaves those syncs silently empty.
+2. Leave `GH_APP_ID` unset (defaults to `0` = PAT mode).
+3. Paste the token when creating/configuring the workspace in the UI.
+4. Set up a webhook manually (next section).
+
+### GitHub App mode
+
+Create the App at **Settings → Developer settings → GitHub Apps → New GitHub App**
+(on your org: `https://github.com/organizations/<org>/settings/apps`).
+
+- **Homepage URL:** `https://<APP_HOSTNAME>`
+- **Webhook → Active:** ✔, **Webhook URL:** `https://<APP_HOSTNAME>/webhooks/github`,
+  **Secret:** your `WEBHOOK_SECRET` from `.env` (byte-identical)
+- **Where can this GitHub App be installed:** *Only on this account* is fine — as long as you created the App on the organization that will install it (an App registered under a personal account can never be installed on an org)
+
+**Repository permissions** (GitHub greys out webhook events until the matching permission
+is granted):
+
+| Permission | Level | Why |
+| --- | --- | --- |
+| Metadata | Read | Baseline (mandatory) |
+| Contents | Read | Push/commit sync, repo checkout for AI review |
+| Pull requests | Read & write | PR/review sync; posting review feedback, inline findings, approvals |
+| Issues | Read & write | Issue sync; delivering feedback as issue/PR comments (GraphQL `addComment`) |
+| Discussions | Read | Discussion sync |
+
+**Organization permissions:**
+
+| Permission | Level | Why |
+| --- | --- | --- |
+| Members | Read | Org membership, teams, member events |
+| Projects | Read | `projects_v2*` events + Projects v2 sync (Projects is an org-level permission) |
+
+**Subscribe to events** (check all — this list mirrors what the server actually consumes,
+`GitHubEventType`):
+
+`push`, `pull_request`, `pull_request_review`, `pull_request_review_comment`,
+`pull_request_review_thread`, `issues`, `issue_comment`, `label`, `milestone`, `member`,
+`repository`, `discussion`, `discussion_comment`, `sub_issues`, `issue_dependencies`,
+`organization`, `team`, `membership`
+
+Installation events are delivered to Apps automatically — there is no checkbox for them.
+If `issue_dependencies` isn't offered in your App's list, skip it: Hephaestus also reads
+issue dependencies through its regular GraphQL sync, so you only lose live updates for
+that one relation type.
+
+**Projects v2 is the exception.** GitHub documents `projects_v2`, `projects_v2_item` and
+`projects_v2_status_update` as **organization-webhook** events, so a GitHub App's own
+webhook may not receive them. If you want project boards to sync live, add an
+organization webhook (next section) alongside the App — and grant the App the
+organization **Projects: Read** permission, which the project sync itself needs.
+
+Then:
+
+1. Generate a **private key** (App settings → Private keys) and download the `.pem`.
+2. **Install the App** on your organization (all repositories, or the ones to monitor).
+3. In `.env`, set:
+
+   ```bash
+   GH_APP_ID=123456
+   # Multi-line PEM: quote the whole value; Docker Compose .env preserves the newlines.
+   GH_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+   ...
+   -----END RSA PRIVATE KEY-----"
+   # Shown in the workspace-creation wizard so admins can install the App:
+   GH_APP_INSTALLATION_URL=https://github.com/apps/<your-app-slug>/installations/new
+   ```
+
+4. `docker compose up -d` to restart with the new environment.
+
+## GitHub webhooks — manual setup (PAT mode)
+
+Unlike GitLab (where Hephaestus auto-registers a group webhook), **there is no GitHub
+webhook auto-registration**. In GitHub App mode the App's webhook covers everything; in
+PAT mode you create one yourself, or your install ingests **zero live events with no
+error telling you why**.
+
+Prefer one **organization webhook** (repo webhooks can't deliver `organization`, `team`,
+`membership`): `https://github.com/organizations/<org>/settings/hooks` → **Add webhook**.
+
+- **Payload URL:** `https://<APP_HOSTNAME>/webhooks/github`
+- **Content type:** `application/json`
+- **Secret:** your `WEBHOOK_SECRET` (verified as `X-Hub-Signature-256` HMAC)
+- **Events:** "Let me select individual events" → check the same event list as above, plus
+  `projects_v2`, `projects_v2_item` and `projects_v2_status_update` if you use project
+  boards. Those three exist on **organization** webhooks only (never repository webhooks)
+  and only fire for organization-level projects.
+
+## Verify it works
+
+1. GitHub → your App/webhook settings → **Recent Deliveries**: real events return `2xx`.
+   Note the initial `ping` returns `200` even when the secret is wrong (it is answered
+   before signature verification), so judge by a real event. A `401` means the secret
+   doesn't match `.env`; a timeout means `/webhooks` isn't reachable from the internet.
+2. `docker compose logs -f webhook-server` — each accepted delivery is published to NATS.
+3. Open a test PR in a monitored repo; it should appear in Hephaestus within seconds
+   (webhook) rather than on the next hourly sync (polling fallback).

--- a/docs/admin/install.mdx
+++ b/docs/admin/install.mdx
@@ -1,0 +1,198 @@
+---
+id: install
+sidebar_position: 0
+title: Install (Self-Hosted)
+description: The one supported way to run your own Hephaestus — Docker Compose on a single host.
+---
+
+This is the **only supported install path**: the Docker Compose stack in
+[`docker/self-host/`](https://github.com/ls1intum/Hephaestus/tree/main/docker/self-host)
+on one Linux host. Other setups (own reverse proxy, external database, Kubernetes, Podman)
+can work but are unsupported.
+
+The stack you get:
+
+| Service | What it is |
+| --- | --- |
+| `reverse-proxy` | Traefik — TLS via Let's Encrypt, routes `/`, `/api`, `/webhooks` |
+| `webapp` | React SPA served by nginx |
+| `application-server` | Spring Boot API + in-process job worker |
+| `webhook-server` | Same image, webhook profile — keeps receiving events while the app restarts |
+| `postgres` | PostgreSQL 17 + pg_partman (custom image — vanilla `postgres:17` is **not** a drop-in) |
+| `nats-server` | NATS JetStream event buffer |
+| `release-pin-fetcher` | One-shot init container verifying the release's signed agent-image digests |
+
+## Requirements
+
+- **4 vCPUs, 8 GB RAM, 40 GB SSD** recommended. Absolute floor: 2 vCPUs / 4 GB RAM —
+  the stack runs **two JVMs** plus Postgres and NATS, so 4 GB means swap and slow starts.
+- **AI practice review adds real memory**: each concurrent review sandbox may use up to
+  4 GiB. The default caps it at 1 concurrent sandbox; raise
+  `SANDBOX_MAX_CONCURRENT` only with RAM to match.
+- 64-bit Linux with **Docker Engine ≥ 24** and **Docker Compose ≥ 2.24.4** (`docker compose version`), plus `git`.
+- A **DNS A record** for your hostname pointing at the host, with ports **80 and 443**
+  reachable from the internet (Let's Encrypt HTTP-01, OAuth callbacks, webhooks).
+- Outbound HTTPS to `ghcr.io` (images), `github.com` (release pin) and `api.github.com`.
+
+## 1. Get the files
+
+Check out the newest version from the
+[releases page](https://github.com/ls1intum/Hephaestus/releases):
+
+```bash
+VERSION=0.73.2   # the release you are installing, without the leading "v"
+sudo git clone --depth 1 --branch "v$VERSION" \
+  https://github.com/ls1intum/Hephaestus.git /opt/hephaestus
+sudo chown -R "$USER" /opt/hephaestus
+cd /opt/hephaestus/docker/self-host
+cp .env.example .env
+```
+
+Everything below runs from `/opt/hephaestus/docker/self-host`. Inspect the effective
+configuration at any time with `docker compose config`.
+
+## 2. Configure `.env`
+
+Open `.env` and fill in every **REQUIRED** value. The short version:
+
+| Variable | What / how |
+| --- | --- |
+| `APP_HOSTNAME` | Your public hostname, e.g. `hephaestus.example.com` |
+| `IMAGE_TAG` | The same `$VERSION` you fetched above — an exact release, never `latest` |
+| `ACME_EMAIL` | Let's Encrypt expiry notices |
+| `POSTGRES_PASSWORD` | `openssl rand -hex 16` |
+| `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` | `openssl rand -base64 24 \| cut -c1-32` — exactly 32 chars (see the warning below) |
+| `HEPHAESTUS_AUTH_STATE_COOKIE_KEY` | `openssl rand -base64 32` |
+| `WEBHOOK_SECRET` | `openssl rand -hex 32` — you'll enter the same value on GitHub later |
+| `GH_OAUTH_CLIENT_ID` / `_SECRET` | From step 3 |
+| `HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS` | From step 4 — set it **before** first boot |
+
+:::danger Back up the encryption key
+`HEPHAESTUS_SECURITY_ENCRYPTION_KEY` encrypts every stored provider token and seals the JWT
+signing key. If you lose or change it, those tokens become unreadable and all sessions
+invalidate. Store it as carefully as the database itself, and never change it after first boot.
+:::
+
+## 3. Create the GitHub OAuth App (login — mandatory)
+
+Without a login provider the instance boots but shows **no sign-in button**. GitHub login
+needs a plain **OAuth App** (this is *not* the same thing as the GitHub App used for data
+access — see [GitHub integration](./github-integration)):
+
+1. [github.com/settings/developers](https://github.com/settings/developers) →
+   **New OAuth App** (or under your org's settings).
+2. **Homepage URL:** `https://<APP_HOSTNAME>`
+3. **Authorization callback URL:** `https://<APP_HOSTNAME>/api/login/oauth2/code/github`
+   — exact string, including `/api`, no trailing slash.
+4. Create a client secret; put both values into `.env` as
+   `GH_OAUTH_CLIENT_ID` / `GH_OAUTH_CLIENT_SECRET`.
+
+GitLab login works the same way and can be used instead of (or next to) GitHub — see the
+[GitLab section in Production Setup](./production-setup#gitlab-rollout-bundle).
+
+## 4. First admin — before first boot
+
+The admin UI is admin-gated, so the **first instance admin must come from operator
+config**, not the UI. Set in `.env`:
+
+```bash
+HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=github:@your-github-username
+```
+
+- Format: comma-separated `<provider>:@<username>` or `<provider>:<numeric-id>`.
+- On public github.com prefer the numeric id (`github:1234567`, from
+  `https://api.github.com/users/<login>`) — abandoned handles can be reclaimed by others.
+- Promotion happens **on sign-in**, is idempotent, and never demotes. If you forgot to set
+  it, add it and restart — no reinstall needed. There is also a break-glass
+  `HEPHAESTUS_AUTH_BOOTSTRAP_TOKEN`; details in the
+  [auth runbook](https://github.com/ls1intum/Hephaestus/blob/main/docs/runbooks/auth-cutover.md#first-instance-admin-bootstrap).
+
+## 5. First boot
+
+```bash
+docker compose up -d
+docker compose logs -f application-server   # watch Liquibase migrations finish
+```
+
+First start pulls ~2 GB of images and runs all database migrations; expect a few minutes.
+Then:
+
+1. Open `https://<APP_HOSTNAME>` — the login page should offer **Sign in with GitHub**.
+2. Sign in as the bootstrap admin. You should see instance-admin navigation.
+3. Create your first workspace and connect it to GitHub.
+
+## 6. Connect GitHub data
+
+Login alone syncs nothing. Two things make data flow, both covered step-by-step in
+[GitHub integration](./github-integration):
+
+1. **Repository access** — either a **PAT** pasted into the workspace UI (simplest) or a
+   **GitHub App** (needed for AI-review feedback posted back to GitHub, better rate limits).
+2. **Webhooks** — Hephaestus does **not** auto-register GitHub webhooks (unlike GitLab).
+   Configure the webhook on your GitHub App **or** create an org/repo webhook manually,
+   pointing at `https://<APP_HOSTNAME>/webhooks/github` with your `WEBHOOK_SECRET`. Without
+   it the instance only sees changes on the hourly sync poll, and nothing warns you.
+
+## 7. Optional integrations
+
+All off by default. The compose file already passes their variables through — enable them
+in `.env` and `docker compose up -d`. Each is documented in
+[Production Setup](./production-setup), which doubles as the variable reference:
+
+| Add-on | What it gives you | Where |
+| --- | --- | --- |
+| GitLab | GitLab login, workspaces, and sync (webhooks auto-register here) | [GitLab bundle](./production-setup#gitlab-rollout-bundle) |
+| Slack | Mentor in Slack, channel ingestion, digests | [Slack app setup](./production-setup#slack-app-configuration) |
+| Outline | Wiki as a content source for reviews | [Outline integration](./production-setup#outline-integration) |
+| AI practice review | Automated PR feedback from the coding agent | [Practice review bundle](./production-setup#practice-review-rollout-bundle) |
+
+**AI practice review needs two things, not one:** the environment bundle above
+(`AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, `PRACTICE_REVIEW_FOR_ALL` — set together, plus
+an `LLM_PROXY_*` upstream), **and** a model with an API key configured per workspace in the
+UI under **Workspace settings → AI**. With the flags on but no workspace model, nothing is
+reviewed and no error explains why.
+
+## 8. Legal pages (public instances)
+
+:::caution Public instances need legal pages
+`/imprint` and `/privacy` serve a red "not configured" fallback until you provide your own.
+For operators in Germany that is a § 5 DDG / Art. 13 GDPR obligation **before** opening the
+instance to users. See [Legal Pages](./legal-pages).
+:::
+
+## Upgrades
+
+Any release upgrades directly to any later one — no intermediate steps. Support window and
+what a version number promises: [Compatibility Policy](./compatibility-policy).
+
+```bash
+# 1. Back up first — see Backup & Restore.
+VERSION=<new version>
+cd /opt/hephaestus
+sudo git fetch --depth 1 origin tag "v$VERSION" && sudo git checkout "v$VERSION"
+# 2. Set IMAGE_TAG=$VERSION in docker/self-host/.env, then:
+cd docker/self-host && docker compose pull && docker compose up -d
+```
+
+Compare your `.env` against the new release's `.env.example` for added variables. A release
+that changes the bundled PostgreSQL major version needs a dump and restore, not an in-place
+upgrade — such releases say so in their notes.
+
+:::warning Downgrades are not supported
+Never point an older `IMAGE_TAG` at a database a newer release has already migrated — restore
+a backup instead. Set up [Backup & Restore](./backup-restore) **before** you have data worth losing.
+:::
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `application-server` exits: *ProxyTrustGuard* | `HEPHAESTUS_TRUSTED_PROXIES` is blank. The compose default is non-blank, so this means you overrode it to empty — unset your override, or set it to match `reverse-proxy`'s IP if you changed the network. |
+| Exits: encryption-key length error | `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` must be exactly 32 characters — regenerate with the command above. |
+| Login page has no sign-in button | No login provider configured: both `GH_OAUTH_CLIENT_ID` **and** `_SECRET` must be non-empty (a half-filled pair is skipped and logged at ERROR). |
+| OAuth redirect loop / cookie never sticks | A proxy in front of Traefik is injecting a `Domain=` attribute on cookies, which browsers reject for `__Host-` cookies. Serve the stack directly on ports 80/443. |
+| Signed in but not admin | `HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS` didn't match. On the account's **first** login the server logs (INFO) the exact `provider subject username` it saw — copy that into the allowlist and restart. (For an account that already existed, check that log line from its first sign-in, or use the numeric id.) |
+| GitHub webhook deliveries show `401` | `WEBHOOK_SECRET` on GitHub differs from `.env` — must be byte-identical. |
+| Data appears only ~hourly | No GitHub webhook configured (see step 6). |
+| `release-pin-fetcher` fails | `IMAGE_TAG` is not a published release (no signed pin asset), or the host can't reach `github.com`. Use a real release tag and check outbound HTTPS. |
+| `docker compose down`/`logs` aborts with "variable is missing" | Required `.env` values are validated for every subcommand. Fill them (dummy values are fine) before teardown. |

--- a/docs/admin/production-setup.mdx
+++ b/docs/admin/production-setup.mdx
@@ -5,7 +5,9 @@ title: Production Setup
 description: Checklist for deploying Hephaestus in a production environment.
 ---
 
-This guide covers the minimum configuration required to deploy Hephaestus in production. It assumes you are familiar with Docker Compose or Kubernetes and have access to the protected secrets managed by TUM.
+This guide documents the **reference (TUM) deployment** — the multi-file compose stack in `docker/compose.{proxy,core,app}.yaml` — and serves as the variable reference for every optional integration bundle. It assumes familiarity with Docker Compose and access to the protected secrets managed by TUM.
+
+**Self-hosting your own instance?** Start with the [Install guide](./install) — the single supported compose file — and come back here only for the optional bundles (GitLab, Slack, Outline, practice review).
 
 ## Platform overview
 
@@ -14,7 +16,7 @@ The production stack consists of:
 - **Application server** (Spring Boot, runs the Pi mentor agent in-process)
 - **Webhook server** (same Spring Boot artifact, `webhook` profile → NATS JetStream)
 - **React webapp** (served via nginx)
-- **PostgreSQL 16**
+- **PostgreSQL 17** (custom image with `pg_partman` — see ADR 0018; vanilla `postgres:17` is not a drop-in)
 - **Hephaestus-native auth** (Spring Security `oauth2Login` federating to GitHub + optional GitLab — gitlab.com or self-hosted — issuing cookie-session JWTs — ADR 0017)
 
 ## Environment variables
@@ -153,16 +155,9 @@ A lapsed key reports `accepted=false` and the mirror stops refreshing until it i
 
 ### GitHub integration
 
-Hephaestus can connect to GitHub using either a **Personal Access Token (PAT)** or a **GitHub App**:
+Hephaestus can connect to GitHub using either a **Personal Access Token (PAT)** or a **GitHub App**. The full setup — mode comparison, required GitHub App permissions, the webhook event list, and manual webhook creation (GitHub has **no** auto-registration, unlike GitLab) — lives in [GitHub Integration](./github-integration).
 
-- **Personal Access Token**: Simpler to set up. Configure tokens through the workspace UI after deployment. No additional environment variables required.
-- **GitHub App** (optional): Provides more granular permissions and better rate limits. If using a GitHub App, set:
-  - `GH_APP_ID`: Your GitHub App ID
-  - `GH_APP_PRIVATE_KEY`: Your GitHub App private key (PEM format)
-  - `GH_APP_PRIVATE_KEY_LOCATION`: Alternative path to private key file (optional)
-   - `GH_APP_INSTALLATION_URL`: Install URL shown in the workspace creation wizard
-
-The application works with either approach. If GitHub App credentials are not provided (defaults to `GH_APP_ID=0`), workspaces will use Personal Access Tokens instead.
+Environment variables for GitHub App mode: `GH_APP_ID`, `GH_APP_PRIVATE_KEY` (or `GH_APP_PRIVATE_KEY_LOCATION`), `GH_APP_INSTALLATION_URL`. If not provided (`GH_APP_ID=0`, the default), workspaces use PATs configured through the UI.
 
 ### GitLab rollout bundle
 
@@ -198,13 +193,12 @@ Practice review is not enabled by a single flag. The following settings must be 
 | `PRACTICE_REVIEW_DELIVER_TO_MERGED` | Allows delivery after merge |
 | `PRACTICE_REVIEW_COOLDOWN_MINUTES` | Minimum delay between repeated reviews of the same PR/MR |
 | `PRACTICE_REVIEW_APP_BASE_URL` | Footer link in review comments |
-| `SANDBOX_ENABLED` | Enables the Docker sandbox used by the coding agent |
 | `AGENT_NATS_ENABLED` | Enables the agent job queue and executor |
 | `GIT_CHECKOUT_ENABLED` | Enables local repo checkout and bind-mount into agent containers |
 | `NATS_ENABLED` | Enables webhook-driven sync consumption |
 | `NATS_DURABLE_CONSUMER_NAME` | Durable consumer name for sync processing |
 
-`SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` must be `true` together for practice review. Anything else is a half-configured deployment.
+The Docker sandbox itself is activated by the **worker runtime role** (`hephaestus.runtime.worker.enabled`, default `true` in the monolith and in the dedicated `application-worker` pod), not by a flag. `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` must be `true` together for practice review — anything else is a half-configured deployment.
 
 ### Rollout tiers
 
@@ -213,7 +207,7 @@ Use the same variables differently across environments:
 | Environment | Intended scope |
 | --- | --- |
 | Preview | Limited by default. Keep GitLab login, GitLab workspaces, sandbox, git checkout, and agent job execution disabled unless preview is explicitly being used as rollout validation. |
-| Staging | Uses the production compose files, but should still be a controlled rollout. Start by enabling GitLab login and GitLab workspace creation first. Only enable `SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` when staging is intentionally validating practice review execution. |
+| Staging | Uses the production compose files, but should still be a controlled rollout. Start by enabling GitLab login and GitLab workspace creation first. Only enable `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` when staging is intentionally validating practice review execution. |
 | Production | Full rollout only after staging has validated the exact same bundle. |
 
 Staging and production both use the production compose files. The difference should come from the `.env` values, not from a different compose topology.
@@ -255,7 +249,7 @@ The sync scheduler fetches recent GitHub activity (issues, PRs, reviews) for mon
 
 ## Deployment steps
 
-1. **Provision infrastructure:** Ensure PostgreSQL, Redis (if used), and storage volumes are ready.
+1. **Provision infrastructure:** Ensure PostgreSQL, NATS, and storage volumes are ready.
 2. **Configure authentication:**
    - Copy `server/.env.example` to `server/.env`, then populate `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `HEPHAESTUS_AUTH_ISSUER`, and `HEPHAESTUS_AUTH_STATE_COOKIE_KEY`. The GitHub OAuth app's callback must be `https://<host>/api/login/oauth2/code/github`.
    - Confirm the GitHub identity provider requests the `user:email` scopes and disable username/password login flows to keep authentication SSO-only.
@@ -267,7 +261,7 @@ The sync scheduler fetches recent GitHub activity (issues, PRs, reviews) for mon
    - Designate the first super-admin **before first boot** via the allowlist `HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=<provider>:@<username>` (e.g. `github:@octocat`), or use the one-time break-glass `HEPHAESTUS_AUTH_BOOTSTRAP_TOKEN` — both are idempotent and lockout-safe (see the `docs/runbooks/auth-cutover.md` runbook → *First instance admin*). They promote on login; subsequent admins are managed from `/admin/users`. Hand-editing `account.app_role = 'APP_ADMIN'` in SQL is a last-resort fallback only.
    - Verify that the super admin user can access workspace admin endpoints for workspaces where they have membership (they are automatically elevated to workspace ADMIN level for those workspaces).
    - Trigger a test webhook from GitHub or GitLab to validate the ingest pipeline.
-   - Verify that `GITLAB_ENABLED`, `GITLAB_WORKSPACE_CREATION`, `SANDBOX_ENABLED`, `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` are all present in the deployed environment before testing GitLab practice review.
+   - Verify that `GITLAB_ENABLED`, `GITLAB_WORKSPACE_CREATION`, `AGENT_NATS_ENABLED`, `GIT_CHECKOUT_ENABLED`, and `NATS_ENABLED` are all present in the deployed environment before testing GitLab practice review.
    - Open `/imprint` and `/privacy`. If the red "not configured" banner is shown, configure a [legal profile or overrides](./legal-pages) **before** opening the deployment to end users — serving the built-in disclaimer is a § 5 DDG / Art. 13 GDPR violation.
 
 ## Global admin privileges

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -244,7 +244,7 @@ const config: Config = {
           items: [
             {
               label: 'Admin Guide',
-              to: '/admin/production-setup',
+              to: '/admin/install',
             },
           ],
         },

--- a/docs/sidebars.admin.ts
+++ b/docs/sidebars.admin.ts
@@ -2,6 +2,9 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
 const sidebars: SidebarsConfig = {
   adminSidebar: [
+    {type: 'doc', id: 'install', label: 'Install (Self-Hosted)'},
+    {type: 'doc', id: 'github-integration', label: 'GitHub Integration'},
+    {type: 'doc', id: 'backup-restore', label: 'Backup & Restore'},
     {type: 'doc', id: 'production-setup', label: 'Production Setup'},
     {type: 'doc', id: 'compatibility-policy', label: 'Compatibility Policy'},
     {type: 'doc', id: 'runtime-roles', label: 'Runtime Roles'},

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -19,8 +19,8 @@ const guideLinks = [
   },
   {
     title: 'Admin Guide',
-    description: 'Deploy Hephaestus securely and manage workspace configuration.',
-    to: '/admin/production-setup',
+    description: 'Install Hephaestus on your own server and operate it.',
+    to: '/admin/install',
   },
 ];
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"packageManager": "pnpm@11.1.2",
 	"scripts": {
+		"changeset:version": "changeset version && node scripts/sync-selfhost-version.mjs",
 		"generate:api:application-server:clean": "node -e \"import('node:fs/promises').then(fs => fs.rm('webapp/src/api', {recursive: true, force: true}))\"",
 		"generate:api:application-server:specs": "cd server && sh -c 'if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then ./mvnw verify -DskipTests=true -Dapp.profiles=specs; else SPRING_DOCKER_COMPOSE_ENABLED=false ./mvnw verify -DskipTests=true -Dapp.profiles=specs; fi'",
 		"generate:api:application-server:client": "pnpm run generate:api:application-server:clean && pnpm --filter webapp run openapi-ts",

--- a/scripts/sync-selfhost-version.mjs
+++ b/scripts/sync-selfhost-version.mjs
@@ -1,0 +1,36 @@
+// Keeps the self-hosted install's pinned release version in step with the root
+// package version. Run by the `changeset:version` script (see package.json) as
+// part of the Version PR, so `IMAGE_TAG` in the self-host .env.example and the
+// `VERSION=` example in the install guide always match the release being cut —
+// no manual bump, no drift. CI (ci-compose-validate) fails if they diverge.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const version = JSON.parse(readFileSync("package.json", "utf8")).version;
+
+const edits = [
+  {
+    file: "docker/self-host/.env.example",
+    re: /^IMAGE_TAG=.*$/m,
+    line: `IMAGE_TAG=${version}`,
+  },
+  {
+    file: "docs/admin/install.mdx",
+    re: /^VERSION=\S+(\s+# the release you are installing.*)$/m,
+    line: `VERSION=${version}$1`,
+  },
+];
+
+for (const { file, re, line } of edits) {
+  let text;
+  try {
+    text = readFileSync(file, "utf8");
+  } catch {
+    continue; // file may not exist in every checkout; skip quietly
+  }
+  if (!re.test(text)) {
+    throw new Error(`sync-selfhost-version: no version literal matched in ${file}`);
+  }
+  writeFileSync(file, text.replace(re, line));
+}
+
+console.log(`Synced self-host version literals to ${version}`);


### PR DESCRIPTION
## Description

Hephaestus had no install a stranger could complete. The only deployment doc assumed the maintainers' own infrastructure ("access to the protected secrets managed by TUM"), the Compose files were split across three files with hardcoded `root`/`root` credentials and a TUM email, and the GitHub setup a self-hoster actually needs was documented nowhere.

This adds **exactly one supported install path** — a single-host Docker Compose stack plus the docs to follow it — in the spirit of [Discourse's policy](https://github.com/discourse/discourse/blob/main/docs/INSTALL.md): support one setup well rather than many badly.

### What a self-hoster gets

- **`docker/self-host/`** — `cp .env.example .env`, fill it in, `docker compose up -d`. The stack: Traefik (TLS via Let's Encrypt), the webapp, the application server (with its worker in-process), the webhook receiver, PostgreSQL and NATS.
- **[Install guide](https://github.com/ls1intum/Hephaestus/blob/1381-blessed-docker-infra-docs/docs/admin/install.mdx)** — honest hardware requirements, the mandatory GitHub OAuth app, **first-admin bootstrap**, optional integrations, upgrades, and a troubleshooting table keyed to the errors the server actually throws.
- **[GitHub integration guide](https://github.com/ls1intum/Hephaestus/blob/1381-blessed-docker-infra-docs/docs/admin/github-integration.mdx)** — the real install cliff: OAuth App vs GitHub App vs PAT, the App permission + webhook-event matrix, and **manual webhook setup**. GitHub has no webhook auto-registration (GitLab does), so without this step an instance receives no live events and nothing tells you why.
- **[Backup & restore](https://github.com/ls1intum/Hephaestus/blob/1381-blessed-docker-infra-docs/docs/admin/backup-restore.mdx)** — a one-pager wired to #1370.

### How it's built (and why it won't rot)

Rather than fork the stack, `docker/self-host/compose.yaml` **`include`s** the maintainers' own `docker/compose.{proxy,core,app}.yaml` and layers a small `compose.single-host.yaml` overlay on top. The overlay is the entire single-host delta: the worker and maintenance services are moved into an unused Compose profile, secrets become required (`:?`) instead of defaulted, the reverse proxy loses the dashboard port and the TUM ACME email, and NATS is sized for one box. **The reference files' service definitions are otherwise unchanged**, so the maintainers' production deploy is untouched — and there is no second copy of the stack to fall out of date.

A new **`Validate Compose` CI job** renders both stacks on every PR and fails if the merge silently drops the overrides or if `.env.example` falls behind — the repo's first compose validation.

### Version stays current automatically

`scripts/sync-selfhost-version.mjs` runs inside the Version PR (via a `changeset:version` step) and rewrites the pinned `IMAGE_TAG` and the guide's `VERSION=` to the release being cut. CI asserts they match `package.json`, so the "install version 0.73.2" in the docs is never stale.

### Two reference fixes (both zero-action for the maintainers)

1. **The release-image pin check rejected every valid pin.** The sanity grep used `[a-z0-9.\-_/:]`, where `\-_` is a POSIX range that *excludes* a literal hyphen — so `agent-pi@sha256:…` never matched, the init container exited 1, and the application server (which waits on it) never started. Verified against the real v0.73.2 pin asset in the real container. This bricks any fresh deploy that enforces the digest pin; it's latent in production only because that deploy runs with the pin skipped. Fixed by reordering the class to `[a-z0-9._/:-]`.
2. **NATS JetStream limits are now overridable** (`NATS_JS_MAX_MEM` / `NATS_JS_MAX_FILE`) with the current `4G`/`50G` as defaults, so the single-host stack can request `1G`/`10G` without duplicating the config block.

Fixes #1381

## How to test

**Docs (CI-covered):** the Docusaurus build gates broken links and anchors. Read the [install guide](https://github.com/ls1intum/Hephaestus/blob/1381-blessed-docker-infra-docs/docs/admin/install.mdx) as if you'd never seen this repo.

**Render + fail-fast (what `Validate Compose` runs):**

```bash
cd docker/self-host
cp .env.example .env && docker compose config   # fails, naming each missing secret
# fill APP_HOSTNAME, ACME_EMAIL and the four secrets, then:
docker compose config --services                # 7 services; no application-worker, no maintenance
```
Requires Docker Compose ≥ 2.24.4 (`include` + `!override`).

**Confirm the maintainers' stack is untouched:**
```bash
cd docker && docker compose -f compose.proxy.yaml -f compose.core.yaml -f compose.app.yaml --env-file self-host/.env config --quiet
git diff main -- docker/compose.proxy.yaml   # empty; the only reference edits are the NATS + pin-grep lines
```

**Full smoke test** needs a host with DNS + ports 80/443. `docker compose up -d`, then sign in with GitHub, confirm the bootstrap admin lands with instance-admin nav, and check a GitHub webhook delivery returns `2xx`.

<details>
<summary>What I verified empirically vs. what I did not</summary>

Booted from the merged model on this machine: `postgres` and `nats-server` reach `healthy`, DB auth works with the `.env` password, and NATS reports JetStream `1G`/`10G` at runtime (proving the parameterized config reaches the running server). Traefik's `/ping` healthcheck returns `OK` with the exact merged flags. The release-pin regex fix was verified against the real published pin asset inside the real `release-pin-fetcher` image. The multi-line GitHub-App PEM instruction was verified by round-tripping a key through a container.

**Not verified:** the full stack has not been booted on a public host — ports 80/443 are occupied here and there's no DNS — so Let's Encrypt issuance, the OAuth round trip, and a live webhook delivery are unconfirmed by me.
</details>

<details>
<summary>Honest limits of the anti-drift design</summary>

The overlay eliminates *copy* drift of service definitions, not every kind. Three things still need a human when the reference changes, and the PR does not pretend otherwise: (1) the reverse-proxy `command`/`ports` are pinned via `!override` and must be re-synced by hand; (2) a service renamed in or added to the reference can silently join or leave the stack; (3) correctness bugs in the reference are inherited, not filtered (the pin-grep bug above is exactly that). The CI job catches the interpolation- and merge-level cases; the rest is documented in the compose header.
</details>

## Checklist

- [x] My changeset summary reads as an operator/user-facing note — two changesets: the feature (minor) and the pin-check fix (patch)
- [x] No operator action required on upgrade; existing deployments are unaffected (stated in the changeset)
