### PR TITLE
fix(server): reap NATS consumers of disposable deployments

### DIFF
--- a/.changeset/reap-disposable-nats-consumers.md
+++ b/.changeset/reap-disposable-nats-consumers.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": minor
+---
+
+Deployments that are deleted rather than shut down can now hand their NATS consumers back automatically. Set `HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD` (for example `72h`) on any stack that shares a NATS server but is disposable — a pull request preview, a throwaway test environment — and its consumers are removed once nothing has been bound for that long, instead of accumulating on the shared stream one generation per deleted stack. Left unset, which is the default and what a long-lived deployment wants, consumers keep their position across restarts exactly as before.

--- a/docker/preview/README.md
+++ b/docker/preview/README.md
@@ -12,6 +12,7 @@ copy of the staging database.
 | Seed data | One live `pg_dump` from `app-postgres-1` on first deploy | Realistic data without touching the staging data volume |
 | NATS | Shared staging `nats-server:4222` on `shared-network` | Previews see the same integration events as staging |
 | NATS consumer | `${SERVICE_NAME_APPSERVER}-consumer` | Every preview has an independent JetStream cursor |
+| Consumer lifetime | JetStream reaps the durable after 72h unbound | A deleted preview cannot delete its own cursors |
 | App image | Immutable `${SOURCE_COMMIT}` tag from CI | The API and SPA both reflect the PR without a shared mutable tag |
 | Agent runtime | Enabled, one sandbox at a time | A selected workspace can run real reviews without exhausting the host |
 | Review automation | Paused in every cloned workspace | A clone cannot post reviews until an admin explicitly opts it in |
@@ -48,6 +49,30 @@ changes persist for the lifetime of the PR preview.
    `pr<id>.hephaestus.felixdietrich.com` and `pr<id>.api.hephaestus.felixdietrich.com`.
 6. Leave the preview `IMAGE_TAG` unset. Coolify injects `SOURCE_COMMIT`, and CI publishes the matching
    application-server image before the preview update is requested.
+7. Put every preview-safe value in the application's **base** environment variables, not in Coolify's
+   separate preview-variable scope. See below.
+
+## Why the safe values live in Coolify's base scope
+
+Coolify documents a second variable scope that only preview deployments see. On the installed version
+that scope is not injected into a Docker Compose application: a preview started with variables
+duplicated across both scopes receives the base value, and the preview copy is silently ignored. A
+preview would then inherit whatever the base entry happens to say — for this stack that meant agent
+support off, larger sandbox limits than the host can afford, and startup sync enabled.
+
+This Coolify application exists only to host PR previews; staging itself is deployed by GitHub Actions
+from `docker/compose.app.yaml` and never reads these entries. So the base scope is the safe place for
+them, and duplicating a key across both scopes is what to avoid — the duplicate reads like the
+effective value and is not.
+
+| Variable | Value | Without it |
+|---|---|---|
+| `AGENT_ENABLED` | `true` | Reviews cannot be tested at all, even deliberately |
+| `NATS_SERVER`, `HEPHAESTUS_SYNC_NATS_SERVER` | staging NATS | The preview sees no integration events |
+| `SANDBOX_MAX_CONCURRENT`, `SANDBOX_CPUS`, `SANDBOX_MEMORY_BYTES` | `1`, `1.0`, `2147483648` | One preview's agent run can starve the host |
+| `MONITORING_RUN_ON_STARTUP`, `MONITORING_SYNC_CRON` | `false`, `-` | The clone starts a full lifecycle sync on boot |
+
+`-` is Spring's disabled-cron value; an empty string fails the boot instead of disabling the schedule.
 
 The Docker socket mount is privileged access to the host Docker daemon even though it is mounted
 read-only. It is intentionally confined to the trusted preview application and used only for

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -232,6 +232,11 @@ services:
       # Per-deploy durable name, so base and previews get their own JetStream consumers instead of
       # competing for one and stealing each other's messages.
       NATS_DURABLE_CONSUMER_NAME: ${SERVICE_NAME_APPSERVER:-appserver}-consumer
