### PR TITLE
fix(docker): raise JVM direct memory above the app's baseline footprint

### DIFF
--- a/.changeset/jvm-direct-memory.md
+++ b/.changeset/jvm-direct-memory.md
@@ -1,0 +1,12 @@
+---
+"hephaestus": patch
+---
+
+Fixes login and other database operations intermittently failing. The build's
+10 MB off-heap direct-memory default sits just below the application server's
+steady I/O footprint, so once it filled, PostgreSQL could no longer allocate the
+buffer for its connection handshake and the connection pool drained. The server
+and worker now get 128 MB of direct memory.
+
+**Operators:** override the default with `APP_MAX_DIRECT_MEMORY` if you need to
+tune it (e.g. a larger value if a heavy backfill ever approaches the limit).

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -99,6 +99,9 @@ services:
     ports:
       - "8080"
     environment:
+      # The buildpack's 10M MaxDirectMemorySize sits below this role's steady NIO
+      # footprint (NATS + HTTP); give it headroom.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=${APP_MAX_DIRECT_MEMORY:-128M}"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: prod
       APPLICATION_HOST_URL: https://${APP_HOSTNAME}
@@ -297,6 +300,8 @@ services:
     # Bounds heap sizing to this container (see application-server).
     mem_limit: ${APPLICATION_WORKER_MEM_LIMIT:-3g}
     environment:
+      # See application-server: the buildpack's 10M direct-memory default is too small.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=${APP_MAX_DIRECT_MEMORY:-128M}"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: prod,worker
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-}

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -171,6 +171,9 @@ services:
     expose:
       - "8080"
     environment:
+      # The buildpack's 10M MaxDirectMemorySize sits below this role's steady NIO
+      # footprint (NATS + HTTP); give it headroom.
+      JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=${APP_MAX_DIRECT_MEMORY:-128M}"
       SPRING_PROFILES_ACTIVE: prod
       # prod runs forward-headers=native, so ProxyTrustGuard aborts the boot unless this is set.
       # Write this Tomcat internal-proxies regex WITHOUT backslashes: Coolify re-escapes them when


### PR DESCRIPTION
## Incident

Login (and every DB-backed request) failing. From the app-server logs:

```
OutOfMemoryError: Cannot reserve 8192 bytes of direct buffer memory (limit: 10485760)
  at org.postgresql.core.v3.ConnectionFactoryImpl.doAuthentication
→ HikariPool-1 - Connection is not available, request timed out after 45000ms
```

## Root cause (verified, not a bandaid)

NMT on staging shows the direct-buffer pool is **~14 MB and flat** (two samples, 30s apart → no growth):

```
Other (direct buffers): 14,553 KB … 14,553 KB
```

No leak, no unbounded spike — the app's **steady** off-heap footprint just sits **above the buildpack's 10 MB default**, so Postgres couldn't get the small buffer for its connection handshake and the pool drained. The 10 MB default is [an arbitrary Cloud Foundry inheritance](https://github.com/orgs/paketo-buildpacks/discussions/241), not tuned for this app.

## Sizing — why 128 MB (not 256)

On a container the memory calculator **budgets direct memory against heap** (`10M direct + 240M code + 250M stacks + metaspace + heap`), so an oversized cap steals heap. Best practice is to size to **actual usage + headroom**, not a round large number ([BellSoft JVM memory guide](https://bell-sw.com/blog/guide-to-jvm-memory-configuration-options/), [GigaSpaces JVM tuning](https://docs.gigaspaces.com/16.2/production/production-jvm-tuning.html)).

Against ~14 MB steady, **128 MB** is ~9× headroom — comfortably above the 10 MB that OOM'd and any observed level, with room for backfill bursts — while returning ~128 MB to heap versus a 256 MB cap. Env-overridable via `APP_MAX_DIRECT_MEMORY` if a heavy backfill ever approaches it.

## Scope

- `docker/compose.app.yaml` — `application-server`, `application-worker`
- `docker/preview/compose.app.yaml` — the preview app-server (where it first surfaced, #1347)
- Not `webhook-server` (core): a light publisher on a tight 1 GB limit that hasn't hit this — a conscious omission.

Set via `JAVA_TOOL_OPTIONS`, which the buildpack honors (detects the user flag, skips its own 10 MB, re-budgets heap within `mem_limit`).

## Verification

Applied live on staging (that restored login): OOM/pool timeouts stopped, readiness `UP`, `GET /api/identity-providers` returns the provider list. This PR makes it durable. `docker compose config` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
