### PR TITLE
ci: open the Version PR as github-actions[bot] with no CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,7 +25,14 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       ci-config: ${{ steps.filter.outputs.ci-config }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.agent-images == 'true' }}
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      # The changesets Version PR only edits package.json, CHANGELOG.md and
+      # deletes .changeset/*.md — nothing that can break a build, yet it touches
+      # package.json and so would otherwise trigger the full matrix (including
+      # Docker builds) on every merge to main. Skip the heavy legs; the "CI
+      # Status Gate" still reports "All CI Passed" (skipped != failure), which
+      # the branch ruleset requires, and main runs the full suite after the
+      # Version PR merges — before release.yml cuts anything.
+      should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' || github.head_ref == 'changeset-release/main' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,14 +25,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       ci-config: ${{ steps.filter.outputs.ci-config }}
       any-code: ${{ steps.filter.outputs.webapp == 'true' || steps.filter.outputs.application-server == 'true' || steps.filter.outputs.agent-images == 'true' }}
-      # The changesets Version PR only edits package.json, CHANGELOG.md and
-      # deletes .changeset/*.md — nothing that can break a build, yet it touches
-      # package.json and so would otherwise trigger the full matrix (including
-      # Docker builds) on every merge to main. Skip the heavy legs; the "CI
-      # Status Gate" still reports "All CI Passed" (skipped != failure), which
-      # the branch ruleset requires, and main runs the full suite after the
-      # Version PR merges — before release.yml cuts anything.
-      should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' || github.head_ref == 'changeset-release/main' }}
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -6,6 +6,17 @@ name: Version PR
 # the deliberate act that cuts a release — release.yml takes over from there.
 #
 # This workflow only ever opens/updates the PR; it never tags or deploys.
+#
+# The PR is opened with GITHUB_TOKEN, so it is authored by github-actions[bot]
+# and carries no CI: events created with that token don't trigger workflows.
+# That is deliberate — the PR only bumps a version string and rewrites
+# CHANGELOG.md, and it is re-pushed on every merge to main, so running the full
+# matrix (Docker builds included) on it would burn CI on every merge without
+# validating anything. The real validation happens after the merge: main runs
+# the full suite and release.yml only cuts a release if that run succeeded.
+# `ls1intum/hephaestus-maintainers` bypasses the branch ruleset, so the missing
+# required checks do not block merging the Version PR.
+#
 # Contributor guide: docs/contributor/release-management.mdx
 
 on:
@@ -28,9 +39,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          # PAT (not GITHUB_TOKEN) so the Version PR's own checks run and, once
-          # merged, its CI/CD run can trigger release.yml.
-          token: ${{ secrets.GH_PAT }}
 
       - name: Setup pnpm + Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -49,4 +57,4 @@ jobs:
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -40,7 +40,12 @@ sequenceDiagram
    is the explicit opt-out for changes with no user-facing effect; write why in the file body.
 2. **The Version PR accumulates.** On every push to `main`, the release workflow maintains a PR
    titled `chore(release): version packages` that previews the next version and the assembled
-   `CHANGELOG.md` section. It is safe to leave open — it updates itself.
+   `CHANGELOG.md` section. It is safe to leave open — it updates itself. It is opened by
+   `github-actions[bot]` and deliberately runs **no CI**: it only bumps a version string and
+   rewrites the changelog, and it is re-pushed on every merge to `main`, so running the full matrix
+   on it would burn CI without validating anything. Validation happens after the merge — `main` runs
+   the full suite and a release is only cut if that run succeeds. Maintainers bypass the branch
+   ruleset, so the absent required checks don't block the merge.
 3. **Merging the Version PR cuts the release.** The release workflow tags `vX.Y.Z` at the merge
    commit, creates the GitHub Release from the new changelog section, retags the CI-built Docker
    images as `X.Y.Z`, `X.Y`, and `latest`, publishes the signed release-pin asset, and starts the


### PR DESCRIPTION
## Description

Two problems with the changesets **Version PR** (`chore(release): version packages`), both caused by opening it with a PAT:

1. **It was authored by the PAT owner**, so a bot's version bump showed up as a human PR.
2. **A PAT triggers workflows**, so every Version PR update ran the **full CI matrix — Docker builds included** — on a PR that only bumps a version string and rewrites `CHANGELOG.md`. That PR is re-pushed on *every* merge to `main`. Observed on #1406: a 6m58s webapp Docker build for a three-file changelog commit.

This switches the Version PR to `GITHUB_TOKEN`, matching [`ls1intum/Apollon`](https://github.com/ls1intum/Apollon/blob/main/.github/workflows/release.yml). It's authored by `github-actions[bot]`, and because events created with `GITHUB_TOKEN` don't trigger workflows, the CI cost **disappears at the source** rather than being filtered.

**Nothing is left unvalidated.** After the Version PR merges, `main` runs the full suite, and `release.yml` only cuts a release if that run succeeded — the safety gate is post-merge, where it belongs. The PR contains nothing that can break a build.

**Why the missing required checks don't block it.** The branch ruleset requires `Validate title` and `All CI Passed`, and a `GITHUB_TOKEN`-authored PR reports neither. I verified `ls1intum/hephaestus-maintainers` is a ruleset bypass actor (`bypass_mode: always`), so maintainers can merge the Version PR regardless. This is exactly why Apollon's approach works for them too — their `main` has no required status checks at all.

> If that bypass is ever removed, the Version PR would become unmergeable. The fix then is a GitHub App token (`actions/create-github-app-token`), which keeps bot attribution *and* triggers the required checks. Not needed today, and it requires provisioning an App.

### Supersedes the first attempt on this branch

The initial commit filtered the heavy CI legs for `changeset-release/main` while keeping the PAT. That's strictly worse and has been reverted:

- With no workflow runs at all, the filter is **dead config**.
- It would have **suppressed CI if a maintainer pushed a real fix** to the Version PR branch — precisely when you'd want it.

`GH_PAT` now remains only in `release.yml`, where it is genuinely required (a `workflow_dispatch` created with `GITHUB_TOKEN` would not start the production deploy).

## How to test

1. Merge this, then merge any PR carrying a changeset.
2. The Version PR is opened/updated by **`github-actions[bot]`** (not a human) and shows **no check runs**.
3. Confirm it is still mergeable as a maintainer (ruleset bypass), merge it → `main` runs the full matrix, then `release.yml` cuts the release.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note — n/a, CI-only change (no shipped code, so `verify-changesets` does not require one)
- [x] If the operator must act on this change — n/a