### PR TITLE
fix(server): gate SlackIntegrationSyncRunner to the server role

### DIFF
--- a/.changeset/worker-slack-sync-role-gating.md
+++ b/.changeset/worker-slack-sync-role-gating.md
@@ -1,0 +1,9 @@
+---
+"hephaestus": patch
+---
+
+Fixes the background worker crash-looping on startup when the Slack integration is
+enabled. A Slack sync runner was loading in the worker role without the scheduler
+it depends on, which only runs on the server role, so the worker failed to boot.
+The runner is now gated to the server role, matching the other integration sync
+runners.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/sync/status/SlackIntegrationSyncRunner.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/slack/sync/status/SlackIntegrationSyncRunner.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.slack.sync.status;
 
+import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationKind;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationRef;
 import de.tum.cit.aet.hephaestus.integration.core.spi.IntegrationSyncRunner;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 /** Runs Slack reconciliation through the consent-gated history sync. */
 @Component
+@ConditionalOnServerRole
 @ConditionalOnProperty(name = "hephaestus.integration.slack.enabled", havingValue = "true")
 public class SlackIntegrationSyncRunner implements IntegrationSyncRunner {
 


### PR DESCRIPTION
## Bug

The background **worker** crash-loops on boot (observed on staging: 73 restarts, never healthy) with:

```
UnsatisfiedDependencyException: Error creating bean 'slackIntegrationSyncRunner' …
  No qualifying bean of type 'SlackDataSyncScheduler' available
→ APPLICATION FAILED TO START
```

## Root cause

`SlackIntegrationSyncRunner` is gated only on the property:

```java
@Component
@ConditionalOnProperty(name = "hephaestus.integration.slack.enabled", havingValue = "true")
```

…so it loads in **every** runtime role. But its dependency `SlackDataSyncScheduler` is `@ConditionalOnServerRole`, so it loads **only** on the server. In the `worker` role the runner is created and the scheduler isn't → the context can't satisfy the constructor → boot fails → crash-loop. (The restart churn also burns CPU/keeps the host hot.)

The sibling `OutlineIntegrationSyncRunner` shows the correct pattern — it pairs `@ConditionalOnServerRole` with its server-role-gated scheduler.

## Fix

Add `@ConditionalOnServerRole` to `SlackIntegrationSyncRunner` so the runner only loads where its dependency exists — a one-line, precedent-matching change.

```java
 @Component
+@ConditionalOnServerRole
 @ConditionalOnProperty(name = "hephaestus.integration.slack.enabled", havingValue = "true")
 public class SlackIntegrationSyncRunner implements IntegrationSyncRunner {
```

## Testing

`pnpm run format:java` clean. Unit tests instantiate the runner directly, so they're unaffected; any role-gating context test now correctly excludes it from the worker. Changeset included.

## Follow-ups (separate, not in this PR)

Two other issues surfaced alongside this on staging, tracked separately:
- **Webhook heap OOM** — the mem-limit I set in #1410 (1 GB) is too small, and it still OOMs at 1.5 GB on a stale image; needs version alignment + a heap-dump investigation.
- **Stalled github NATS consumers** — ~974K messages unprocessed with no forward progress; separate diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Slack integration startup issue that could cause background workers to repeatedly crash.
  * Slack synchronization now runs only in the appropriate server environment, improving application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->