### PR TITLE
fix(server): stabilize evidence-aware practice reviews

### DIFF
--- a/.changeset/calm-reviews-align.md
+++ b/.changeset/calm-reviews-align.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Operators can now upgrade practice reviews without losing curated overrides or being blocked by one malformed catalogue entry. Worker readiness reports disabled repository evidence and expired review authorization.

--- a/docs/admin/practice-review-operations.mdx
+++ b/docs/admin/practice-review-operations.mdx
@@ -62,9 +62,17 @@ The job queue exposes its own signals — alert off these rather than reading ap
 - **`agent.job.retention.stripped`** / **`agent.job.retention.deleted`** — rows pruned by the retention
   sweep.
 - **`llm.budget.exhausted`** / **`llm.budget.blocked`** — a cap crossed, and work refused at a cap.
+- **`practice.review.refused`** — refused reviews, tagged by `phase` (`submission` or `execution`) and
+  `reason`.
 
-Gauge sampling is periodic; timers and counters are recorded inline. None run on a request path. Metric
-names in the instrumented code are the source of truth for dashboards and alerts.
+Query `/actuator/health/readiness` for aggregate readiness. An authorized response includes the
+**`practiceReview`** component. An enabled review worker reports `OUT_OF_SERVICE` with
+`GIT_CHECKOUT_DISABLED` when repository checkout is disabled, or `SOURCE_AUTHORIZATION_EXPIRED` when an
+automated-review source authorization has expired. Missing model bindings are workspace-specific and remain
+visible in **Review activity** and the refusal counter; they do not remove the worker from service.
+
+Gauges are sampled periodically; timers and counters are recorded when the corresponding event occurs.
+Metric names in the instrumented code are the source of truth for dashboards and alerts.
 
 **Retention.** Terminal job payloads are stripped before their rows are deleted. Row retention must not be
 shorter than payload retention. Set both against the approved retention policy, verify them in the effective
@@ -94,3 +102,10 @@ behaviors matter independently of their exact defaults:
   records evidence-backed observations. After Java admits them, a second turn composes lane-specific
   feedback from those observations and their evidence. Practice criteria affect what is observed; the
   composition contract affects what is said. Nothing on the administration screens edits either prompt.
+
+## Rollback
+
+Before upgrading, create and verify a database snapshot as described in
+[Backup and restore](./backup-restore.mdx). To return to the previous release after this migration, stop all
+Hephaestus roles, restore the snapshot, then deploy the previous version. Do not run the previous version
+against the migrated schema.

--- a/docs/contributor/erd/schema.mmd
+++ b/docs/contributor/erd/schema.mmd
@@ -255,7 +255,7 @@ erDiagram
         INTEGER position
         VARCHAR(64) icon
         VARCHAR(32) color
-        VARCHAR(64) based_on_digest
+        VARCHAR(128) based_on_digest
         TIMESTAMPTZ retired_at
         TIMESTAMPTZ created_at "NOT NULL"
         TIMESTAMPTZ updated_at "NOT NULL"
@@ -273,7 +273,7 @@ erDiagram
         TEXT what_good_looks_like
         VARCHAR(64) area_slug
         INTEGER position
