### PR TITLE
fix(docker): make the webhook-server boot (heap + access log)

### DIFF
--- a/.changeset/webhook-mem-limit.md
+++ b/.changeset/webhook-mem-limit.md
@@ -1,0 +1,11 @@
+---
+"hephaestus": patch
+---
+
+Fixes the webhook-server crash-looping on startup. Two causes: its 1 GB memory
+limit left too little heap for the Spring classpath-scan spike (it OOMed before
+boot finished), and — because prod enables Tomcat file access logging to
+`/var/log/hephaestus`, which the core stack gives no writable location — the
+access-log valve failed and aborted the boot. The webhook now gets a 2 GB default
+limit (`WEBHOOK_SERVER_MEM_LIMIT`) and its file access log is disabled (requests
+are already logged by the reverse proxy and to stdout).

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -8,9 +8,10 @@ services:
   # ─────────────────────────────────────────────────────────────────────────────
   webhook-server:
     image: "ghcr.io/ls1intum/hephaestus/application-server:${IMAGE_TAG}"
-    # Bounds heap sizing to this container; without it the JVM targets host RAM and co-located
-    # services oversubscribe and swap. Webhook only receives and republishes, so its heap is small.
-    mem_limit: ${WEBHOOK_SERVER_MEM_LIMIT:-1g}
+    # Bounds heap sizing to this container so co-located JVMs don't oversubscribe host RAM.
+    # Must fit the Spring classpath-scan startup spike (well above the small steady footprint),
+    # or the JVM OOMs during boot.
+    mem_limit: ${WEBHOOK_SERVER_MEM_LIMIT:-2g}
     expose:
       - "8080"
     environment:
@@ -20,6 +21,10 @@ services:
       HEPHAESTUS_RUNTIME_SERVER_ENABLED: "false"
       HEPHAESTUS_RUNTIME_WORKER_ENABLED: "false"
       SPRING_LIQUIBASE_ENABLED: "false"
+      # application-prod.yml enables Tomcat file access logging to /var/log/hephaestus, which the
+      # image doesn't create and the core stack gives no writable volume — the access-log valve then
+      # fails the boot. Requests are already logged by Traefik and to stdout, so disable the file valve.
+      SERVER_TOMCAT_ACCESSLOG_ENABLED: "false"
       # NATS — reuses the existing `natsConnection` bean to publish inbound events.
       HEPHAESTUS_SYNC_NATS_ENABLED: "true"
       HEPHAESTUS_SYNC_NATS_SERVER: "nats://nats-server:4222"
@@ -137,7 +142,7 @@ networks:
     driver: bridge
 
 volumes:
-  nats-data: 
+  nats-data:
 
 configs:
   nats-server.conf:


### PR DESCRIPTION
## Problem

The `webhook-server` crash-looped on boot. Diagnosed on staging as **three stacked causes** (each masked the next):

1. **Heap too small** — the 1 GB limit I set in #1410 leaves ~270 MB heap; the Spring classpath-scan spike during startup OOMs it before boot finishes.
2. **File access logging** — `application-prod.yml` enables Tomcat access logging to `/var/log/hephaestus/access`. The image doesn't create that dir and the core stack has no writable volume for it (a fresh named volume is `root:root`, unwritable by the `cnb` user), so the access-log valve fails and aborts boot. (This one only surfaced once heap was sufficient.)
3. **A bean bug** — `slackIntegrationSyncRunner` requires a server-only scheduler; fixed separately in **#1415**. The webhook is a non-server role, so it hit the same bug.

This PR fixes (1) and (2); #1415 fixes (3).

## Fix

- **Memory** → default 2 GB (`WEBHOOK_SERVER_MEM_LIMIT`-overridable) so heap fits the startup spike.
- **Access log** → `SERVER_TOMCAT_ACCESSLOG_ENABLED=false` for the webhook. Requests are already logged by Traefik and to stdout, so this drops the file valve entirely and avoids the `/var/log` ownership fragility (rather than mounting a volume that a fresh deploy would leave `root:root`).

## Verified

Applied live on staging (with #1415's image): the webhook boots clean — `Started Application in 14.4s`, `restarts=0`, healthy. With the worker also fixed by #1415, host load dropped from ~6–10 to ~1.3.

## Note

`application-server` also writes access logs to `/var/log/hephaestus` and only works because its volume is old/persistent — a truly fresh app deploy would hit the same `root:root` issue. Worth a follow-up (a chown init, or the same disable), but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
