### PR TITLE
fix(webapp): identify the deployment in the header and footer

### DIFF
--- a/.changeset/header-version-badge.md
+++ b/.changeset/header-version-badge.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+Every deployment is now clearly identifiable. Outside production the header shows
+an environment pill (Staging / Preview / Local) instead of a raw commit hash, and
+the footer gains a deployment strip — branch, commit (linked to the exact commit),
+and how long ago it was deployed. Production is unchanged: the header shows the
+release version linking to its notes, and the footer stays clean.

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -36,6 +36,11 @@ jobs:
       docker-file: "./webapp/Dockerfile"
       docker-context: "."
       registry: "ghcr.io"
+      # Bake commit + branch (the Dockerfile's ARGs) so the footer build strip is
+      # populated on CI-built deploys; Coolify sets these itself for previews.
+      build-args: |
+        SOURCE_COMMIT=${{ github.sha }}
+        COOLIFY_BRANCH=${{ github.ref_name }}
       # amd64-only on PRs (main/release build both arches). See reusable-docker-build.yml.
       single-arch: ${{ github.event_name == 'pull_request' }}
       tags: |

--- a/webapp/src/components/core/Footer.tsx
+++ b/webapp/src/components/core/Footer.tsx
@@ -3,10 +3,13 @@ import { Link } from "@tanstack/react-router";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { optionalIntegrationsAvailable, requestConsentReopen } from "@/integrations/consent";
+import { formatRelativeTime } from "@/lib/relative-time";
 import { cn } from "@/lib/utils";
 
 export interface FooterProps {
 	className?: string;
+	/** Whether this is the production deployment (hides the build strip). */
+	isProduction?: boolean;
 	buildInfo?: {
 		branch?: string;
 		commit?: string;
@@ -15,11 +18,12 @@ export interface FooterProps {
 }
 
 /**
- * Minimal footer with navigation links, attribution, and build info for previews.
- * Version is NOT shown here - it's displayed in the Header beside the logo.
+ * Footer with navigation, attribution, and — outside production — a strip
+ * identifying the running build (branch, commit, deploy time).
  */
-export default function Footer({ className, buildInfo }: FooterProps) {
-	const showBuildInfo = buildInfo?.branch || buildInfo?.commit || buildInfo?.deployedAt;
+export default function Footer({ className, isProduction, buildInfo }: FooterProps) {
+	const showBuildInfo =
+		!isProduction && (buildInfo?.branch || buildInfo?.commit || buildInfo?.deployedAt);
 
 	return (
 		<footer className={cn("border-t border-sidebar-border bg-sidebar py-2 md:px-8", className)}>
@@ -100,7 +104,6 @@ export default function Footer({ className, buildInfo }: FooterProps) {
 						)}
 					</nav>
 
-					{/* Build info only for preview/dev - minimal style */}
 					{showBuildInfo && (
 						<div className="hidden sm:flex items-center gap-2 border-l border-sidebar-border pl-4 text-xs text-muted-foreground/60 font-mono">
 							{buildInfo?.branch && (
@@ -147,9 +150,10 @@ export default function Footer({ className, buildInfo }: FooterProps) {
 								<Tooltip>
 									<TooltipTrigger className="flex items-center gap-1 cursor-help">
 										<ClockIcon size={12} />
+										<span>{formatRelativeTime(buildInfo.deployedAt)}</span>
 									</TooltipTrigger>
 									<TooltipContent>
-										Deployed: {buildInfo.deployedAt.replace("T", " ").substring(0, 16)}
+										Deployed {buildInfo.deployedAt.replace("T", " ").substring(0, 16)} UTC
 									</TooltipContent>
 								</Tooltip>
 							)}

--- a/webapp/src/components/core/Header.stories.tsx
+++ b/webapp/src/components/core/Header.stories.tsx
@@ -16,6 +16,8 @@ const meta = {
 	tags: ["autodocs"],
 	args: {
 		version: "1.0.0",
+		environmentName: "Production",
+		isProduction: true,
 		name: "John Doe",
 		username: "johnDoe",
 		workspaceSlug: "demo-workspace",
@@ -74,13 +76,40 @@ export const Default: Story = {
 };
 
 /**
- * Local development header with non-clickable DEV version badge.
+ * Staging deployment: an amber environment pill instead of a version — the exact
+ * build (commit, branch, deploy time) is shown in the footer.
+ */
+export const Staging: Story = {
+	args: {
+		isAuthenticated: true,
+		isLoading: false,
+		environmentName: "Staging",
+		isProduction: false,
+	},
+};
+
+/**
+ * PR preview deployment: a violet environment pill.
+ */
+export const Preview: Story = {
+	args: {
+		isAuthenticated: true,
+		isLoading: false,
+		environmentName: "Preview",
+		isProduction: false,
+	},
+};
+
+/**
+ * Local development: a neutral environment pill.
  */
 export const Development: Story = {
 	args: {
 		isAuthenticated: true,
 		isLoading: false,
 		version: "DEV",
+		environmentName: "Local",
+		isProduction: false,
 	},
 };
 

--- a/webapp/src/components/core/Header.tsx
+++ b/webapp/src/components/core/Header.tsx
@@ -5,6 +5,7 @@ import { SignInButtons } from "@/components/auth/SignInButtons";
 import { ModeToggle } from "@/components/core/ModeToggle";
 import { SurveyNotificationButton } from "@/components/surveys/survey-notification-button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -17,12 +18,24 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getInitials } from "@/lib/avatar";
+import { cn } from "@/lib/utils";
+import { type EnvironmentTone, resolveHeaderBadge } from "@/lib/version";
+
+const ENV_DOT: Record<EnvironmentTone, string> = {
+	staging: "bg-amber-500 dark:bg-amber-400",
+	preview: "bg-violet-500 dark:bg-violet-400",
+	local: "bg-muted-foreground/50",
+};
 
 export interface HeaderProps {
 	/** Sidebar trigger button component */
 	sidebarTrigger?: React.ReactNode;
-	/** Application version displayed beside logo */
+	/** Application version displayed beside logo (used in production) */
 	version: string;
+	/** Friendly deployment environment name, e.g. "Staging" */
+	environmentName: string;
+	/** Whether this is the production deployment */
+	isProduction: boolean;
 	/** User authentication state */
 	isAuthenticated: boolean;
 	/** Whether the authentication is currently loading */
@@ -48,6 +61,8 @@ export interface HeaderProps {
 export default function Header({
 	sidebarTrigger,
 	version,
+	environmentName,
+	isProduction,
 	isAuthenticated,
 	isLoading,
 	name,
@@ -59,6 +74,7 @@ export default function Header({
 }: HeaderProps) {
 	const hasWorkspace = Boolean(workspaceSlug);
 	const hasUsername = Boolean(username);
+	const badge = resolveHeaderBadge(version, environmentName, isProduction);
 
 	return (
 		<header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 justify-between">
@@ -80,27 +96,37 @@ export default function Header({
 							<span className="text-xl font-semibold">Hephaestus</span>
 						</Link>
 					)}
-					{/* Version badge - clickable for production releases */}
-					{version !== "DEV" && version !== "preview" ? (
+					{/* Release version in production; environment pill elsewhere. */}
+					{badge.kind === "release" ? (
 						<Tooltip>
 							<TooltipTrigger
 								render={
 									<a
-										href={`https://github.com/ls1intum/Hephaestus/releases/tag/v${version}`}
+										href={badge.href}
 										target="_blank"
 										rel="noopener noreferrer"
-										aria-label={`View release v${version}`}
+										aria-label={badge.ariaLabel}
 										className="flex items-center gap-1 text-xs font-mono mt-1 text-muted-foreground hover:text-foreground transition-colors"
 									/>
 								}
 							>
 								<TagIcon size={12} />
-								<span>v{version}</span>
+								<span>{badge.label}</span>
 							</TooltipTrigger>
-							<TooltipContent>View release notes</TooltipContent>
+							<TooltipContent>{badge.tooltip}</TooltipContent>
 						</Tooltip>
 					) : (
-						<span className="text-xs font-mono mt-1 text-muted-foreground">{version}</span>
+						<Tooltip>
+							<TooltipTrigger
+								render={
+									<Badge variant="outline" className="gap-1.5 font-normal text-muted-foreground" />
+								}
+							>
+								<span className={cn("size-1.5 rounded-full", ENV_DOT[badge.tone])} />
+								{badge.label}
+							</TooltipTrigger>
+							<TooltipContent>{badge.label} environment</TooltipContent>
+						</Tooltip>
 					)}
 				</div>
 			</div>

--- a/webapp/src/components/surveys/survey-notification-button.stories.tsx
+++ b/webapp/src/components/surveys/survey-notification-button.stories.tsx
@@ -73,6 +73,8 @@ export const FullPagePreview: Story = {
 				<div className="min-h-screen bg-background">
 					<Header
 						version="demo"
+						environmentName="Local"
+						isProduction={false}
 						isAuthenticated
 						isLoading={false}
 						name="Demo"

--- a/webapp/src/environment/index.ts
+++ b/webapp/src/environment/index.ts
@@ -51,8 +51,22 @@ const defaults: RuntimeEnvVars = {
 
 const env = (key: keyof RuntimeEnvVars): string => window.__ENV__?.[key] ?? defaults[key] ?? "";
 
+// Deployment identity from SENTRY_ENVIRONMENT (production / staging / preview / local).
+const DEPLOYMENT_NAMES: Record<string, string> = {
+	production: "Production",
+	staging: "Staging",
+	preview: "Preview",
+	local: "Local",
+};
+const deploymentEnvironment = env("SENTRY_ENVIRONMENT") || "local";
+
 const environment = {
 	version: env("APPLICATION_VERSION").replace(/^v/, "") || "DEV",
+	deployment: {
+		environment: deploymentEnvironment,
+		name: DEPLOYMENT_NAMES[deploymentEnvironment] ?? "Local",
+		isProduction: deploymentEnvironment === "production",
+	},
 	clientUrl: env("APPLICATION_CLIENT_URL"),
 	serverUrl: env("APPLICATION_SERVER_URL"),
 	// CSRF double-submit cookie name. `__Host-`-prefixed in production; dropped for local http E2E

--- a/webapp/src/lib/relative-time.test.ts
+++ b/webapp/src/lib/relative-time.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatRelativeTime } from "./relative-time";
+
+describe("formatRelativeTime", () => {
+	const now = Date.parse("2026-07-21T12:00:00Z");
+
+	it("returns an empty string for empty or unparseable input", () => {
+		expect(formatRelativeTime("", now)).toBe("");
+		expect(formatRelativeTime("not-a-date", now)).toBe("");
+	});
+
+	it("humanizes a past timestamp", () => {
+		expect(formatRelativeTime("2026-07-21T10:00:00Z", now)).toBe("2 hours ago");
+		expect(formatRelativeTime("2026-07-20T12:00:00Z", now)).toBe("yesterday");
+	});
+
+	it("reports the current instant as now", () => {
+		expect(formatRelativeTime("2026-07-21T12:00:00Z", now)).toBe("now");
+	});
+});

--- a/webapp/src/lib/relative-time.ts
+++ b/webapp/src/lib/relative-time.ts
@@ -1,0 +1,30 @@
+const DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
+	{ amount: 60, unit: "second" },
+	{ amount: 60, unit: "minute" },
+	{ amount: 24, unit: "hour" },
+	{ amount: 7, unit: "day" },
+	{ amount: 4.34524, unit: "week" },
+	{ amount: 12, unit: "month" },
+	{ amount: Number.POSITIVE_INFINITY, unit: "year" },
+];
+
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+/**
+ * Humanize an ISO timestamp relative to now — e.g. "2 hours ago", "now".
+ * Returns "" for an empty or unparseable value so callers can skip rendering.
+ */
+export function formatRelativeTime(iso: string, now: number = Date.now()): string {
+	if (!iso) return "";
+	const then = Date.parse(iso);
+	if (Number.isNaN(then)) return "";
+
+	let duration = (then - now) / 1000; // seconds; negative = in the past
+	for (const division of DIVISIONS) {
+		if (Math.abs(duration) < division.amount) {
+			return rtf.format(Math.round(duration), division.unit);
+		}
+		duration /= division.amount;
+	}
+	return "";
+}

--- a/webapp/src/lib/version.test.ts
+++ b/webapp/src/lib/version.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveHeaderBadge } from "./version";
+
+// The header shows the release version in production (linked to its notes) and an
+// environment pill everywhere else — a commit SHA never belongs in the header.
+describe("resolveHeaderBadge", () => {
+	it("shows a production semver as a release linking to its GitHub tag", () => {
+		const badge = resolveHeaderBadge("0.73.2", "Production", true);
+		expect(badge).toEqual({
+			kind: "release",
+			label: "v0.73.2",
+			href: "https://github.com/ls1intum/Hephaestus/releases/tag/v0.73.2",
+			tooltip: "View release notes",
+			ariaLabel: "View release v0.73.2",
+		});
+	});
+
+	it("shows an environment pill for staging, never the version", () => {
+		const badge = resolveHeaderBadge("c46f9f8", "Staging", false);
+		expect(badge).toEqual({ kind: "environment", label: "Staging", tone: "staging" });
+	});
+
+	it.each([
+		["Preview", "preview"],
+		["Local", "local"],
+	] as const)("tones the %s pill as %s", (name, tone) => {
+		expect(resolveHeaderBadge("anything", name, false)).toEqual({
+			kind: "environment",
+			label: name,
+			tone,
+		});
+	});
+
+	it("falls back to an environment pill if production somehow lacks a semver", () => {
+		expect(resolveHeaderBadge("nightly", "Production", true).kind).toBe("environment");
+	});
+});

--- a/webapp/src/lib/version.ts
+++ b/webapp/src/lib/version.ts
@@ -1,0 +1,36 @@
+const REPO_URL = "https://github.com/ls1intum/Hephaestus";
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+export type EnvironmentTone = "staging" | "preview" | "local";
+
+export type HeaderBadge =
+	| { kind: "release"; label: string; href: string; tooltip: string; ariaLabel: string }
+	| { kind: "environment"; label: string; tone: EnvironmentTone };
+
+function toneFor(environmentName: string): EnvironmentTone {
+	const name = environmentName.toLowerCase();
+	if (name === "staging") return "staging";
+	if (name === "preview") return "preview";
+	return "local";
+}
+
+/**
+ * Production shows the release version linked to its notes; every other
+ * environment shows its name, keeping the commit SHA out of the header.
+ */
+export function resolveHeaderBadge(
+	version: string,
+	environmentName: string,
+	isProduction: boolean,
+): HeaderBadge {
+	if (isProduction && SEMVER.test(version)) {
+		return {
+			kind: "release",
+			label: `v${version}`,
+			href: `${REPO_URL}/releases/tag/v${version}`,
+			tooltip: "View release notes",
+			ariaLabel: `View release v${version}`,
+		};
+	}
+	return { kind: "environment", label: environmentName, tone: toneFor(environmentName) };
+}

--- a/webapp/src/routes/__root.tsx
+++ b/webapp/src/routes/__root.tsx
@@ -100,7 +100,12 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 								<main className={isFullscreenRoute ? "" : "flex-1 p-4"}>
 									<Outlet />
 								</main>
-								{!isFullscreenRoute && <Footer buildInfo={environment.buildInfo} />}
+								{!isFullscreenRoute && (
+									<Footer
+										buildInfo={environment.buildInfo}
+										isProduction={environment.deployment.isProduction}
+									/>
+								)}
 							</div>
 						</SidebarInset>
 					</SidebarProvider>
@@ -237,6 +242,8 @@ function HeaderContainer() {
 		<Header
 			sidebarTrigger={isAuthenticated && <SidebarTrigger className="-ml-1" />}
 			version={environment.version}
+			environmentName={environment.deployment.name}
+			isProduction={environment.deployment.isProduction}
 			isAuthenticated={isAuthenticated}
 			isLoading={isLoading}
 			name={effectiveName}


### PR DESCRIPTION
## Problem

The header assumed any version that wasn't `DEV`/`preview` was a semver release. Since [staging CD (#1412)](https://github.com/ls1intum/Hephaestus/pull/1412) deploys each commit by its SHA, staging rendered the **full 40-char hash** as `v<sha>` linking to a release tag that **404s**.

## Approach — split header and footer, don't compete

- **Header = identity at a glance.** Production shows the release version (linked to its notes). Every other environment shows a subtle **environment pill** — `Staging` (amber) / `Preview` (violet) / `Local` — *no SHA*. One glance tells you where you are.
- **Footer = the exact build.** The build strip (which already existed, only wired for previews) is now shown on **all non-production** deploys: branch → tree, commit → the exact commit, and a relative **deploy time** ("deployed 2h ago", absolute on hover). Production stays clean.

| Env | Header | Footer strip |
|---|---|---|
| Production | `v0.73.2` → release notes | — |
| Staging | `● Staging` | `main · c46f9f8 · deployed 2h ago` |
| Preview | `● Preview` | `feat/x · a1b2c3d · deployed 5m ago` |
| Local | `● Local` | — |

## How it's wired (the plumbing)

The footer reads `GIT_BRANCH`/`GIT_COMMIT`/`DEPLOYED_AT` from `window.__ENV__`; `entrypoint.sh` restores them from **baked** `BUILD_GIT_*` and auto-stamps `DEPLOYED_AT`. Previews get them from Coolify. Staging was dark because **CI never passed the build-args** the Dockerfile already accepts — so this adds `SOURCE_COMMIT`/`COOLIFY_BRANCH` to the webapp build in `ci-docker-build.yml`. The env pill comes from `SENTRY_ENVIRONMENT`, already set per environment. (If the commit ever isn't baked, the strip simply hides — no broken state.)

## Changes

- `lib/version.ts` — `resolveHeaderBadge()` (release vs. environment pill), tested.
- `lib/relative-time.ts` — `formatRelativeTime()`, tested.
- `environment/index.ts` — derives `deployment { name, isProduction }` from `SENTRY_ENVIRONMENT`.
- `Header.tsx` / `Footer.tsx` — env pill; footer strip gated to non-prod + relative time.
- `ci-docker-build.yml` — bake commit/branch into the webapp image.
- Stories for Staging / Preview / Local; changeset included.

## Testing

`vitest` (helpers), `biome check`, and `tsc --noEmit` all clean. Storybook stories cover every environment state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment badges for Staging, Preview, and Local deployments.
  * Added a non-production deployment strip showing the branch, exact commit link, and relative deployment time.
  * Production continues to display the release version and a clean footer.
* **Bug Fixes**
  * Improved handling of deployment metadata and fallback environment labels.
  * Deployment timestamps now use clearer relative-time formatting.
* **Tests**
  * Added coverage for environment badges, release links, and relative deployment times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->