-        VARCHAR(64) based_on_digest
+        VARCHAR(128) based_on_digest
         TIMESTAMPTZ retired_at
         TIMESTAMPTZ created_at "NOT NULL"
         TIMESTAMPTZ updated_at "NOT NULL"

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/config/PracticeReviewHealthIndicator.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/config/PracticeReviewHealthIndicator.java
@@ -1,0 +1,60 @@
+package de.tum.cit.aet.hephaestus.agent.config;
+
+import de.tum.cit.aet.hephaestus.agent.job.AgentProperties;
+import de.tum.cit.aet.hephaestus.evidence.ArtifactSourceCatalogRegistry;
+import de.tum.cit.aet.hephaestus.evidence.SourceUsePurpose;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.workdir.GitRepositoryProperties;
+import java.time.Clock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PracticeReviewHealthIndicator implements HealthIndicator {
+
+    private final AgentProperties agentProperties;
+    private final GitRepositoryProperties gitProperties;
+    private final ArtifactSourceCatalogRegistry sourceCatalog;
+    private final Clock clock;
+    private final boolean workerRole;
+
+    public PracticeReviewHealthIndicator(
+        AgentProperties agentProperties,
+        GitRepositoryProperties gitProperties,
+        ArtifactSourceCatalogRegistry sourceCatalog,
+        Clock clock,
+        @Value("${hephaestus.runtime.worker.enabled:true}") boolean workerRole
+    ) {
+        this.agentProperties = agentProperties;
+        this.gitProperties = gitProperties;
+        this.sourceCatalog = sourceCatalog;
+        this.clock = clock;
+        this.workerRole = workerRole;
+    }
+
+    @Override
+    public Health health() {
+        if (!workerRole || !agentProperties.enabled()) {
+            return Health.up().withDetail("reviewsEnabled", false).build();
+        }
+        if (!gitProperties.enabled()) {
+            return Health.outOfService()
+                .withDetail("reviewsEnabled", true)
+                .withDetail("reason", "GIT_CHECKOUT_DISABLED")
+                .build();
+        }
+        if (
+            sourceCatalog
+                .earliestUseDecisionExpiry(SourceUsePurpose.AUTOMATED_PRACTICE_REVIEW)
+                .filter(expiry -> !expiry.isAfter(clock.instant()))
+                .isPresent()
+        ) {
+            return Health.outOfService()
+                .withDetail("reviewsEnabled", true)
+                .withDetail("reason", "SOURCE_AUTHORIZATION_EXPIRED")
+                .build();
+        }
+        return Health.up().withDetail("reviewsEnabled", true).build();
+    }
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutor.java
@@ -623,7 +623,7 @@ public class AgentJobExecutor {
                     )
                 );
                 if (updated != null && updated == 1) {
-                    meterRegistry.counter("agent.job.evidence.refused").increment();
+                    recordPracticeReviewRefusal(job, "insufficient_evidence");
                     metricOutcome = "INSUFFICIENT_EVIDENCE";
                     log.info(
                         "Completed agent job without model execution: jobId={}, outcome=INSUFFICIENT_EVIDENCE",
@@ -1098,6 +1098,7 @@ public class AgentJobExecutor {
                 job.getWorkspace().getId(),
                 blockReason
             );
+            recordPracticeReviewRefusal(job, "budget_exhausted");
             meterRegistry.counter("agent.job.budget.refused").increment();
             return ClaimOutcome.BUDGET_BLOCKED;
         }
@@ -1125,8 +1126,15 @@ public class AgentJobExecutor {
         job.setCancellationReason(AgentJobCancellationReason.MODEL_UNAVAILABLE);
         jobRepository.save(job);
         meterRegistry.counter("agent.job.model.refused").increment();
+        recordPracticeReviewRefusal(job, "model_unavailable");
         log.info("Refusing claim — configured model unavailable: jobId={}", job.getId());
         return ClaimOutcome.MODEL_UNAVAILABLE;
+    }
+
+    private void recordPracticeReviewRefusal(AgentJob job, String reason) {
+        if (job.getPurpose() == AgentPurpose.PRACTICE_REVIEW) {
+            meterRegistry.counter("practice.review.refused", "phase", "execution", "reason", reason).increment();
+        }
     }
 
     private void releaseCapacity() {

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/evidence/ArtifactSourceCatalogRegistry.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/evidence/ArtifactSourceCatalogRegistry.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 public interface ArtifactSourceCatalogRegistry {
     ArtifactSourceCatalog current();
@@ -32,5 +33,5 @@ public interface ArtifactSourceCatalogRegistry {
 
     SourceUseDecision requireUseDecision(SourceContractVersion version, String decisionId);
 
-    Optional<Instant> earliestUseDecisionExpiry();
+    Optional<Instant> earliestUseDecisionExpiry(@Nullable SourceUsePurpose purpose);
 }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/evidence/internal/ArtifactSourceGovernanceMetrics.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/evidence/internal/ArtifactSourceGovernanceMetrics.java
@@ -17,7 +17,7 @@ final class ArtifactSourceGovernanceMetrics {
     ) {
         Gauge.builder("artifact.source.governance.expiry.seconds", sourceCatalogs, catalogs ->
             catalogs
-                .earliestUseDecisionExpiry()
+                .earliestUseDecisionExpiry(null)
                 .map(expiry -> (double) Duration.between(clock.instant(), expiry).toSeconds())
                 .orElse(Double.NaN)
         )

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/evidence/internal/ClasspathArtifactSourceCatalogRegistry.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/evidence/internal/ClasspathArtifactSourceCatalogRegistry.java
@@ -149,10 +149,11 @@ public final class ClasspathArtifactSourceCatalogRegistry implements ArtifactSou
     }
 
     @Override
-    public Optional<Instant> earliestUseDecisionExpiry() {
+    public Optional<Instant> earliestUseDecisionExpiry(@Nullable SourceUsePurpose purpose) {
         return useDecisions
             .values()
             .stream()
+            .filter(decision -> purpose == null || decision.purpose() == purpose)
             .map(SourceUseDecision::expiresAt)
             .filter(java.util.Objects::nonNull)
             .min(Instant::compareTo);

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/LedgerSignalRecorder.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/signal/LedgerSignalRecorder.java
@@ -1,6 +1,8 @@
 package de.tum.cit.aet.hephaestus.integration.core.signal;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -22,9 +24,11 @@ public class LedgerSignalRecorder implements SignalRecorder {
     private static final Logger log = LoggerFactory.getLogger(LedgerSignalRecorder.class);
 
     private final ArtifactSignalRepository repository;
+    private final MeterRegistry meterRegistry;
 
-    public LedgerSignalRecorder(ArtifactSignalRepository repository) {
+    public LedgerSignalRecorder(ArtifactSignalRepository repository, MeterRegistry meterRegistry) {
         this.repository = repository;
+        this.meterRegistry = meterRegistry;
     }
 
     @Override
@@ -98,6 +102,9 @@ public class LedgerSignalRecorder implements SignalRecorder {
             logUnsettled("refused", key);
             return;
         }
+        meterRegistry
+            .counter("practice.review.refused", "phase", "submission", "reason", reason.name().toLowerCase(Locale.ROOT))
+            .increment();
         log.debug(
             "Signal refused: workspaceId={}, signal={}, artifactId={}, reason={}, state={}",
             key.workspaceId(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/PracticeRepository.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/PracticeRepository.java
@@ -96,14 +96,14 @@ public interface PracticeRepository extends JpaRepository<Practice, Long> {
     boolean existsByWorkspaceIdAndSlug(Long workspaceId, String slug);
 
     @Query(
-        "SELECT DISTINCT p FROM Practice p JOIN FETCH p.currentRevision current, PracticeRevision previous " +
+        "SELECT DISTINCT p.id FROM Practice p JOIN p.currentRevision current, PracticeRevision previous " +
             "WHERE p.sourceCuratedSlug IS NOT NULL " +
             "AND previous.practice = p " +
             "AND previous.revisionNumber = current.revisionNumber - 1 " +
             "AND p.sourceCuratedFingerprint = previous.reviewRuleFingerprint " +
             "AND p.sourceCuratedFingerprint LIKE 'v1:%'"
     )
-    List<Practice> findSourceAlignedV1Practices();
+    List<Long> findSourceAlignedV1PracticeIds();
 
     /**
      * Every practice of a workspace in the order the admin catalogue shows them, areas first. No tier

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogEntry.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogEntry.java
@@ -33,10 +33,10 @@ public record CatalogEntry<D extends CatalogDefinition>(
         if (shipped == null) {
             return acceptedBundledDigest == null ? CatalogEntryState.YOURS : CatalogEntryState.NO_LONGER_SHIPPED;
         }
-        if (shipped.digest(slug).equals(overridden.digest(slug))) {
+        if (CuratedDefinitionDigest.of(slug, shipped).equals(CuratedDefinitionDigest.of(slug, overridden))) {
             return CatalogEntryState.EDITED_HERE;
         }
-        return shipped.digest(slug).equals(acceptedBundledDigest)
+        return CuratedDefinitionDigest.of(slug, shipped).equals(acceptedBundledDigest)
             ? CatalogEntryState.EDITED_HERE
             : CatalogEntryState.UPDATE_WAITING;
     }
@@ -46,7 +46,7 @@ public record CatalogEntry<D extends CatalogDefinition>(
         if (shipped == null || overridden == null) {
             return CatalogChangeKind.NONE;
         }
-        if (shipped.digest(slug).equals(overridden.digest(slug))) {
+        if (CuratedDefinitionDigest.of(slug, shipped).equals(CuratedDefinitionDigest.of(slug, overridden))) {
             return CatalogChangeKind.NONE;
         }
         if (overridden instanceof AreaDefinition) {
@@ -64,8 +64,8 @@ public record CatalogEntry<D extends CatalogDefinition>(
     public String etag() {
         return new CanonicalDigest()
             .add(slug)
-            .add(effective.digest(slug))
-            .addNullable(shipped == null ? null : shipped.digest(slug))
+            .add(CuratedDefinitionDigest.of(slug, effective))
+            .addNullable(shipped == null ? null : CuratedDefinitionDigest.of(slug, shipped))
             .addNullable(acceptedBundledDigest)
             .add(state().name())
             .add(changeKind().name())

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfill.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfill.java
@@ -32,7 +32,7 @@ public class CatalogProvenanceBackfill {
     private final PracticeAreaRepository practiceAreaRepository;
     private final PracticeRevisionRepository revisionRepository;
     private final PracticeRevisionService revisionService;
-    private final BundledPracticeCatalogLoader bundledCatalogLoader;
+    private final CuratedCatalogService curatedCatalogService;
     private final TransactionOperations transactionOperations;
     private final Clock clock;
 
@@ -43,7 +43,7 @@ public class CatalogProvenanceBackfill {
         if (pending.isEmpty()) {
             return new Stamped(0, 0);
         }
-        BundledPracticeCatalog catalog = bundledCatalogLoader.catalog();
+        EffectiveCatalog catalog = curatedCatalogService.catalog();
         Stamped total = new Stamped(0, 0);
         int completed = 0;
         for (Long workspaceId : pending) {
@@ -64,21 +64,40 @@ public class CatalogProvenanceBackfill {
     }
 
     private void alignVersionedEvidence() {
-        BundledPracticeCatalog catalog = bundledCatalogLoader.catalog();
-        for (Practice practice : practiceRepository.findSourceAlignedV1Practices()) {
-            catalog
-                .practices()
-                .stream()
-                .filter(entry -> entry.slug().equals(practice.getSourceCuratedSlug()))
-                .findFirst()
-                .ifPresent(entry ->
-                    transactionOperations.executeWithoutResult(ignored -> {
-                        Practice managed = practiceRepository.findById(practice.getId()).orElseThrow();
-                        managed.setAutomatedReviewPolicy(entry.definition().automatedReviewPolicy());
-                        managed.setSourceCuratedFingerprint(entry.definition().provenanceFingerprint(entry.slug()));
-                        revisionService.append(managed);
-                    })
-                );
+        EffectiveCatalog catalog = curatedCatalogService.catalog();
+        for (Long practiceId : practiceRepository.findSourceAlignedV1PracticeIds()) {
+            try {
+                transactionOperations.executeWithoutResult(ignored -> {
+                    Practice managed = practiceRepository.findById(practiceId).orElseThrow();
+                    catalog
+                        .practice(managed.getSourceCuratedSlug())
+                        .ifPresent(entry -> {
+                            PracticeDefinition effective = entry.effective();
+                            PracticeDefinition aligned = new PracticeDefinition(
+                                managed.getName(),
+                                managed.getBindings(),
+                                managed.getCriteria(),
+                                managed.getPrecomputeScript(),
+                                effective.automatedReviewPolicy(),
+                                managed.getWhyItMatters(),
+                                managed.getWhatGoodLooksLike(),
+                                managed.getArea() == null ? null : managed.getArea().getSlug()
+                            );
+                            if (
+                                !aligned
+                                    .provenanceFingerprint(entry.slug())
+                                    .equals(effective.provenanceFingerprint(entry.slug()))
+                            ) {
+                                return;
+                            }
+                            managed.setAutomatedReviewPolicy(effective.automatedReviewPolicy());
+                            managed.setSourceCuratedFingerprint(effective.provenanceFingerprint(entry.slug()));
+                            revisionService.append(managed);
+                        });
+                });
+            } catch (RuntimeException exception) {
+                log.error("Could not align catalog evidence: practiceId={}", practiceId, exception);
+            }
         }
     }
 
@@ -98,7 +117,7 @@ public class CatalogProvenanceBackfill {
         }
     }
 
-    private Stamped stamp(Long workspaceId, BundledPracticeCatalog catalog) {
+    private Stamped stamp(Long workspaceId, EffectiveCatalog catalog) {
         PracticeCatalogInstallation installation = installationRepository
             .findByWorkspaceIdForUpdate(workspaceId)
             .orElse(null);
@@ -118,7 +137,7 @@ public class CatalogProvenanceBackfill {
         }
     }
 
-    private int stampPractices(Long workspaceId, BundledPracticeCatalog catalog) {
+    private int stampPractices(Long workspaceId, EffectiveCatalog catalog) {
         int stamped = 0;
         for (Practice practice : practiceRepository.findAllForCatalog(workspaceId)) {
             if (practice.getSourceCuratedSlug() != null || practice.getCurrentRevision() == null) {
@@ -130,7 +149,7 @@ public class CatalogProvenanceBackfill {
                 .stream()
                 .filter(entry -> entry.slug().equals(practice.getSlug()))
                 .findFirst()
-                .map(entry -> entry.definition().provenanceFingerprint(entry.slug()).equals(fingerprint))
+                .map(entry -> entry.effective().provenanceFingerprint(entry.slug()).equals(fingerprint))
                 .orElse(false);
             if (!matchesCatalog) {
                 continue;
@@ -143,7 +162,7 @@ public class CatalogProvenanceBackfill {
         return stamped;
     }
 
-    private int stampAreas(Long workspaceId, BundledPracticeCatalog catalog) {
+    private int stampAreas(Long workspaceId, EffectiveCatalog catalog) {
         int stamped = 0;
         for (PracticeArea area : practiceAreaRepository.findByWorkspaceIdOrderByDisplayOrderAscNameAsc(workspaceId)) {
             if (area.getSourceCuratedSlug() != null) {
@@ -155,7 +174,7 @@ public class CatalogProvenanceBackfill {
                 .stream()
                 .filter(entry -> entry.slug().equals(area.getSlug()))
                 .findFirst()
-                .map(entry -> entry.definition().provenanceFingerprint(entry.slug()).equals(fingerprint))
+                .map(entry -> entry.effective().provenanceFingerprint(entry.slug()).equals(fingerprint))
                 .orElse(false);
             if (!matchesCatalog) {
                 continue;

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfillStartup.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfillStartup.java
@@ -2,22 +2,38 @@ package de.tum.cit.aet.hephaestus.practices.curated;
 
 import de.tum.cit.aet.hephaestus.core.runtime.ConditionalOnServerRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-/** Runs pending provenance linking before application readiness. */
 @Component
+@Slf4j
 @Profile("!test & !specs")
 @ConditionalOnServerRole
 @RequiredArgsConstructor
-class CatalogProvenanceBackfillStartup implements ApplicationRunner {
+class CatalogProvenanceBackfillStartup implements ApplicationRunner, HealthIndicator {
 
     private final CatalogProvenanceBackfill backfill;
+    private volatile boolean failed;
 
     @Override
-    public void run(ApplicationArguments args) {
-        backfill.run();
+    public void run(ApplicationArguments arguments) {
+        try {
+            backfill.run();
+        } catch (RuntimeException exception) {
+            failed = true;
+            log.error("Could not run catalog provenance repair", exception);
+        }
+    }
+
+    @Override
+    public Health health() {
+        return failed
+            ? Health.outOfService().withDetail("reason", "CATALOG_PROVENANCE_REPAIR_FAILED").build()
+            : Health.up().build();
     }
 }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedAreaOverride.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedAreaOverride.java
@@ -40,7 +40,7 @@ public class CuratedAreaOverride {
     @Column(name = "color", length = 32)
     private @Nullable String color;
 
-    @Column(name = "based_on_digest", length = 64)
+    @Column(name = "based_on_digest", length = 128)
     private @Nullable String acceptedBundledDigest;
 
     @Column(name = "retired_at")

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogModel.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedCatalogModel.java
@@ -127,7 +127,7 @@ final class CuratedCatalogModel {
     }
 
     static @Nullable String digestOf(@Nullable CatalogDefinition definition, String slug) {
-        return definition == null ? null : definition.digest(slug);
+        return definition == null ? null : CuratedDefinitionDigest.of(slug, definition);
     }
 
     static List<CatalogEntry<AreaDefinition>> orderAreas(

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedDefinitionDigest.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedDefinitionDigest.java
@@ -1,0 +1,22 @@
+package de.tum.cit.aet.hephaestus.practices.curated;
+
+import de.tum.cit.aet.hephaestus.practices.AreaDefinition;
+import de.tum.cit.aet.hephaestus.practices.CatalogDefinition;
+import de.tum.cit.aet.hephaestus.practices.PracticeDefinition;
+
+final class CuratedDefinitionDigest {
+
+    private static final String AREA_V1 = "area:v1:";
+    private static final String PRACTICE_V2 = "practice:v2:";
+
+    private CuratedDefinitionDigest() {}
+
+    static String of(String slug, CatalogDefinition definition) {
+        String prefix = switch (definition) {
+            case AreaDefinition ignored -> AREA_V1;
+            case PracticeDefinition ignored -> PRACTICE_V2;
+            default -> throw new IllegalArgumentException("Unsupported catalog definition: " + definition.getClass());
+        };
+        return prefix + definition.digest(slug);
+    }
+}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedPracticeOverride.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/practices/curated/CuratedPracticeOverride.java
@@ -64,7 +64,7 @@ public class CuratedPracticeOverride {
     @Column(name = "position")
     private @Nullable Integer position;
 
-    @Column(name = "based_on_digest", length = 64)
+    @Column(name = "based_on_digest", length = 128)
     private @Nullable String acceptedBundledDigest;
 
     @Column(name = "retired_at")

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -140,14 +140,10 @@ management:
             enabled: true
         readinessState:
             enabled: true
-        # Spring Boot derives indicator bean names from the class by stripping the
-        # "HealthIndicator" suffix and lowercasing the first letter. Adding the
-        # integration-consumer probe to the readiness group makes a degraded NATS
-        # consumer (DOWN) take the pod out of the load balancer without crash-
-        # looping it — the indicator's javadoc explicitly promises this.
+        # Operational dependencies affect readiness, not process liveness.
         group:
             readiness:
-                include: readinessState,integrationConsumer
+                include: readinessState,integrationConsumer,practiceReview,catalogProvenanceBackfillStartup
 
 springdoc:
     # Off unless a profile asks for it. SecurityConfig permitAll()s /v3/api-docs/** and /swagger-ui/**

--- a/server/src/main/resources/db/changelog/1787086476726_changelog.xml
+++ b/server/src/main/resources/db/changelog/1787086476726_changelog.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="hephaestus" id="1787086476726-1">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="curated_area_override"/>
+                <tableExists tableName="curated_practice_override"/>
+                <sqlCheck expectedResult="1">
+                    SELECT count(*) FROM information_schema.table_constraints
+                    WHERE table_schema = current_schema()
+                      AND table_name = 'curated_area_override'
+                      AND constraint_name = 'ck_curated_area_override_based_on'
+                </sqlCheck>
+                <sqlCheck expectedResult="1">
+                    SELECT count(*) FROM information_schema.table_constraints
+                    WHERE table_schema = current_schema()
+                      AND table_name = 'curated_practice_override'
+                      AND constraint_name = 'ck_curated_practice_override_based_on'
+                </sqlCheck>
+            </and>
+        </preConditions>
+        <comment>Namespace curated base digests by definition type and canonicalization version.</comment>
+        <sql splitStatements="true" endDelimiter=";"><![CDATA[
+            ALTER TABLE curated_area_override DROP CONSTRAINT ck_curated_area_override_based_on;
+            ALTER TABLE curated_practice_override DROP CONSTRAINT ck_curated_practice_override_based_on;
+            ALTER TABLE curated_area_override ALTER COLUMN based_on_digest TYPE VARCHAR(128);
+            ALTER TABLE curated_practice_override ALTER COLUMN based_on_digest TYPE VARCHAR(128);
+            UPDATE curated_area_override
+               SET based_on_digest = 'area:v1:' || based_on_digest
+             WHERE based_on_digest ~ '^[0-9a-f]{64}$';
+            UPDATE curated_practice_override
+               SET based_on_digest = 'practice:v1:' || based_on_digest
+             WHERE based_on_digest ~ '^[0-9a-f]{64}$';
+            ALTER TABLE curated_area_override
+                ADD CONSTRAINT ck_curated_area_override_based_on
+                CHECK (based_on_digest IS NULL OR based_on_digest ~ '^area:v1:[0-9a-f]{64}$');
+            ALTER TABLE curated_practice_override
+                ADD CONSTRAINT ck_curated_practice_override_based_on
+                CHECK (based_on_digest IS NULL OR based_on_digest ~ '^practice:v[12]:[0-9a-f]{64}$');
+        ]]></sql>
+        <rollback>
+            <sql splitStatements="true" endDelimiter=";"><![CDATA[
+                ALTER TABLE curated_area_override DROP CONSTRAINT ck_curated_area_override_based_on;
+                ALTER TABLE curated_practice_override DROP CONSTRAINT ck_curated_practice_override_based_on;
+                ALTER TABLE curated_practice_override
+                    ADD CONSTRAINT ck_curated_practice_override_rollback_v1
+                    CHECK (based_on_digest IS NULL OR based_on_digest !~ '^practice:v2:');
+                UPDATE curated_area_override
+                   SET based_on_digest = substring(based_on_digest from 9)
+                 WHERE based_on_digest ~ '^area:v1:[0-9a-f]{64}$';
+                UPDATE curated_practice_override
+                   SET based_on_digest = substring(based_on_digest from 13)
+                 WHERE based_on_digest ~ '^practice:v1:[0-9a-f]{64}$';
+                ALTER TABLE curated_practice_override
+                    DROP CONSTRAINT ck_curated_practice_override_rollback_v1;
+                ALTER TABLE curated_area_override ALTER COLUMN based_on_digest TYPE VARCHAR(64);
+                ALTER TABLE curated_practice_override ALTER COLUMN based_on_digest TYPE VARCHAR(64);
+                ALTER TABLE curated_area_override
+                    ADD CONSTRAINT ck_curated_area_override_based_on
+                    CHECK (based_on_digest IS NULL OR based_on_digest ~ '^[0-9a-f]{64}$');
+                ALTER TABLE curated_practice_override
+                    ADD CONSTRAINT ck_curated_practice_override_based_on
+                    CHECK (based_on_digest IS NULL OR based_on_digest ~ '^[0-9a-f]{64}$');
+            ]]></sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/server/src/main/resources/db/master.xml
+++ b/server/src/main/resources/db/master.xml
@@ -90,4 +90,5 @@
     <include file="./changelog/1785678171817_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1785739495153_changelog.xml" relativeToChangelogFile="true"/>
     <include file="./changelog/1785743133884_changelog.xml" relativeToChangelogFile="true"/>
+    <include file="./changelog/1787086476726_changelog.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/PracticeCatalogInstallationMigrationIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/PracticeCatalogInstallationMigrationIntegrationTest.java
@@ -3,11 +3,21 @@ package de.tum.cit.aet.hephaestus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import de.tum.cit.aet.hephaestus.evidence.RequiredCaptureQuality;
+import de.tum.cit.aet.hephaestus.evidence.SourceKind;
+import de.tum.cit.aet.hephaestus.evidence.internal.ClasspathArtifactSourceCatalogRegistry;
+import de.tum.cit.aet.hephaestus.practices.EvidenceStance;
+import de.tum.cit.aet.hephaestus.practices.PracticeAutomatedReviewPolicy;
+import de.tum.cit.aet.hephaestus.practices.PracticeBinding;
+import de.tum.cit.aet.hephaestus.practices.PracticeDefinition;
+import de.tum.cit.aet.hephaestus.practices.PracticeDefinitionValidator;
+import de.tum.cit.aet.hephaestus.practices.PracticeSignalOptionsFixture;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import liquibase.Contexts;
@@ -23,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 
 @Testcontainers
 @Tag("integration")
@@ -73,14 +85,17 @@ class PracticeCatalogInstallationMigrationIntegrationTest {
         updateThrough("1785743133884-5");
         assertHistoricalFingerprintsVersioned();
         seedLegacyAuditVocabulary();
+        seedLegacyCuratedOverrides();
         try (Liquibase liquibase = liquibase()) {
             liquibase.update(contexts());
         }
 
+        assertLegacyCuratedDigestsVersioned();
+        assertMigratedCuratedPoliciesAreValid();
         assertMarkerRepair();
         assertHistoricalFingerprintsClearedForRecomputation();
         assertAuditHistoryPreserved();
-        assertEmptyCatalogBootstrap();
+        assertCatalogBootstrap(3, 1);
         assertWorkspaceRevisionBackfill();
         assertEvidenceRevisionBackfill();
         assertPointerOwnership();
@@ -108,6 +123,108 @@ class PracticeCatalogInstallationMigrationIntegrationTest {
             )
             """
         );
+    }
+
+    private static void seedLegacyCuratedOverrides() throws SQLException {
+        execute(
+            """
+            INSERT INTO curated_area_override (
+                slug, name, description, based_on_digest, created_at, updated_at, version
+            ) VALUES (
+                'real-area', 'Real area override', 'Preserve this curated intent', repeat('a', 64), now(), now(), 0
+            )
+            """,
+            """
+            INSERT INTO curated_practice_override (
+                slug, name, applies_to, trigger_events, criteria, automated_review_policy,
+                based_on_digest, created_at, updated_at, version
+            ) VALUES
+            (
+                'real-practice', 'Real practice override', 'PULL_REQUEST', '[\"READY_FOR_REVIEW\"]'::jsonb,
+                'Keep the effective override',
+                '{"sourceContractVersion":"1.0.0","automatedReview":{"mode":"LANGUAGE_MODEL","evidenceSufficiency":"SUFFICIENT_WHEN_REQUIREMENTS_MET"},"requiredEvidence":[{"sourceKind":"scm.pull-request.core","completeness":"COMPLETE","freshness":"CURRENT"},{"sourceKind":"scm.pull-request.diff","completeness":"COMPLETE","freshness":"CURRENT"}],"optionalContext":[{"sourceKind":"scm.pull-request.comments"}],"whenEvidenceIsInsufficient":"SKIP_AUTOMATED_REVIEW","knownLimitations":[]}'::jsonb,
+                repeat('b', 64), now(), now(), 0
+            ), (
+                'legacy-issue', 'Legacy issue override', 'ISSUE', '[\"IssueCreated\"]'::jsonb,
+                'Preserve issue intent',
+                '{"sourceContractVersion":"1.0.0","automatedReview":{"mode":"LANGUAGE_MODEL","evidenceSufficiency":"SUFFICIENT_WHEN_REQUIREMENTS_MET"},"requiredEvidence":[{"sourceKind":"scm.issue.core","completeness":"COMPLETE","freshness":"CURRENT"}],"optionalContext":[{"sourceKind":"scm.issue.comments"}],"whenEvidenceIsInsufficient":"SKIP_AUTOMATED_REVIEW","knownLimitations":[]}'::jsonb,
+                NULL, now(), now(), 0
+            ), (
+                'legacy-conversation', 'Legacy conversation override', 'CONVERSATION_THREAD', '[]'::jsonb,
+                'Preserve conversation intent',
+                '{"sourceContractVersion":"1.0.0","automatedReview":{"mode":"LANGUAGE_MODEL","evidenceSufficiency":"SUFFICIENT_WHEN_REQUIREMENTS_MET"},"requiredEvidence":[{"sourceKind":"slack.conversation.thread","completeness":"COMPLETE","freshness":"CURRENT"}],"optionalContext":[],"whenEvidenceIsInsufficient":"SKIP_AUTOMATED_REVIEW","knownLimitations":[]}'::jsonb,
+                NULL, now(), now(), 0
+            )
+            """
+        );
+    }
+
+    private static void assertMigratedCuratedPoliciesAreValid() throws Exception {
+        JsonMapper mapper = JsonMapper.builder().build();
+        var sources = new ClasspathArtifactSourceCatalogRegistry(mapper, Clock.systemUTC());
+        var validator = new PracticeDefinitionValidator(sources, PracticeSignalOptionsFixture.real());
+        int validated = 0;
+        try (
+            Connection connection = connect();
+            Statement statement = connection.createStatement();
+            ResultSet rows = statement.executeQuery(
+                "SELECT slug, name, bindings::text, criteria, automated_review_policy::text, area_slug " +
+                    "FROM curated_practice_override ORDER BY slug"
+            )
+        ) {
+            while (rows.next()) {
+                List<PracticeBinding> bindings = mapper.readValue(
+                    rows.getString("bindings"),
+                    new TypeReference<List<PracticeBinding>>() {}
+                );
+                PracticeAutomatedReviewPolicy policy = mapper.readValue(
+                    rows.getString("automated_review_policy"),
+                    PracticeAutomatedReviewPolicy.class
+                );
+                validator.validate(
+                    new PracticeDefinition(
+                        rows.getString("name"),
+                        bindings,
+                        rows.getString("criteria"),
+                        null,
+                        policy,
+                        null,
+                        null,
+                        rows.getString("area_slug")
+                    )
+                );
+                if (rows.getString("slug").equals("real-practice")) {
+                    assertThat(bindings)
+                        .flatExtracting(PracticeBinding::needs)
+                        .anySatisfy(need -> {
+                            assertThat(need.sourceKind()).isEqualTo(new SourceKind("scm.pull-request.diff"));
+                            assertThat(need.stance()).isEqualTo(EvidenceStance.REQUIRED);
+                        });
+                }
+                validated++;
+            }
+        }
+        assertThat(validated).isEqualTo(3);
+        assertThat(scalar("SELECT criteria FROM curated_practice_override WHERE slug = 'real-practice'")).isEqualTo(
+            "Keep the effective override"
+        );
+        assertThat(
+            sources
+                .requireSource(
+                    new de.tum.cit.aet.hephaestus.evidence.SourceContractVersion("1.0.0"),
+                    new SourceKind("scm.pull-request.diff")
+                )
+                .requiredQuality()
+        ).isEqualTo(RequiredCaptureQuality.COMPLETE_AND_NON_EMPTY);
+    }
+
+    private static void assertLegacyCuratedDigestsVersioned() throws SQLException {
+        assertThat(scalar("SELECT based_on_digest FROM curated_area_override WHERE slug = 'real-area'")).isEqualTo(
+            "area:v1:" + "a".repeat(64)
+        );
+        assertThat(
+            scalar("SELECT based_on_digest FROM curated_practice_override WHERE slug = 'real-practice'")
+        ).isEqualTo("practice:v1:" + "b".repeat(64));
     }
 
     private static void assertAuditHistoryPreserved() throws SQLException {
@@ -164,9 +281,9 @@ class PracticeCatalogInstallationMigrationIntegrationTest {
         assertThat(markedWorkspaceSlugs()).containsExactly("area-only", "practice-only");
     }
 
-    private static void assertEmptyCatalogBootstrap() throws SQLException {
-        assertThat(scalar("SELECT count(*)::text FROM curated_practice_override")).isEqualTo("0");
-        assertThat(scalar("SELECT count(*)::text FROM curated_area_override")).isEqualTo("0");
+    private static void assertCatalogBootstrap(int practices, int areas) throws SQLException {
+        assertThat(scalar("SELECT count(*)::text FROM curated_practice_override")).isEqualTo(String.valueOf(practices));
+        assertThat(scalar("SELECT count(*)::text FROM curated_area_override")).isEqualTo(String.valueOf(areas));
         assertThat(
             scalar("SELECT count(*)::text FROM practice_catalog_installation WHERE provenance_linked_at IS NOT NULL")
         ).isEqualTo("1");
@@ -429,6 +546,22 @@ class PracticeCatalogInstallationMigrationIntegrationTest {
     }
 
     private static void assertRollbackAndReapply() throws Exception {
+        execute(
+            "UPDATE curated_practice_override SET based_on_digest = 'practice:v2:' || repeat('e', 64) " +
+                "WHERE slug = 'real-practice'"
+        );
+        try (Liquibase liquibase = liquibase()) {
+            assertThatThrownBy(() ->
+                liquibase.rollback(BEFORE_CATALOG_TAG, contexts(), new LabelExpression())
+            ).hasMessageContaining("ck_curated_practice_override_rollback_v1");
+        }
+        assertThat(
+            scalar("SELECT based_on_digest FROM curated_practice_override WHERE slug = 'real-practice'")
+        ).startsWith("practice:v2:");
+        execute(
+            "UPDATE curated_practice_override SET based_on_digest = 'practice:v1:' || repeat('b', 64) " +
+                "WHERE slug = 'real-practice'"
+        );
         try (Liquibase liquibase = liquibase()) {
             liquibase.rollback(BEFORE_CATALOG_TAG, contexts(), new LabelExpression());
         }
@@ -455,7 +588,7 @@ class PracticeCatalogInstallationMigrationIntegrationTest {
         }
 
         assertMarkerRepair();
-        assertEmptyCatalogBootstrap();
+        assertCatalogBootstrap(0, 0);
         assertThat(
             scalar(
                 """

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/config/PracticeReviewHealthIndicatorTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/config/PracticeReviewHealthIndicatorTest.java
@@ -1,0 +1,92 @@
+package de.tum.cit.aet.hephaestus.agent.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.hephaestus.agent.job.AgentProperties;
+import de.tum.cit.aet.hephaestus.evidence.ArtifactSourceCatalogRegistry;
+import de.tum.cit.aet.hephaestus.evidence.SourceUsePurpose;
+import de.tum.cit.aet.hephaestus.integration.scm.domain.workdir.GitRepositoryProperties;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.util.unit.DataSize;
+
+class PracticeReviewHealthIndicatorTest extends BaseUnitTest {
+
+    @Test
+    void shouldRefuseReadinessWhenReviewWorkerHasNoCheckout() {
+        var health = indicator(true, false, Optional.empty()).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails()).containsEntry("reason", "GIT_CHECKOUT_DISABLED");
+    }
+
+    @Test
+    void shouldStayHealthyWhenReviewsAreDisabled() {
+        assertThat(indicator(false, false, Optional.empty()).health().getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    void shouldStayHealthyOnANonWorkerRole() {
+        assertThat(indicator(true, false, Optional.empty(), false).health().getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    void shouldRefuseReadinessWhenSourceAuthorizationExpired() {
+        var health = indicator(true, true, Optional.of(Instant.parse("2025-01-01T00:00:00Z"))).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails()).containsEntry("reason", "SOURCE_AUTHORIZATION_EXPIRED");
+    }
+
+    private static PracticeReviewHealthIndicator indicator(
+        boolean agentEnabled,
+        boolean gitEnabled,
+        Optional<Instant> expiry
+    ) {
+        return indicator(agentEnabled, gitEnabled, expiry, true);
+    }
+
+    private static PracticeReviewHealthIndicator indicator(
+        boolean agentEnabled,
+        boolean gitEnabled,
+        Optional<Instant> expiry,
+        boolean workerRole
+    ) {
+        ArtifactSourceCatalogRegistry sourceCatalog = mock(ArtifactSourceCatalogRegistry.class);
+        expiry.ifPresent(value ->
+            when(sourceCatalog.earliestUseDecisionExpiry(SourceUsePurpose.AUTOMATED_PRACTICE_REVIEW)).thenReturn(
+                Optional.of(value)
+            )
+        );
+        return new PracticeReviewHealthIndicator(
+            agent(agentEnabled),
+            git(gitEnabled),
+            sourceCatalog,
+            java.time.Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC),
+            workerRole
+        );
+    }
+
+    private static AgentProperties agent(boolean enabled) {
+        return new AgentProperties(
+            enabled,
+            Duration.ofSeconds(1),
+            5,
+            5,
+            Duration.ofSeconds(25),
+            Duration.ofDays(14),
+            Duration.ofDays(90)
+        );
+    }
+
+    private static GitRepositoryProperties git(boolean enabled) {
+        return new GitRepositoryProperties(enabled, 20_000, DataSize.ofMegabytes(32), DataSize.ofMegabytes(10));
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/job/AgentJobExecutorTest.java
@@ -368,6 +368,35 @@ class AgentJobExecutorTest extends BaseUnitTest {
             assertThat(captured.getValue().getStatus()).isEqualTo(AgentJobStatus.RUNNING);
             assertThat(captured.getValue().getStartedAt()).isNotNull();
         }
+
+        @Test
+        void modelRefusalKeepsGeneralTelemetryAndAddsPracticeTelemetry() {
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any())).thenReturn(Optional.of(job));
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            executor.processJob(jobId);
+
+            assertThat(meterRegistry.get("agent.job.model.refused").counter().count()).isOne();
+            assertThat(
+                meterRegistry
+                    .get("practice.review.refused")
+                    .tags("phase", "execution", "reason", "model_unavailable")
+                    .counter()
+                    .count()
+            ).isOne();
+        }
+
+        @Test
+        void nonPracticeModelRefusalDoesNotCreatePracticeTelemetry() {
+            job.setPurpose(AgentPurpose.MENTOR);
+            when(jobRepository.findByIdQueuedForUpdateSkipLocked(eq(jobId), any())).thenReturn(Optional.of(job));
+            when(jobRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            executor.processJob(jobId);
+
+            assertThat(meterRegistry.get("agent.job.model.refused").counter().count()).isOne();
+            assertThat(meterRegistry.find("practice.review.refused").counter()).isNull();
+        }
     }
 
     @Nested
@@ -516,6 +545,14 @@ class AgentJobExecutorTest extends BaseUnitTest {
             verify(jobRepository).save(saved.capture());
             assertThat(saved.getValue().getStatus()).isEqualTo(AgentJobStatus.CANCELLED);
             assertThat(saved.getValue().getCancellationReason()).isEqualTo(AgentJobCancellationReason.BUDGET_EXHAUSTED);
+            assertThat(meterRegistry.get("agent.job.budget.refused").counter().count()).isOne();
+            assertThat(
+                meterRegistry
+                    .get("practice.review.refused")
+                    .tags("phase", "execution", "reason", "budget_exhausted")
+                    .counter()
+                    .count()
+            ).isOne();
             // The message must say why it was cancelled and that waiting is over — not merely "expired",
             // which reads like the job itself timed out rather than the budget never being raised.
             assertThat(saved.getValue().getErrorMessage()).contains("budget").contains("7 days old");
@@ -694,6 +731,13 @@ class AgentJobExecutorTest extends BaseUnitTest {
             ArgumentCaptor<JsonNode> output = ArgumentCaptor.forClass(JsonNode.class);
             verify(jobRepository).transitionToEvidenceRefused(eq(jobId), isNull(), eq(0), any(), output.capture());
             assertThat(output.getValue().path("outcome").asString()).isEqualTo("INSUFFICIENT_EVIDENCE");
+            assertThat(
+                meterRegistry
+                    .get("practice.review.refused")
+                    .tags("phase", "execution", "reason", "insufficient_evidence")
+                    .counter()
+                    .count()
+            ).isOne();
             verify(sandboxManager, never()).execute(any());
         }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/LedgerSignalRecorderTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/signal/LedgerSignalRecorderTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.hephaestus.integration.core.signal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -7,6 +8,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import java.time.Instant;
@@ -23,7 +25,9 @@ class LedgerSignalRecorderTest extends BaseUnitTest {
     );
 
     private final ArtifactSignalRepository repository = mock(ArtifactSignalRepository.class);
-    private final LedgerSignalRecorder recorder = new LedgerSignalRecorder(repository);
+    private final io.micrometer.core.instrument.simple.SimpleMeterRegistry meterRegistry =
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    private final LedgerSignalRecorder recorder = new LedgerSignalRecorder(repository, meterRegistry);
 
     @Test
     void shouldNotLetAReconciliationPassDisplaceADecisionAlreadyTaken() {
@@ -47,9 +51,18 @@ class LedgerSignalRecorderTest extends BaseUnitTest {
 
     @Test
     void shouldHoldARefusalAnOperatorCanLiftAsPending() {
+        when(repository.markRefused(eq(KEY), eq("PENDING"), eq("BUDGET_EXHAUSTED"), any())).thenReturn(1);
+
         recorder.markRefused(KEY, SignalStateReason.BUDGET_EXHAUSTED);
 
         verify(repository).markRefused(eq(KEY), eq("PENDING"), eq("BUDGET_EXHAUSTED"), any());
+        assertThat(
+            meterRegistry
+                .get("practice.review.refused")
+                .tags("phase", "submission", "reason", "budget_exhausted")
+                .counter()
+                .count()
+        ).isOne();
     }
 
     @Test

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogEntryTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogEntryTest.java
@@ -34,14 +34,16 @@ class CatalogEntryTest extends BaseUnitTest {
     void anEditIsHeldAgainstTheDefinitionItWasWrittenAgainst() {
         PracticeDefinition mine = practice("Small PRs", "Our criteria", "Shipped reason");
 
-        assertThat(entry(mine, SHIPPED, SHIPPED.digest(SLUG)).state()).isEqualTo(CatalogEntryState.EDITED_HERE);
+        assertThat(entry(mine, SHIPPED, CuratedDefinitionDigest.of(SLUG, SHIPPED)).state()).isEqualTo(
+            CatalogEntryState.EDITED_HERE
+        );
     }
 
     @Test
     void aBuildThatMovesOnLeavesTheEditInForceAndTheNewDefinitionWaiting() {
         PracticeDefinition mine = practice("Small PRs", "Our criteria", "Shipped reason");
         PracticeDefinition newer = practice("Small PRs", "Newer criteria", "Shipped reason");
-        CatalogEntry<PracticeDefinition> entry = entry(mine, newer, SHIPPED.digest(SLUG));
+        CatalogEntry<PracticeDefinition> entry = entry(mine, newer, CuratedDefinitionDigest.of(SLUG, SHIPPED));
 
         assertThat(entry.state()).isEqualTo(CatalogEntryState.UPDATE_WAITING);
         assertThat(entry.effective()).isEqualTo(mine);
@@ -59,7 +61,9 @@ class CatalogEntryTest extends BaseUnitTest {
     void anEntryTheBuildStopsShippingKeepsTheInstancesOwnDefinition() {
         PracticeDefinition mine = practice("Small PRs", "Our criteria", "Shipped reason");
 
-        assertThat(entry(mine, null, SHIPPED.digest(SLUG)).state()).isEqualTo(CatalogEntryState.NO_LONGER_SHIPPED);
+        assertThat(entry(mine, null, CuratedDefinitionDigest.of(SLUG, SHIPPED)).state()).isEqualTo(
+            CatalogEntryState.NO_LONGER_SHIPPED
+        );
     }
 
     @Test
@@ -110,7 +114,9 @@ class CatalogEntryTest extends BaseUnitTest {
         PracticeDefinition mine = practice("Small PRs", "Our criteria", "Shipped reason");
 
         assertThat(untouched.etag()).isNotBlank();
-        assertThat(entry(mine, SHIPPED, SHIPPED.digest(SLUG)).etag()).isNotEqualTo(untouched.etag());
+        assertThat(entry(mine, SHIPPED, CuratedDefinitionDigest.of(SLUG, SHIPPED)).etag()).isNotEqualTo(
+            untouched.etag()
+        );
         assertThat(retired(untouched).etag()).isNotEqualTo(untouched.etag());
         assertThat(withPosition(untouched, 1).etag()).isEqualTo(untouched.etag());
     }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfillIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfillIntegrationTest.java
@@ -122,6 +122,57 @@ class CatalogProvenanceBackfillIntegrationTest extends AbstractWorkspaceIntegrat
         ).isEqualTo(3);
     }
 
+    @Test
+    void shouldContinueAligningWhenAPracticeIsMalformed() {
+        String v1Fingerprint = "v1:" + "a".repeat(64);
+        seedLegacyWorkspace(
+            matching,
+            shipped().criteria(),
+            false,
+            evidenceDefaults.policyFor(shipped().artifactKind()),
+            v1Fingerprint
+        );
+        seedLegacyWorkspace(
+            edited,
+            shipped().criteria(),
+            false,
+            evidenceDefaults.policyFor(shipped().artifactKind()),
+            v1Fingerprint
+        );
+        jdbcTemplate.update(
+            "UPDATE practice SET automated_review_policy = '{\"subject\":\"INVALID\"}'::jsonb WHERE workspace_id = ?",
+            matching.getId()
+        );
+
+        backfill.run();
+
+        assertThat(sourceFingerprint(edited)).isEqualTo(shipped().provenanceFingerprint(SHIPPED_SLUG));
+        assertThat(sourceFingerprint(matching)).isEqualTo(v1Fingerprint);
+    }
+
+    @Test
+    void shouldKeepCustomizedV1DefinitionWhenItDiffersFromTheCatalog() {
+        String v1Fingerprint = "v1:" + "a".repeat(64);
+        seedLegacyWorkspace(
+            matching,
+            "The workspace intentionally changed these criteria",
+            false,
+            evidenceDefaults.policyFor(shipped().artifactKind()),
+            v1Fingerprint
+        );
+
+        backfill.run();
+
+        assertThat(sourceFingerprint(matching)).isEqualTo(v1Fingerprint);
+        assertThat(
+            jdbcTemplate.queryForObject(
+                "SELECT criteria FROM practice WHERE workspace_id = ?",
+                String.class,
+                matching.getId()
+            )
+        ).isEqualTo("The workspace intentionally changed these criteria");
+    }
+
     private PracticeDefinition shipped() {
         return catalogService.catalog().practice(SHIPPED_SLUG).orElseThrow().effective();
     }
@@ -276,6 +327,14 @@ class CatalogProvenanceBackfillIntegrationTest extends AbstractWorkspaceIntegrat
     private long stampedPractices(Workspace workspace) {
         return count(
             "SELECT count(*) FROM practice WHERE workspace_id = ? AND source_curated_slug IS NOT NULL",
+            workspace.getId()
+        );
+    }
+
+    private String sourceFingerprint(Workspace workspace) {
+        return jdbcTemplate.queryForObject(
+            "SELECT source_curated_fingerprint FROM practice WHERE workspace_id = ?",
+            String.class,
             workspace.getId()
         );
     }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfillStartupTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/practices/curated/CatalogProvenanceBackfillStartupTest.java
@@ -1,0 +1,25 @@
+package de.tum.cit.aet.hephaestus.practices.curated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.boot.health.contributor.Status;
+
+class CatalogProvenanceBackfillStartupTest extends BaseUnitTest {
+
+    @Test
+    void shouldReportOutOfServiceWhenRepairFails() {
+        CatalogProvenanceBackfill backfill = mock(CatalogProvenanceBackfill.class);
+        doThrow(new IllegalStateException("broken catalog")).when(backfill).run();
+        var startup = new CatalogProvenanceBackfillStartup(backfill);
+
+        startup.run(new DefaultApplicationArguments());
+
+        assertThat(startup.health().getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(startup.health().getDetails()).containsEntry("reason", "CATALOG_PROVENANCE_REPAIR_FAILED");
+    }
+}


### PR DESCRIPTION
## Description

Stabilizes the evidence-aware practice-review path before its first production shadow run. Catalogue provenance repair now preserves effective curated overrides, isolates malformed practice rows, and uses versioned digest semantics; workers also expose actionable readiness and bounded refusal telemetry when reviews cannot run.

The migration corrects unreleased override digests without adding a compatibility model. Its integration fixture carries the invalid branch-era issue, conversation, and pull-request policies through the complete migration, loads the resulting definitions through the production validator, and verifies that pull-request diffs still require complete, non-empty evidence.

Fixes #1450

## Operational behavior

- A malformed persisted practice no longer prevents unrelated catalogue entries from aligning.
- Intentional workspace customizations are not relabeled as curated definitions.
- Enabled review workers report `OUT_OF_SERVICE` when Git checkout is disabled or automated-review source authorization has expired.
- Review refusals use `practice.review.refused` with bounded `phase` and `reason` tags.
- Existing `agent.job.budget.refused` and `agent.job.model.refused` counters remain available for every agent purpose.
- Missing model bindings remain workspace-scoped and appear in Review activity and refusal telemetry rather than taking the whole worker out of service.
- Rollback requires restoring the verified pre-upgrade database snapshot before deploying the previous image.

## How to test

Automated checks run locally:

- `pnpm run format`
- `pnpm run check`
- `AgentJobExecutorTest`: 62 tests passed, including general and practice-specific refusal metrics
- `PracticeCatalogInstallationMigrationIntegrationTest`: migrated issue, conversation, and pull-request overrides pass the production policy validator
- Catalogue provenance integration suite, including malformed and intentionally customized definitions
- Silent Mode delivery tests confirming no SCM or Slack writes
- OpenAPI specification and generated client regeneration

Production deployment remains gated on rehearsing this migration against a restored production snapshot and running the first full cycle with global Silent Mode enabled, as required by #1450.

Manual readiness smoke test:

1. Enable practice reviews on a worker and disable Git checkout.
2. Query the authenticated `/actuator/health/readiness` response.
3. Confirm `practiceReview` is `OUT_OF_SERVICE` with `GIT_CHECKOUT_DISABLED`.
4. Re-enable checkout and install an expired automated-review source decision.
5. Confirm the reason changes to `SOURCE_AUTHORIZATION_EXPIRED`.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] No new operator configuration or manual migration step is introduced; the documented snapshot-restore procedure remains the rollback path
