### PR TITLE
feat(profile): add practice area status cards

### DIFF
--- a/.changeset/practice-area-status-cards.md
+++ b/.changeset/practice-area-status-cards.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": minor
+---
+
+Developer profiles now provide compact practice-area summaries of current standing, guidance, and recent development.

--- a/webapp/src/components/admin/curated-catalog/CuratedCatalogTree.tsx
+++ b/webapp/src/components/admin/curated-catalog/CuratedCatalogTree.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { GripVertical, MoreHorizontal } from "lucide-react";
 import type { CuratedArea, CuratedPracticeSummary } from "@/api/types.gen";
-import { getAreaVisual } from "@/components/admin/practice-catalog/area-visuals";
 import { WORK_ARTIFACT_LABELS } from "@/components/admin/practice-catalog/constants";
 import {
 	type CatalogEntryMoveActions,
@@ -9,6 +8,7 @@ import {
 	SortableCatalogTree,
 	UNASSIGNED_CATALOG_BUCKET,
 } from "@/components/admin/practice-catalog/SortableCatalogTree";
+import { getAreaVisual } from "@/components/shared/area-visuals";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {

--- a/webapp/src/components/admin/practice-catalog/AreaVisualPicker.tsx
+++ b/webapp/src/components/admin/practice-catalog/AreaVisualPicker.tsx
@@ -1,10 +1,5 @@
 import { Check, Search } from "lucide-react";
 import { useId, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { cn } from "@/lib/utils";
 import {
 	areaSeed,
 	COLOR_KEYS,
@@ -14,7 +9,12 @@ import {
 	iconLabel,
 	iconSearchText,
 	PILL,
-} from "./area-visuals";
+} from "@/components/shared/area-visuals";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
 
 export interface AreaVisualPickerProps {
 	id?: string;

--- a/webapp/src/components/admin/practice-reviews/ReviewPracticeLabel.tsx
+++ b/webapp/src/components/admin/practice-reviews/ReviewPracticeLabel.tsx
@@ -1,5 +1,5 @@
 import type { ReviewPracticeArea } from "@/api/types.gen";
-import { getAreaVisual } from "@/components/admin/practice-catalog/area-visuals";
+import { getAreaVisual } from "@/components/shared/area-visuals";
 import { cn } from "@/lib/utils";
 
 export interface ReviewPracticeLabelProps {

--- a/webapp/src/components/profile/PracticeAreaStatusCard.stories.tsx
+++ b/webapp/src/components/profile/PracticeAreaStatusCard.stories.tsx
@@ -1,0 +1,196 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, fn, userEvent, within } from "storybook/test";
+import type { PracticeArea, PracticeAreaStatus } from "@/api/types.gen";
+import { PracticeAreaStatusCard } from "@/components/profile/PracticeAreaStatusCard";
+
+const makeArea = (id: number, slug: string, name: string, description: string): PracticeArea => ({
+	id,
+	active: true,
+	slug,
+	name,
+	description,
+	displayOrder: id,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+});
+
+// Real areas (names + descriptions verbatim) from the seeded default catalog. No admin-set icon,
+// so the chips use the centrally defined catalog icons.
+const areas: PracticeArea[] = [
+	makeArea(
+		1,
+		"review-ready-work",
+		"Packaging work for review",
+		"Make a change cheap to review before you ask for one. Keep it to a single self-contained concern of a readable size, say what changed and why, write commit subjects a reviewer can follow, and link it to the issue it answers. This is about how the work is packaged, not whether the code has bugs.",
+	),
+	makeArea(
+		2,
+		"acting-on-review-feedback",
+		"Acting on review feedback",
+		"Close the review loop. When a reviewer leaves a substantive comment on a line, answer it with a reply that names what changed or a follow-up commit that addresses it, and resolve the thread before merging. Feedback only improves the work once someone acts on it.",
+	),
+	makeArea(
+		3,
+		"testing-discipline",
+		"Testing your changes",
+		"When a change adds or fixes behaviour, it comes with the tests that exercise it. And it never quietly deletes, skips, or weakens a test just to make the build pass.",
+	),
+];
+
+// Statuses as the server generates them: label-colon summaries built from the catalog's
+// imperative practice names, trajectory hints, and the actual feedback span with its start date.
+const statuses: Record<string, PracticeAreaStatus> = {
+	"review-ready-work": {
+		areaSlug: "review-ready-work",
+		areaName: "Packaging work for review",
+		status: "MIXED",
+		guidance:
+			"Your recent feedback shows a strength in “Describe what changed and why”. Next, focus on “Scope the change to one concern”.",
+		guidanceSource: "RULE_BASED",
+		trajectory: "IMPROVING",
+		feedbackSpanDays: 34,
+		feedbackSince: new Date("2026-06-24T09:00:00Z"),
+		items: [
+			{
+				observationId: "0b54c9f2-8f4e-4a53-9be1-0e6a35a1c001",
+				title: "Change bundles two unrelated concerns",
+				guidance: "Split the refactoring from the feature change so each can be reviewed alone.",
+				severity: "MINOR",
+				artifactType: "PULL_REQUEST",
+				artifactId: 41,
+			},
+		],
+		sources: [
+			{ source: "PULL_REQUEST", count: 12 },
+			{ source: "ISSUE", count: 3 },
+		],
+	},
+	"acting-on-review-feedback": {
+		areaSlug: "acting-on-review-feedback",
+		areaName: "Acting on review feedback",
+		status: "STRENGTH",
+		guidance:
+			"Your recent feedback shows strengths in “Respond to each review comment” and “Resolve open threads before merging”. Keep building on them.",
+		guidanceSource: "RULE_BASED",
+		feedbackSpanDays: 21,
+		feedbackSince: new Date("2026-07-07T09:00:00Z"),
+		items: [
+			{
+				observationId: "0b54c9f2-8f4e-4a53-9be1-0e6a35a1c002",
+				title: "Every review thread answered",
+				guidance: "You consistently close the loop on review threads — keep it up.",
+				artifactType: "PULL_REQUEST",
+				artifactId: 42,
+			},
+		],
+		sources: [{ source: "PULL_REQUEST", count: 9 }],
+	},
+	"testing-discipline": {
+		areaSlug: "testing-discipline",
+		areaName: "Testing your changes",
+		status: "DEVELOPING",
+		guidance:
+			"Your recent feedback points to “Include tests with the change” as the next practice to focus on.",
+		guidanceSource: "RULE_BASED",
+		trajectory: "REGRESSING",
+		feedbackSpanDays: 8,
+		feedbackSince: new Date("2026-07-20T09:00:00Z"),
+		items: [
+			{
+				observationId: "0b54c9f2-8f4e-4a53-9be1-0e6a35a1c003",
+				title: "Behaviour change shipped without a test",
+				guidance: "Add a test that fails without this fix so the behaviour stays covered.",
+				severity: "MAJOR",
+				artifactType: "PULL_REQUEST",
+				artifactId: 43,
+			},
+		],
+		sources: [
+			{ source: "PULL_REQUEST", count: 4 },
+			{ source: "ISSUE", count: 1 },
+		],
+	},
+};
+
+const meta = {
+	component: PracticeAreaStatusCard,
+	parameters: {
+		layout: "padded",
+	},
+	tags: ["autodocs"],
+} satisfies Meta<typeof PracticeAreaStatusCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+	args: {
+		areas,
+		statuses,
+		isLoading: false,
+		onOpenDetails: fn(),
+	},
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.queryByText("Feedback highlight")).not.toBeInTheDocument();
+		await userEvent.click(
+			canvas.getByRole("button", { name: "See details about Packaging work for review" }),
+		);
+		await expect(args.onOpenDetails).toHaveBeenCalledWith(areas[0]);
+	},
+};
+
+/** The provenance row identifies Slack when conversation feedback contributes to the summary. */
+export const WithSlackFeedback: Story = {
+	args: {
+		areas: [areas[0]],
+		statuses: {
+			"review-ready-work": {
+				...statuses["review-ready-work"],
+				sources: [
+					...statuses["review-ready-work"].sources,
+					{ source: "CONVERSATION_THREAD", count: 5 },
+				],
+			},
+		},
+		isLoading: false,
+		onOpenDetails: fn(),
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByText("Feedback from 5 Slack conversations")).toBeInTheDocument();
+	},
+};
+
+export const NoDataYet: Story = {
+	args: {
+		areas,
+		statuses: {},
+		isLoading: false,
+	},
+};
+
+export const EmptyWorkspace: Story = {
+	args: {
+		areas: [],
+		statuses: {},
+		isLoading: false,
+	},
+};
+
+export const Loading: Story = {
+	args: {
+		areas,
+		statuses: {},
+		isLoading: true,
+	},
+};
+
+export const ErrorState: Story = {
+	args: {
+		areas,
+		statuses: {},
+		isLoading: false,
+		error: new Error("Request failed"),
+	},
+};

