### PR TITLE
fix: stop writing Tomcat file access logs in prod

### DIFF
--- a/.changeset/disable-tomcat-file-accesslog.md
+++ b/.changeset/disable-tomcat-file-accesslog.md
@@ -1,0 +1,10 @@
+---
+"hephaestus": patch
+---
+
+Stops writing Tomcat file access logs in production. They were written to a
+`/var/log/hephaestus` volume that wasn't shipped or aggregated anywhere, and the
+requirement for a writable directory there made containers fail to start on a
+fresh volume. Per-request logging is unchanged — the reverse proxy already
+records every request at the edge. This also removes the now-unused log volumes
+from the compose stacks.

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -239,7 +239,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - git-repos:/data/git-repos
-      - application-server-logs:/var/log/hephaestus
       - release-pin:/pin:ro
     networks:
       - shared-network
@@ -410,5 +409,4 @@ networks:
 volumes:
   postgresql-data:
   git-repos:
-  application-server-logs:
   release-pin:

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -21,10 +21,6 @@ services:
       HEPHAESTUS_RUNTIME_SERVER_ENABLED: "false"
       HEPHAESTUS_RUNTIME_WORKER_ENABLED: "false"
       SPRING_LIQUIBASE_ENABLED: "false"
-      # application-prod.yml enables Tomcat file access logging to /var/log/hephaestus, which the
-      # image doesn't create and the core stack gives no writable volume — the access-log valve then
-      # fails the boot. Requests are already logged by Traefik and to stdout, so disable the file valve.
-      SERVER_TOMCAT_ACCESSLOG_ENABLED: "false"
       # NATS — reuses the existing `natsConnection` bean to publish inbound events.
       HEPHAESTUS_SYNC_NATS_ENABLED: "true"
       HEPHAESTUS_SYNC_NATS_SERVER: "nats://nats-server:4222"

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -148,10 +148,9 @@ services:
     command:
       - sh
       - -c
-      - chown -R 1002:1001 /data/git-repos /var/log/hephaestus && chmod 0755 /data/git-repos /var/log/hephaestus
+      - chown -R 1002:1001 /data/git-repos && chmod 0755 /data/git-repos
     volumes:
       - git-repos:/data/git-repos
-      - appserver-logs:/var/log/hephaestus
     restart: "no"
 
   # The service name must stay dash-free. Coolify stores a service's configured domain under the
@@ -298,7 +297,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - git-repos:/data/git-repos
-      - appserver-logs:/var/log/hephaestus
     depends_on:
       postgres:
         condition: service_healthy
@@ -359,4 +357,3 @@ services:
 volumes:
   postgres-data:
   git-repos:
-  appserver-logs:

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -50,14 +50,11 @@ server:
             remote-ip-header: X-Forwarded-For
             protocol-header: X-Forwarded-Proto
         redirect-context-root: false
+        # No Tomcat file access log: the ingress (Traefik) already logs every request, and writing
+        # to a host volume added nothing but a boot dependency on a writable /var/log/hephaestus
+        # (a fresh named volume is root:root, which aborted startup). Request logging lives at the edge.
         accesslog:
-            enabled: true
-            directory: /var/log/hephaestus/access
-            prefix: access
-            suffix: .log
-            file-date-format: .yyyy-MM-dd
-            max-days: 14
-            pattern: "%{yyyy-MM-dd'T'HH:mm:ssXXX}t %a %m %U %H %s %b %D"
+            enabled: false
 
 hephaestus:
     host-url: ${APPLICATION_HOST_URL}


### PR DESCRIPTION
## Why

Tomcat file access logging (`application-prod.yml`) wrote to `/var/log/hephaestus`, which forced **every** runtime role to carry a writable volume there. A fresh Docker named volume is `root:root`, so the `cnb` user can't create the log directory and the **access-log valve aborts startup**. That was one of the webhook crash-loop causes, and it's a latent landmine for any from-scratch `application-server` deploy (it only survives today because its volume is old). Meanwhile the files landed on an unaggregated host volume — effectively **unused**, while Traefik already logs every request at the edge.

This replaces the earlier per-service bandaids (a `SERVER_TOMCAT_ACCESSLOG_ENABLED=false` env on the webhook in #1416, and a rejected chown-sidecar idea) with the **root-cause fix at the source**.

## Change

- **`application-prod.yml`** — `server.tomcat.accesslog.enabled: false`. One place, all roles.
- **Remove the now-dead log volumes**: `application-server-logs` (compose.app.yaml), `appserver-logs` (preview) — mounts + declarations, and the `/var/log/hephaestus` chown from the preview's `volume-init` (git-repos chown stays).
- **Drop** the redundant `SERVER_TOMCAT_ACCESSLOG_ENABLED` toggle #1416 added to the webhook (the yml default now covers it).

Net −12 lines; no volume, no chown, no per-service override, no `/var/log/hephaestus` dependency anywhere.

## Impact

Per-request logging is unchanged — the ingress (Traefik) records every request. If the app's own access-log stream is ever wanted, the right way is `logback-access` to stdout, not files on a host volume; out of scope here.

## Testing

`docker compose config` validates (app + core); no remaining `/var/log/hephaestus` or `*-logs` references. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled unused production file-based access logs to prevent startup issues on fresh volumes.
  - Removed obsolete application log volumes and setup steps.
  - Preserved request logging through the reverse proxy.

- **Infrastructure**
  - Added read-only access to the release-pin artifact for application services.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->