+      # A preview is deleted, not shut down, so it never removes the durables it created on the
+      # shared stream. JetStream reaps them once nothing has been bound for this long — one closed
+      # PR would otherwise leave its cursors, and their backlogs, behind for good. Long enough that
+      # a redeploy or a paused review session resumes on its own cursor rather than skipping ahead.
+      HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD: ${HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD:-72h}
       # Issuer is this deploy's own origin, so a preview's tokens validate against the deploy that
       # issued them (Hephaestus-native auth, ADR 0017).
       HEPHAESTUS_AUTH_ISSUER: https://${SERVICE_FQDN_WEBAPP}

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumer.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumer.java
@@ -726,6 +726,13 @@ public class IntegrationNatsConsumer {
             // means a JetStream-side observability tool (`nats stream info`) cannot see
             // the policy. Mirrors the value the poison handler uses to ACK-terminate.
             .maxDeliver(consumerProperties.poison().maxRedeliver());
+        // Server-side reaping for deployments that are deleted rather than shut down. A PR preview
+        // never gets to clean up after itself, so its durables would otherwise pile up on the
+        // shared stream one generation per closed PR. Unset for long-lived deployments, where a
+        // reaped durable would silently resume at DeliverPolicy.New and skip an outage's backlog.
+        if (consumerProperties.inactiveThreshold() != null) {
+            builder.inactiveThreshold(consumerProperties.inactiveThreshold());
+        }
         if (!isBlank(durableName)) {
             builder.durable(durableName);
         }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerProperties.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.convert.DurationUnit;
@@ -15,6 +16,12 @@ import org.springframework.validation.annotation.Validated;
 /**
  * NATS consumer tuning bound to {@code hephaestus.integration.consumer}. Read by every
  * consumer-side collaborator under {@code integration.consumer}.
+ *
+ * <p>{@code inactive-threshold} is unset by default, which is what a long-lived deployment wants:
+ * a durable that outlives an outage resumes at its own cursor instead of skipping whatever arrived
+ * while the pod was down. Set it only where the deployment itself is disposable — a PR preview
+ * leaves its durables behind when the stack is deleted, and without a threshold those cursors
+ * accumulate on the shared stream forever.
  */
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.integration.consumer")
@@ -31,9 +38,13 @@ public record NatsConsumerProperties(
     @DefaultValue("2s")
     @NotNull(message = "reconnect-delay must not be null")
     Duration reconnectDelay,
+    @DurationUnit(ChronoUnit.HOURS) @Nullable Duration inactiveThreshold,
     @Valid PoisonProperties poison
 ) {
     public NatsConsumerProperties {
+        if (inactiveThreshold != null && (inactiveThreshold.isZero() || inactiveThreshold.isNegative())) {
+            throw new IllegalStateException("inactive-threshold must be positive when set");
+        }
         if (poison == null) {
             poison = new PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5));
         }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumerTest.java
@@ -69,6 +69,7 @@ class IntegrationNatsConsumerTest {
                 Duration.ofMinutes(5),
                 500,
                 Duration.ofSeconds(2),
+                null,
                 new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
             ),
             subscriptions,
@@ -96,6 +97,7 @@ class IntegrationNatsConsumerTest {
                 Duration.ofMinutes(5),
                 500,
                 Duration.ofSeconds(2),
+                null,
                 new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
             ),
             scopeId -> Optional.empty(),
@@ -134,6 +136,7 @@ class IntegrationNatsConsumerTest {
             Duration.ofMinutes(5),
             500,
             Duration.ofSeconds(2),
+            null,
             new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
         );
 
@@ -145,6 +148,27 @@ class IntegrationNatsConsumerTest {
 
         assertThat(config.getDeliverPolicy()).isEqualTo(DeliverPolicy.New);
         assertThat(config.getDurable()).isEqualTo("heph-slack");
+        assertThat(config.getInactiveThreshold()).isNull();
+    }
+
+    @Test
+    void disposableDeploymentLetsJetStreamReapItsDurableWhenTheStackIsDeleted() {
+        NatsConsumerProperties properties = new NatsConsumerProperties(
+            Duration.ofMinutes(5),
+            500,
+            Duration.ofSeconds(2),
+            Duration.ofHours(72),
+            new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
+        );
+
+        var config = IntegrationNatsConsumer.newConsumerConfiguration(
+            new String[] { "github.>" },
+            properties,
+            "appserver-pr-1443-consumer"
+        );
+
+        assertThat(config.getInactiveThreshold()).isEqualTo(Duration.ofHours(72));
+        assertThat(config.getDurable()).isEqualTo("appserver-pr-1443-consumer");
     }
 
     @Nested
@@ -209,6 +233,7 @@ class IntegrationNatsConsumerTest {
                     Duration.ofMinutes(5),
                     500,
                     Duration.ofSeconds(2),
+                    null,
                     new NatsConsumerProperties.PoisonProperties(10, Duration.ofMillis(1), Duration.ofSeconds(1))
                 ),
                 scopeId -> Optional.empty(),
@@ -350,6 +375,7 @@ class IntegrationNatsConsumerTest {
                         Duration.ofMinutes(5),
                         500,
                         Duration.ofSeconds(2),
+                        null,
                         new NatsConsumerProperties.PoisonProperties(10, Duration.ofMillis(1), Duration.ofSeconds(1))
                     ),
                     scopeId ->

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationPoisonHandlerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationPoisonHandlerTest.java
@@ -39,6 +39,7 @@ class IntegrationPoisonHandlerTest extends BaseUnitTest {
             Duration.ofMinutes(5),
             500,
             Duration.ofSeconds(2),
+            null,
             new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
         );
         handler = new IntegrationPoisonHandler(properties, meterRegistry);

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerPropertiesTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerPropertiesTest.java
@@ -27,6 +27,7 @@ class NatsConsumerPropertiesTest extends BaseUnitTest {
                 Duration.ofMinutes(5),
                 500,
                 Duration.ofSeconds(2),
+                null,
                 null
             );
 
@@ -47,6 +48,7 @@ class NatsConsumerPropertiesTest extends BaseUnitTest {
                 Duration.ofMinutes(5),
                 500,
                 Duration.ofSeconds(2),
+                null,
                 custom
             );
 


### PR DESCRIPTION
## Description

A pull request preview is **deleted**, not shut down. It never gets a chance to remove the JetStream consumers it created on staging's shared NATS server, so every closed PR left a generation of durables — and their unread backlogs — behind for good.

That had been running unnoticed for a while. On staging today the `github` stream carried **113 consumers, of which 8 were actually bound**; the rest were cursors belonging to previews, local development runs, and naming schemes that no longer exist. One orphan from a closed PR was holding 19,714 pending messages. The `gitlab` stream had 23 consumers and none bound.

Consumers now take an optional inactive threshold:

- **unset by default** — a long-lived deployment keeps today's behaviour, resuming at its own cursor after a restart or an outage rather than skipping whatever arrived while it was down;
- **72h for previews** (`docker/preview/compose.app.yaml`) — JetStream reaps what a deleted stack cannot, while still leaving a redeploy or a paused testing session on its own cursor.

I chose server-side expiry over deleting the consumers from `cleanup-preview.yml` deliberately: that workflow no-ops when `COOLIFY_API_TOKEN` is unset and never runs at all for a preview removed by hand, and it would need a NATS network path and credentials from a GitHub runner. An inactive threshold covers every one of those cases without CI reaching into shared infrastructure.

The second commit-worthy part is documentation. `docker/preview/README.md` now records **why the preview stack's safe values live in Coolify's base variable scope**. Coolify documents a separate preview-only scope, but the installed version does not inject it into a Docker Compose application: a key duplicated across both scopes reads like the effective value while the base entry is what the container actually receives. For this stack that silently meant agent support off, sandbox limits larger than the host can afford, and startup sync enabled on a cloned database. The README now names the variables that must live in the base scope and what breaks without each.

**Already cleaned up on staging** (operational, not part of this diff): 128 unbound consumers removed from the `github` and `gitlab` streams after sampling binding state twice, leaving exactly the 8 live ones — 4 for staging, 4 for the PR #1443 preview. A stranded `pr-1454` PostgreSQL container, its two volumes, and its network were also removed. Staging and the running preview stayed healthy throughout.

## How to test

Unit tests cover both directions of the new setting:

```
cd server && MANAGEMENT_PORT=0 SERVER_PORT=0 ./mvnw test -P'!quick' \
  -Dtest='IntegrationNatsConsumerTest,NatsConsumerPropertiesTest,IntegrationPoisonHandlerTest'
```

- `newConsumerStartsAtNewMessagesInsteadOfReplayingStreamHistory` asserts no threshold is set when unconfigured.
- `disposableDeploymentLetsJetStreamReapItsDurableWhenTheStackIsDeleted` asserts the configured duration reaches the consumer.

End to end, once a preview redeploys on a merged image: `nats consumer info github appserver-pr-<n>-consumer-installation` reports a 72h inactive threshold, and the consumer disappears on its own after the preview is deleted.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No operator action is required: the new `HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD` is optional and unset by default, which preserves current behaviour everywhere except the preview stack, which sets it for itself. `MIGRATION.md` is therefore untouched.

`pnpm run format` and `pnpm run check` both pass on the final state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup of inactive message consumers for disposable deployments.
  - Preview environments now remove inactive consumers after 72 hours while preserving state during redeployments and paused sessions.
  - Cleanup thresholds can be configured in hours; existing behavior remains unchanged when unset.

- **Documentation**
  - Added setup guidance for configuring preview environments and required monitoring and messaging settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->