--- a/webapp/src/components/profile/PracticeAreaStatusCard.test.tsx
+++ b/webapp/src/components/profile/PracticeAreaStatusCard.test.tsx
@@ -1,0 +1,216 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { PracticeArea, PracticeAreaStatus } from "@/api/types.gen";
+import { PracticeAreaStatusCard } from "./PracticeAreaStatusCard";
+
+const makeArea = (id: number, slug: string, name: string, description?: string): PracticeArea => ({
+	id,
+	active: true,
+	slug,
+	name,
+	description,
+	displayOrder: id,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+});
+
+const areas: PracticeArea[] = [
+	makeArea(
+		1,
+		"code-quality",
+		"Code Quality",
+		"Tracks how readable and maintainable your changes are.",
+	),
+	makeArea(2, "collaboration", "Collaboration"),
+	makeArea(3, "review-communication", "Review Communication"),
+];
+
+const statuses: Record<string, PracticeAreaStatus | undefined> = {
+	"code-quality": {
+		areaSlug: "code-quality",
+		areaName: "Code Quality",
+		status: "DEVELOPING",
+		guidance:
+			"Your recent feedback points to “Include tests with the change” as the next practice to focus on.",
+		guidanceSource: "RULE_BASED",
+		trajectory: "REGRESSING",
+		feedbackSpanDays: 12,
+		feedbackSince: new Date("2026-07-15T09:00:00Z"),
+		items: [
+			{
+				observationId: "0b54c9f2-8f4e-4a53-9be1-0e6a35a1c001",
+				title: "Missing rollout plan",
+				guidance: "Add a rollout section describing how the change ships.",
+				severity: "MAJOR",
+				artifactType: "PULL_REQUEST",
+				artifactId: 42,
+			},
+		],
+		sources: [
+			{ source: "PULL_REQUEST", count: 3 },
+			{ source: "ISSUE", count: 1 },
+			{ source: "CONVERSATION_THREAD", count: 2 },
+		],
+	},
+	collaboration: {
+		areaSlug: "collaboration",
+		areaName: "Collaboration",
+		status: "STRENGTH",
+		guidance:
+			"Your recent feedback shows a strength in “Respond to each review comment”. Keep building on it.",
+		guidanceSource: "RULE_BASED",
+		trajectory: "IMPROVING",
+		feedbackSpanDays: 1,
+		feedbackSince: new Date("2026-07-27T08:00:00Z"),
+		items: [
+			{
+				observationId: "0b54c9f2-8f4e-4a53-9be1-0e6a35a1c002",
+				title: "Responsive to review feedback",
+				artifactType: "PULL_REQUEST",
+				artifactId: 43,
+			},
+		],
+		sources: [{ source: "PULL_REQUEST", count: 1 }],
+	},
+	"review-communication": {
+		areaSlug: "review-communication",
+		areaName: "Review Communication",
+		status: "NO_DATA",
+		items: [],
+		sources: [],
+	},
+};
+
+describe("PracticeAreaStatusCard", () => {
+	it("shows a skeleton while loading", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={{}} isLoading={true} />);
+
+		expect(screen.getByTestId("practice-area-status-loading")).toBeTruthy();
+	});
+
+	it("shows an error alert when a query failed", () => {
+		render(
+			<PracticeAreaStatusCard
+				areas={areas}
+				statuses={{}}
+				isLoading={false}
+				error={new Error("boom")}
+				onRetry={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("Could not load your practice-area status")).toBeTruthy();
+	});
+
+	it("renders one card per area with the call-to-action status label", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={statuses} isLoading={false} />);
+
+		expect(screen.getByText("Code Quality")).toBeTruthy();
+		expect(screen.getByText("Needs attention")).toBeTruthy();
+		expect(screen.getByText("Collaboration")).toBeTruthy();
+		expect(screen.getByText("Going well")).toBeTruthy();
+		expect(screen.getByText("Review Communication")).toBeTruthy();
+		expect(screen.getByText("No feedback yet")).toBeTruthy();
+	});
+
+	it("shows the guidance text on a card that has feedback", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={statuses} isLoading={false} />);
+
+		expect(
+			screen.getByText(
+				"Your recent feedback points to “Include tests with the change” as the next practice to focus on.",
+			),
+		).toBeTruthy();
+		expect(
+			screen.getByText(
+				"Your recent feedback shows a strength in “Respond to each review comment”. Keep building on it.",
+			),
+		).toBeTruthy();
+	});
+
+	it("does not surface individual feedback items on the overview card", () => {
+		render(<PracticeAreaStatusCard areas={[areas[0]]} statuses={statuses} isLoading={false} />);
+
+		expect(screen.queryByText("Feedback highlight")).toBeNull();
+		expect(screen.queryByText("Missing rollout plan")).toBeNull();
+	});
+
+	it("tints the card frame with the status colour", () => {
+		const { container } = render(
+			<PracticeAreaStatusCard areas={[areas[0]]} statuses={statuses} isLoading={false} />,
+		);
+
+		expect(container.querySelector(".ring-destructive\\/40")).toBeTruthy();
+	});
+
+	it("shows provenance chips for the artifacts the feedback comes from", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={statuses} isLoading={false} />);
+
+		expect(screen.getByText("Feedback from 3 pull requests")).toBeTruthy();
+		expect(screen.getByText("Feedback from 1 issue")).toBeTruthy();
+		expect(screen.getByText("Feedback from 2 Slack conversations")).toBeTruthy();
+		expect(screen.getByText("Feedback from 1 pull request")).toBeTruthy();
+	});
+
+	it("shows the actual feedback span, with a singular form for a single day", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={statuses} isLoading={false} />);
+
+		expect(screen.getByText("Based on feedback from the last 12 days")).toBeTruthy();
+		expect(screen.getByText("Based on feedback from the last day")).toBeTruthy();
+	});
+
+	it("hints at the trajectory without turning it into a score", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={statuses} isLoading={false} />);
+
+		expect(screen.getByText("Improving lately")).toBeTruthy();
+		expect(screen.getByText("More to work on lately")).toBeTruthy();
+	});
+
+	it("offers the area description behind the info affordance", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={statuses} isLoading={false} />);
+
+		expect(screen.getByRole("button", { name: "About Code Quality" })).toBeTruthy();
+	});
+
+	it("opens the deeper analysis for the selected area", () => {
+		const onOpenDetails = vi.fn();
+		render(
+			<PracticeAreaStatusCard
+				areas={areas}
+				statuses={statuses}
+				isLoading={false}
+				onOpenDetails={onOpenDetails}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "See details about Code Quality" }));
+
+		expect(onOpenDetails).toHaveBeenCalledWith(areas[0]);
+	});
+
+	it("does not render a dead detail action before a destination is connected", () => {
+		render(<PracticeAreaStatusCard areas={[areas[0]]} statuses={statuses} isLoading={false} />);
+
+		expect(screen.queryByRole("button", { name: "See details about Code Quality" })).toBeNull();
+	});
+
+	it("shows a clear no-data hint on an area without findings", () => {
+		render(<PracticeAreaStatusCard areas={areas} statuses={statuses} isLoading={false} />);
+
+		expect(screen.getByText("Status appears once your work has been reviewed.")).toBeTruthy();
+	});
+
+	it("treats an area whose status has not arrived yet as no-data", () => {
+		render(<PracticeAreaStatusCard areas={[areas[0]]} statuses={{}} isLoading={false} />);
+
+		expect(screen.getByText("No feedback yet")).toBeTruthy();
+	});
+
+	it("explains when the workspace has no practice areas", () => {
+		render(<PracticeAreaStatusCard areas={[]} statuses={{}} isLoading={false} />);
+
+		expect(
+			screen.getByText("No practice areas are configured in this workspace yet."),
+		).toBeTruthy();
+	});
+});

