### PR TITLE
feat(docker): make the core NATS bind host configurable

### DIFF
--- a/.changeset/configurable-nats-bind.md
+++ b/.changeset/configurable-nats-bind.md
@@ -1,0 +1,10 @@
+---
+"hephaestus": minor
+---
+
+The core NATS port can now be exposed beyond localhost. It stays bound to `127.0.0.1` by default;
+set `NATS_BIND_HOST=0.0.0.0` (or a specific interface address) to let other hosts reach the bus — for
+example when a separate environment consumes events from this one's JetStream.
+
+**Operators:** only expose it on a trusted or firewalled network. The bus is unauthenticated, so a
+public bind puts its contents within reach of anyone who can route to the host.

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -104,7 +104,9 @@ services:
     image: nats:alpine
     restart: unless-stopped
     ports:
-      - "127.0.0.1:4222:4222"
+      # Loopback-only by default. Set NATS_BIND_HOST=0.0.0.0 (or a specific interface) to let other
+      # hosts reach the bus — only on a trusted or firewalled network, as NATS runs unauthenticated.
+      - "${NATS_BIND_HOST:-127.0.0.1}:4222:4222"
     command: ["--config", "/etc/nats/nats-server.conf"]
     volumes:
       - nats-data:/data


### PR DESCRIPTION
## Motivation

`core-nats-server` was published only on `127.0.0.1:4222`, so nothing off-box could reach the bus. But the integration/sync consumers in other environments are meant to consume events from an upstream environment's JetStream (see `docker/preview/compose.app.yaml` — `HEPHAESTUS_SYNC_NATS_SERVER` may point at an upstream NATS). With a hardcoded loopback bind that's impossible, and those consumers fail to start.

## Change

Bind the port via `${NATS_BIND_HOST:-127.0.0.1}`:
- **Default unchanged** — loopback-only, so existing single-host deployments keep the safe posture.
- Operators can set `NATS_BIND_HOST=0.0.0.0` (or a specific interface address) to expose the bus to other hosts.

The bus is unauthenticated, so the changeset and the inline comment both spell out that exposure belongs only on a trusted or firewalled network.

## Testing

- `docker compose config` validates.
- No application code changed; Java/TS gates N/A (docker/ + changeset only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