--- a/webapp/src/components/profile/PracticeAreaStatusCard.tsx
+++ b/webapp/src/components/profile/PracticeAreaStatusCard.tsx
@@ -1,0 +1,223 @@
+import { ArrowRightIcon, InfoIcon, LayersIcon } from "lucide-react";
+import type { PracticeArea, PracticeAreaStatus } from "@/api/types.gen";
+import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
+import { ICON_COMPONENTS } from "@/components/shared/area-visuals";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import {
+	PRACTICE_AREA_SOURCE_META,
+	PRACTICE_AREA_STATUS_BADGE,
+	PRACTICE_AREA_TREND_HINT,
+} from "./practice-area-status-presentation";
+
+export interface PracticeAreaStatusSectionProps {
+	/** The workspace's active practice areas. */
+	areas: PracticeArea[];
+	/** Derived status per area slug. */
+	statuses: Record<string, PracticeAreaStatus | undefined>;
+	isLoading: boolean;
+	/** The thrown query error, if either request failed. */
+	error?: unknown;
+	onRetry?: () => void;
+	/** Opens the deeper analysis for an area once that surface is available. */
+	onOpenDetails?: (area: PracticeArea) => void;
+}
+
+/**
+ * Own-profile practice-area overview — one card per area: a neutral icon chip (the admin-set area
+ * icon when configured, else a default), the description behind an info affordance, the status badge
+ * with a muted trend hint beside it, the server's guidance text, and the days of feedback the
+ * standing rests on (hover or focus reveals when tracking started). Individual feedback items stay off
+ * this overview — they belong to the detail surface. A details action only appears when its
+ * destination is actually wired. The card frame carries the same tint as the status badge
+ * background, so the status colours the frame without shouting.
+ */
+export function PracticeAreaStatusCard({
+	areas,
+	statuses,
+	isLoading,
+	error,
+	onRetry,
+	onOpenDetails,
+}: PracticeAreaStatusSectionProps) {
+	if (isLoading) {
+		return <Skeleton className="h-40 w-full" data-testid="practice-area-status-loading" />;
+	}
+
+	if (error) {
+		return (
+			<QueryErrorAlert
+				error={error}
+				title="Could not load your practice-area status"
+				onRetry={onRetry}
+			/>
+		);
+	}
+
+	if (areas.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground">
+				No practice areas are configured in this workspace yet.
+			</p>
+		);
+	}
+
+	return (
+		<section className="flex flex-col gap-3">
+			<div>
+				<h2 className="text-lg font-semibold">Practice areas</h2>
+				<p className="text-sm text-muted-foreground">
+					Where you stand in each area, derived from feedback on your recent work.
+				</p>
+			</div>
+			<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+				{areas.map((area) => {
+					const status = statuses[area.slug];
+					const badge = PRACTICE_AREA_STATUS_BADGE[status?.status ?? "NO_DATA"];
+					const trend = status?.trajectory
+						? PRACTICE_AREA_TREND_HINT[status.trajectory]
+						: undefined;
+					// The admin-set icon when configured, else a neutral default — no seeded guessing,
+					// and monochrome so the status tint stays the card's only colour signal.
+					const AreaIcon = (area.icon ? ICON_COMPONENTS[area.icon] : undefined) ?? LayersIcon;
+					const spanDays = status?.feedbackSpanDays;
+					// Only source kinds this webapp knows how to draw; a newer server enum value is
+					// silently skipped instead of rendering a broken chip.
+					const sources = (status?.sources ?? [])
+						.map((sourceCount) => ({
+							sourceCount,
+							meta: PRACTICE_AREA_SOURCE_META[sourceCount.source],
+						}))
+						.filter((entry) => entry.meta !== undefined);
+					return (
+						<Card key={area.slug} className={cn("flex h-full flex-col", badge.ringClass)}>
+							<CardHeader className="gap-2">
+								<div className="flex items-center gap-2">
+									<span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+										<AreaIcon className="size-4" aria-hidden />
+									</span>
+									<CardTitle className="min-w-0 flex-1 text-pretty text-base leading-snug">
+										{area.name}
+									</CardTitle>
+									<Tooltip>
+										<TooltipTrigger
+											render={
+												<button
+													type="button"
+													aria-label={`About ${area.name}`}
+													className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+												/>
+											}
+										>
+											<InfoIcon className="size-3.5" aria-hidden />
+										</TooltipTrigger>
+										<TooltipContent>
+											{area.description ?? "No description for this area yet."}
+										</TooltipContent>
+									</Tooltip>
+								</div>
+								<div className="flex flex-wrap items-center gap-2">
+									<Badge variant={badge.variant}>{badge.label}</Badge>
+									{trend && (
+										<Tooltip>
+											<TooltipTrigger
+												render={
+													<button
+														type="button"
+														className="flex cursor-help items-center gap-1 text-xs text-muted-foreground underline decoration-dotted underline-offset-2"
+													/>
+												}
+											>
+												<trend.Icon className="size-3.5" aria-hidden />
+												{trend.label}
+											</TooltipTrigger>
+											<TooltipContent className="max-w-72">{trend.explanation}</TooltipContent>
+										</Tooltip>
+									)}
+								</div>
+							</CardHeader>
+							<CardContent className="flex flex-1 flex-col gap-2">
+								{status?.guidance ? (
+									<p className="text-pretty text-sm">{status.guidance}</p>
+								) : (
+									<p className="text-sm text-muted-foreground">
+										Status appears once your work has been reviewed.
+									</p>
+								)}
+							</CardContent>
+							{(spanDays != null || onOpenDetails) && (
+								<CardFooter className="mt-auto items-center justify-between gap-2">
+									{spanDays != null ? (
+										<div className="flex min-w-0 flex-col gap-1">
+											<Tooltip>
+												<TooltipTrigger
+													render={
+														<button
+															type="button"
+															className="cursor-help text-left text-xs text-muted-foreground underline decoration-dotted underline-offset-2"
+														/>
+													}
+												>
+													{spanDays === 1
+														? "Based on feedback from the last day"
+														: `Based on feedback from the last ${spanDays} days`}
+												</TooltipTrigger>
+												<TooltipContent>
+													{status?.feedbackSince
+														? `Tracking since ${new Intl.DateTimeFormat(undefined, { dateStyle: "long" }).format(new Date(status.feedbackSince))}`
+														: "Tracking start unknown"}
+												</TooltipContent>
+											</Tooltip>
+											{sources.length > 0 && (
+												<span className="flex flex-wrap items-center gap-3">
+													{sources.map(({ sourceCount, meta }) => {
+														if (!meta) return null;
+														const noun = sourceCount.count === 1 ? meta.singular : meta.plural;
+														return (
+															<Tooltip key={sourceCount.source}>
+																<TooltipTrigger
+																	render={
+																		<span className="flex cursor-help items-center gap-1 text-xs text-muted-foreground" />
+																	}
+																>
+																	<meta.Icon size={12} aria-hidden />
+																	<span aria-hidden>{sourceCount.count}</span>
+																	<span className="sr-only">{`Feedback from ${sourceCount.count} ${noun}`}</span>
+																</TooltipTrigger>
+																<TooltipContent>
+																	{`Feedback from ${sourceCount.count} ${noun}`}
+																</TooltipContent>
+															</Tooltip>
+														);
+													})}
+												</span>
+											)}
+										</div>
+									) : (
+										<span />
+									)}
+									{onOpenDetails && (
+										<Button
+											type="button"
+											size="sm"
+											variant="outline"
+											aria-label={`See details about ${area.name}`}
+											onClick={() => onOpenDetails(area)}
+										>
+											See details
+											<ArrowRightIcon className="size-3.5" aria-hidden />
+										</Button>
+									)}
+								</CardFooter>
+							)}
+						</Card>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/webapp/src/components/profile/ProfilePage.tsx
+++ b/webapp/src/components/profile/ProfilePage.tsx
@@ -4,6 +4,10 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import type { ActivityMonitorFilters } from "@/lib/activity-monitor";
 import type { ProviderType } from "@/lib/provider";
 import type { LeaderboardSchedule } from "@/lib/timeframe";
+import {
+	PracticeAreaStatusCard,
+	type PracticeAreaStatusSectionProps,
+} from "./PracticeAreaStatusCard";
 import { ProfileContent } from "./ProfileContent";
 import { ProfileHeader } from "./ProfileHeader";
 
@@ -26,6 +30,8 @@ interface ProfileProps {
 	achievementsEnabled?: boolean;
 	progressionEnabled?: boolean;
 	leaguesEnabled?: boolean;
+	/** Own-profile practice-area status section; omit to hide (e.g. on someone else's profile). */
+	practiceAreaStatus?: PracticeAreaStatusSectionProps;
 }
 
 export function ProfilePage({
@@ -46,6 +52,7 @@ export function ProfilePage({
 	achievementsEnabled = true,
 	progressionEnabled = true,
 	leaguesEnabled = true,
+	practiceAreaStatus,
 }: ProfileProps) {
 	if (error) {
 		return (
@@ -73,6 +80,7 @@ export function ProfilePage({
 				progressionEnabled={progressionEnabled}
 				leaguesEnabled={leaguesEnabled}
 			/>
+			{practiceAreaStatus && <PracticeAreaStatusCard {...practiceAreaStatus} />}
 			<ProfileContent
 				providerType={providerType}
 				activityMonitorData={activityMonitorData}

--- a/webapp/src/components/profile/practice-area-status-presentation.ts
+++ b/webapp/src/components/profile/practice-area-status-presentation.ts
@@ -1,0 +1,76 @@
+import {
+	GitPullRequestIcon,
+	IssueOpenedIcon,
+	type Icon as OcticonComponent,
+} from "@primer/octicons-react";
+import { type LucideIcon, TrendingDownIcon, TrendingUpIcon } from "lucide-react";
+import type { FeedbackSourceCount, PracticeAreaStatus } from "@/api/types.gen";
+import { type BrandIcon, SlackIcon } from "@/components/icons/brand";
+
+/** Shared formative labels and badge variants for every practice-area status surface. */
+export const PRACTICE_AREA_STATUS_BADGE: Record<
+	PracticeAreaStatus["status"],
+	{ label: string; variant: "destructive" | "warning" | "success" | "outline"; ringClass?: string }
+> = {
+	DEVELOPING: {
+		label: "Needs attention",
+		variant: "destructive",
+		ringClass: "ring-destructive/40 dark:ring-destructive/50",
+	},
+	MIXED: {
+		label: "Mixed feedback",
+		variant: "warning",
+		ringClass: "ring-warning/40 dark:ring-warning/50",
+	},
+	STRENGTH: {
+		label: "Going well",
+		variant: "success",
+		ringClass: "ring-success/40 dark:ring-success/50",
+	},
+	NO_DATA: { label: "No feedback yet", variant: "outline" },
+};
+
+/**
+ * Display metadata per feedback source kind, mirroring the activity monitor's icon language. The map is
+ * the single point to extend when a new observable integration lands server-side; a source the webapp
+ * does not know yet is skipped rather than rendered broken.
+ */
+export const PRACTICE_AREA_SOURCE_META: Partial<
+	Record<
+		FeedbackSourceCount["source"],
+		{ Icon: OcticonComponent | BrandIcon; singular: string; plural: string }
+	>
+> = {
+	PULL_REQUEST: { Icon: GitPullRequestIcon, singular: "pull request", plural: "pull requests" },
+	ISSUE: { Icon: IssueOpenedIcon, singular: "issue", plural: "issues" },
+	CONVERSATION_THREAD: {
+		Icon: SlackIcon,
+		singular: "Slack conversation",
+		plural: "Slack conversations",
+	},
+};
+
+/**
+ * Only directional changes need a hint; STEADY is intentionally left quiet. The explanation mirrors
+ * the server's derivation (day-to-day comparison of averaged feedback across the area's practices)
+ * so the hover answers "where does this arrow come from?" truthfully.
+ */
+export const PRACTICE_AREA_TREND_HINT: Partial<
+	Record<
+		NonNullable<PracticeAreaStatus["trajectory"]>,
+		{ label: string; Icon: LucideIcon; explanation: string }
+	>
+> = {
+	IMPROVING: {
+		label: "Improving lately",
+		Icon: TrendingUpIcon,
+		explanation:
+			"Compares the two most recent days with feedback across this area's practices. The latest day shows more strengths or fewer areas to work on.",
+	},
+	REGRESSING: {
+		label: "More to work on lately",
+		Icon: TrendingDownIcon,
+		explanation:
+			"Compares the two most recent days with feedback across this area's practices. The latest day shows more areas to work on or fewer strengths.",
+	},
+};

--- a/webapp/src/components/shared/area-visuals.test.ts
+++ b/webapp/src/components/shared/area-visuals.test.ts
@@ -1,9 +1,47 @@
 import { Folder, Package, Rocket } from "lucide-react";
 import { describe, expect, it } from "vitest";
-import { getAreaVisual, ICON_NAMES, iconLabel, iconSearchText, PILL } from "./area-visuals";
+import {
+	getAreaVisual,
+	ICON_NAMES,
+	iconLabel,
+	iconSearchText,
+	PILL,
+	SEEDED_AREA_SLUGS,
+} from "./area-visuals";
+
+/**
+ * The 11 seeded practice-area slugs (mirror of default-catalog.json). If a slug is renamed in the
+ * catalogue without updating the seed map, the area silently loses its icon/colour — this guard fails
+ * loudly instead.
+ */
+const EXPECTED_SLUGS = [
+	"review-ready-work",
+	"acting-on-review-feedback",
+	"actionable-issue-authoring",
+	"constructive-code-review",
+	"testing-discipline",
+	"code-craftsmanship",
+	"robust-error-handling",
+	"secure-by-default-changes",
+	"decisions-and-documentation",
+	"delivery-and-version-control-discipline",
+	"issue-traceability-and-lifecycle",
+];
 
 describe("areaVisuals", () => {
-	it("lets an admin-set icon and color override the seeded default", () => {
+	it("has a seed for every seeded area slug", () => {
+		expect([...SEEDED_AREA_SLUGS].sort()).toEqual([...EXPECTED_SLUGS].sort());
+	});
+
+	it("resolves every seeded slug to a curated (non-fallback) icon and a real colour pill", () => {
+		for (const slug of SEEDED_AREA_SLUGS) {
+			const visual = getAreaVisual(slug);
+			expect(visual.Icon).not.toBe(Folder);
+			expect(visual.pill).toMatch(/^bg-/);
+		}
+	});
+
+	it("lets an admin-set icon and colour override the seeded default", () => {
 		const visual = getAreaVisual(
 			"review-ready-work",
 			"Packaging work for review",
@@ -14,14 +52,14 @@ describe("areaVisuals", () => {
 		expect(visual.pill).toBe(PILL.fuchsia);
 	});
 
-	it("ignores an unknown icon name or color key and falls back to the seed", () => {
+	it("ignores an unknown icon name / colour key and falls back to the seed", () => {
 		const visual = getAreaVisual(
 			"review-ready-work",
 			"Packaging work for review",
 			"NotAnIcon",
 			"chartreuse",
 		);
-		expect(visual.Icon).toBe(Package);
+		expect(visual.Icon).toBe(Package); // the seeded icon for review-ready-work
 		expect(visual.pill).toBe(PILL.sky);
 	});
 

--- a/webapp/src/components/shared/area-visuals.ts
+++ b/webapp/src/components/shared/area-visuals.ts
@@ -100,9 +100,23 @@ import {
 	Zap,
 } from "lucide-react";
 
+/**
+ * Visual identity for a practice area: a lucide icon (the primary, glanceable identity) plus an
+ * accessible colour pill. Colour is a redundant cue only — the icon and the area NAME always carry
+ * the meaning, so the chip stays legible for colour-blind readers and never relies on hue alone.
+ *
+ * An area persists an optional {@code icon} (a lucide name) and {@code color} (a palette key) that an
+ * admin can edit; when set they win, otherwise the seeded defaults below apply, otherwise a keyword
+ * fallback.
+ *
+ * Pill classes are written as full literal strings so Tailwind keeps them (no runtime interpolation).
+ * Every family is contrast-checked: text-700/800 on bg-100 (light) and text-200 on bg-950/800 (dark)
+ * all clear AA. Free-form hex is intentionally NOT offered — it would defeat this guaranteed-legible,
+ * theme-aware, purge-safe contract; admins pick from this curated, accessible spectrum instead.
+ */
 export type AreaVisual = { Icon: LucideIcon; pill: string };
 
-// Tailwind requires complete class names in source to include them in the generated CSS.
+/** Palette family → accessible chip classes (AA on Tailwind 50–950, light + dark). */
 export const PILL: Record<string, string> = {
 	red: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-200",
 	orange: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-200",
@@ -127,8 +141,10 @@ export const PILL: Record<string, string> = {
 	stone: "bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-200",
 };
 
+/** The colour keys offered in the admin picker, in spectrum-then-neutral display order. */
 export const COLOR_KEYS = Object.keys(PILL);
 
+/** Curated lucide icons offered in the admin picker — a broad, searchable software-practice set. */
 export const ICON_COMPONENTS: Record<string, LucideIcon> = {
 	ShieldAlert,
 	ShieldCheck,
@@ -230,23 +246,28 @@ export const ICON_COMPONENTS: Record<string, LucideIcon> = {
 	Folder,
 };
 
+/** The icon names offered in the admin picker, in display order. */
 export const ICON_NAMES = Object.keys(ICON_COMPONENTS);
 
+/** Human-readable label for a PascalCase icon name, e.g. "MessageSquareReply" → "Message square reply". */
 export function iconLabel(name: string): string {
 	const words = name.replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
 	return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
+/** Lowercased, word-split form of a PascalCase icon name, so a search for "git" matches "GitBranch". */
 export function iconSearchText(name: string): string {
-	return iconLabel(name).toLowerCase();
+	return name.replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
 }
 
+/** Resolve a stored lucide name to a component, or undefined if unknown/unset. */
 function resolveIcon(name?: string | null): LucideIcon | undefined {
 	return name ? ICON_COMPONENTS[name] : undefined;
 }
 
 type Seed = { icon: string; color: string };
 
+/** Icon + colour for each of the 11 seeded practice areas (keyed on slug). */
 const AREA_SEEDS: Record<string, Seed> = {
 	"robust-error-handling": { icon: "ShieldAlert", color: "rose" },
 	"secure-by-default-changes": { icon: "ShieldCheck", color: "red" },
@@ -262,15 +283,19 @@ const AREA_SEEDS: Record<string, Seed> = {
 		icon: "GitBranch",
 		color: "fuchsia",
 	},
-	communication: { icon: "MessageCircle", color: "violet" },
 };
+
+/** The slugs of the seeded areas — exported for tests/guards. */
+export const SEEDED_AREA_SLUGS = Object.keys(AREA_SEEDS);
 
 const FALLBACK: Seed = { icon: "Folder", color: "slate" };
 
+/** The effective icon/colour *names* for an area before any admin override — for picker highlighting. */
 export function areaSeed(slug: string, name = ""): { icon: string; color: string } {
 	return seedFor(slug, name);
 }
 
+/** Seed defaults for any slug: the curated entry, else a keyword guess, else a neutral folder. */
 function seedFor(slug: string, name: string): Seed {
 	const known = AREA_SEEDS[slug];
 	if (known) return known;
@@ -285,6 +310,11 @@ function seedFor(slug: string, name: string): Seed {
 	return FALLBACK;
 }
 
+/**
+ * Resolve the visual for an area. An explicit (admin-set) `icon`/`color` wins; otherwise the seeded
+ * default for the slug; otherwise a keyword fallback. Unknown icon names / colour keys degrade to the
+ * seed so the chip always renders.
+ */
 export function getAreaVisual(
 	slug: string,
 	name = "",

--- a/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
+++ b/webapp/src/routes/_authenticated/w/$workspaceSlug/user/$username/index.tsx
@@ -3,8 +3,10 @@ import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/reac
 import { z } from "zod";
 import {
 	getActivityMonitorOptions,
+	getPracticeAreaStatusesOptions,
 	getUserProfileOptions,
 	getWorkspaceOptions,
+	listAreasOptions,
 } from "@/api/@tanstack/react-query.gen";
 import { QueryErrorAlert } from "@/components/common/QueryErrorAlert";
 import { ProfilePage } from "@/components/profile/ProfilePage";
@@ -115,6 +117,24 @@ function UserProfile() {
 
 	const currUserIsDashboardUser = isCurrentUser(username);
 
+	// Practice-area status is a self-view: the endpoint derives the CALLER's standing, so only
+	// fetch (and render) it when the profile being viewed is the logged-in user's own.
+	const areasQuery = useQuery({
+		...listAreasOptions({ path: { workspaceSlug }, query: { activeOnly: true } }),
+		enabled: Boolean(workspaceSlug) && currUserIsDashboardUser,
+	});
+	const practiceAreas = areasQuery.data ?? [];
+	const areaStatusesQuery = useQuery({
+		...getPracticeAreaStatusesOptions({
+			path: { workspaceSlug },
+		}),
+		enabled: Boolean(workspaceSlug) && currUserIsDashboardUser,
+	});
+	const areaStatuses = Object.fromEntries(
+		(areaStatusesQuery.data ?? []).map((status) => [status.areaSlug, status]),
+	);
+
+	// Query for user profile data
 	const profileQuery = useQuery({
 		...getUserProfileOptions({
 			path: { workspaceSlug, login: username },
@@ -197,6 +217,20 @@ function UserProfile() {
 			achievementsEnabled={achievementsEnabled === true}
 			progressionEnabled={progressionEnabled === true}
 			leaguesEnabled={leaguesEnabled === true}
+			practiceAreaStatus={
+				currUserIsDashboardUser
+					? {
+							areas: practiceAreas,
+							statuses: areaStatuses,
+							isLoading: areasQuery.isPending || areaStatusesQuery.isPending,
+							error: areasQuery.error ?? areaStatusesQuery.error ?? undefined,
+							onRetry: () => {
+								if (areasQuery.isError) areasQuery.refetch();
+								if (areaStatusesQuery.isError) areaStatusesQuery.refetch();
+							},
+						}
+					: undefined
+			}
 		/>
 	);
 }


### PR DESCRIPTION
## Description

Adds the profile overview: one card per active practice area showing where the developer stands — area icon, status badge, a trend hint whose derivation is explained on hover, the guidance sentence, and the pull requests, issues, and Slack conversations the assessment rests on.

Individual feedback items stay off this overview; they belong to the detail surface in the next pull request.

Second of three stacked pull requests — **targets `feat/practice-area-profile-api`**, so review that one first.

1. `feat/practice-area-profile-api` — server API
2. **this one** — profile cards
3. `feat/practice-area-detail-view` — detail page

## How to test

- Storybook: `pnpm --filter webapp run storybook` → `Components/Profile/PracticeAreaStatusCard` (overview, Slack provenance, no-data, loading, error).
- Vitest: `pnpm run test:webapp` covers card rendering, the provenance chips, the trend hover and the empty states.
- In the app: open your own profile in a workspace with practices enabled; the section only renders on the own profile, because the endpoint derives the caller's standing.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note
- [x] No operator action required

## Screenshots

Storybook stories cover every state; see `Components/Profile/PracticeAreaStatusCard`.