### PR TITLE
fix(docker): give a preview its own login apps and signing key

### DIFF
--- a/.changeset/preview-owns-its-login-identity.md
+++ b/.changeset/preview-owns-its-login-identity.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Pull request previews now sign in through their own login apps instead of the ones they cloned. A preview starts from a copy of another instance's database, and it used to keep that instance's OAuth registrations — whose callback URLs belong to the original hostname, so every sign-in attempt was rejected by the provider before it began. A preview now rebuilds its login providers from its own configuration on first boot, and mints its own token-signing key rather than reusing the cloned one. Existing accounts are unaffected: signing in through the preview's own app lands on the same account as before.

--- a/docker/preview/README.md
+++ b/docker/preview/README.md
@@ -22,9 +22,13 @@ Before the first restore, the seeder recreates only the uniquely resolved previe
 both succeed. A failed or partial first attempt can therefore retry cleanly, while redeploying an
 already seeded PR preserves changes made while testing. A new preview volume gets a fresh staging clone.
 
-## Silence policy
+## Preview policy
 
-Before the application server starts, `seed-loader`:
+`seed-loader` applies [`sanitize.sql`](./sanitize.sql) to the restored clone before the application
+server starts. A clone is another instance's live database, so the policy answers two questions, and
+the file is organised by them.
+
+### Silence — a clone must not act
 
 1. disables automatic and manual practice-review triggers for every workspace;
 2. disables each `PRACTICE_REVIEW` model binding while preserving its selected model;
@@ -37,6 +41,29 @@ visible in the UI. To test reviews for one workspace, enable its practice-review
 enable the desired manual or automatic trigger in that workspace's practice-review settings. Those
 changes persist for the lifetime of the PR preview.
 
+### Re-home — a clone must not keep the source instance's identity
+
+A preview runs with the **source instance's** `HEPHAESTUS_SECURITY_ENCRYPTION_KEY`, because that is the
+only key the cloned rows can be read with. Without it the preview boots and then fails every request
+that touches a credential, with `AEADBadTagException: Tag mismatch` in the log. That key also unseals
+the source's JWT signing key and decrypts its OAuth client secrets, so three tables are emptied and
+rebuilt from this deployment's own configuration:
+
+| Table | Why it cannot be inherited |
+|---|---|
+| `login_provider` | The source's OAuth apps are registered against the source's hostname, so the provider rejects every sign-in that starts from a preview host |
+| `jwt_signing_key` | The preview would otherwise mint its own tokens signed with the source instance's production signing key |
+| `issued_jwt` | Cloned sessions belong to the source instance's users |
+
+`LoginProviderService` seeds `login_provider` from the environment whenever a registration id is
+absent, so emptying the table hands the preview its own login apps on the next boot — which is why the
+preview stack needs `GITHUB_OAUTH_*` (and any other provider it should offer) pointed at an OAuth app
+whose callback covers the preview hostnames. A provider with no credentials in the preview environment
+is simply not offered; Slack, being link-only, is normally absent for that reason.
+
+Accounts survive all of this: `identity_link` keys on `identity_provider`, not on `login_provider`, so
+a cloned user signs in through the preview's own OAuth app and lands on the same account.
+
 ## One-time server and Coolify setup
 
 1. Keep staging's `nats-server` attached to the external Docker network `shared-network`.
@@ -45,11 +72,14 @@ changes persist for the lifetime of the PR preview.
    joins `shared-network` as a second network.
 4. Set `PREVIEW_SEED_SOURCE_CONTAINER=app-postgres-1` if the staging Compose project/container name
    ever changes. The source user defaults to `root` and database to `hephaestus`.
-5. Assign the web and API services sibling wildcard domains. With the current template these are
+5. Set `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` to the **seed source instance's** key, and point
+   `GITHUB_OAUTH_CLIENT_ID`/`_SECRET` at an OAuth app whose callback covers the preview hostnames —
+   see the re-home policy above for both.
+6. Assign the web and API services sibling wildcard domains. With the current template these are
    `pr<id>.hephaestus.felixdietrich.com` and `pr<id>.api.hephaestus.felixdietrich.com`.
-6. Leave the preview `IMAGE_TAG` unset. Coolify injects `SOURCE_COMMIT`, and CI publishes the matching
+7. Leave the preview `IMAGE_TAG` unset. Coolify injects `SOURCE_COMMIT`, and CI publishes the matching
    application-server image before the preview update is requested.
-7. Put every preview-safe value in the application's **base** environment variables, not in Coolify's
+8. Put every preview-safe value in the application's **base** environment variables, not in Coolify's
    separate preview-variable scope. See below.
 
 ## Why the safe values live in Coolify's base scope
@@ -73,6 +103,15 @@ effective value and is not.
 | `MONITORING_RUN_ON_STARTUP`, `MONITORING_SYNC_CRON` | `false`, `-` | The clone starts a full lifecycle sync on boot |
 
 `-` is Spring's disabled-cron value; an empty string fails the boot instead of disabling the schedule.
+
+## This file only takes effect once it reaches `main`
+
+Coolify parses the Compose file from the branch configured on the application — `main` — and stores it
+on the application record. A preview deployment builds the pull request's images but runs that stored
+definition, so a change to `compose.app.yaml` or [`sanitize.sql`](./sanitize.sql) is **not** exercised
+by the preview of the pull request that makes it. Reviewing a change here means reading it; the first
+preview that actually runs it is the next one created after the change is merged and Coolify has
+re-read `main`.
 
 The Docker socket mount is privileged access to the host Docker daemon even though it is mounted
 read-only. It is intentionally confined to the trusted preview application and used only for

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -115,49 +115,18 @@ services:
           -U hephaestus -d hephaestus \
           --exit-on-error --no-owner --no-privileges < /tmp/seed.dump
 
-        echo "Applying preview silence policy"
-        docker exec -i "$$PREVIEW_PG" psql -v ON_ERROR_STOP=1 -U hephaestus -d hephaestus <<'SQL'
-        UPDATE workspace
-           SET practice_review_auto_trigger_enabled = FALSE,
-               practice_review_manual_trigger_enabled = FALSE;
-
-        UPDATE workspace_agent_binding
-           SET enabled = FALSE,
-               updated_at = NOW()
-         WHERE purpose = 'PRACTICE_REVIEW';
-
-        UPDATE review_sweep_schedule
-           SET enabled = FALSE,
-               updated_at = NOW();
-
-        UPDATE agent_job
-           SET status = 'CANCELLED',
-               completed_at = COALESCE(completed_at, NOW()),
-               worker_id = NULL,
-               error_message = 'Cancelled when staging data was cloned into a preview.',
-               cancellation_reason = NULL
-         WHERE status IN ('QUEUED', 'RUNNING');
-
-        UPDATE agent_job
-           SET delivery_status = 'FAILED',
-               error_message = CONCAT_WS(E'\n', NULLIF(error_message, ''),
-                   'Delivery paused when staging data was cloned into a preview.')
-         WHERE status = 'COMPLETED'
-           AND delivery_status = 'PENDING';
-
-        UPDATE sync_job
-           SET status = 'CANCELLED',
-               cancel_requested = TRUE,
-               finished_at = COALESCE(finished_at, NOW()),
-               heartbeat_at = NULL,
-               error_summary = 'Cancelled when staging data was cloned into a preview.'
-         WHERE status IN ('PENDING', 'RUNNING');
-        SQL
+        echo "Applying the preview policy"
+        test -s /preview/sanitize.sql
+        docker exec -i "$$PREVIEW_PG" psql \
+          -v ON_ERROR_STOP=1 -U hephaestus -d hephaestus < /preview/sanitize.sql
 
         docker exec "$$PREVIEW_PG" touch /var/lib/postgresql/data/.hephaestus-preview-seeded
-        echo "Seed loaded; every cloned workspace starts with practice reviews paused"
+        echo "Seed loaded; reviews are paused and the preview owns its login apps and signing key"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # The policy this preview is held to, kept next to the stack it applies to rather than inline
+      # in a shell heredoc where it cannot be read, reviewed or diffed as SQL.
+      - ./sanitize.sql:/preview/sanitize.sql:ro
     restart: "no"
     deploy:
       resources:

--- a/docker/preview/sanitize.sql
+++ b/docker/preview/sanitize.sql
@@ -1,0 +1,72 @@
+-- Applied once to a freshly restored clone, before this preview's application server starts.
+--
+-- The clone is another instance's live database, so two things have to be made true before it boots.
+--
+--   1. SILENCE — a clone must not act. It holds real workspaces, real connections and real
+--      credentials, so everything that would post, deliver or schedule work still points at the
+--      originals. Triggers, schedules and in-flight jobs are stopped. Nothing is deleted: the data
+--      and the settings stay visible, and a tester can re-enable one workspace deliberately.
+--
+--   2. RE-HOME — a clone must not keep the source instance's identity. A preview reads the clone
+--      with the source instance's encryption key, because that is the only key those rows can be
+--      read with. The same key also unseals the source's JWT signing key and decrypts its OAuth
+--      client secrets. Both belong to the source deployment, not this one, and are replaced here.
+--
+-- seed-loader runs this with ON_ERROR_STOP=1 and does not write the seed marker unless it succeeds,
+-- so a preview is never left half-sanitized: the next deployment retries the whole clone.
+
+-- ─── 1. Silence ──────────────────────────────────────────────────────────────────────────────────
+
+UPDATE workspace
+   SET practice_review_auto_trigger_enabled = FALSE,
+       practice_review_manual_trigger_enabled = FALSE;
+
+UPDATE workspace_agent_binding
+   SET enabled = FALSE,
+       updated_at = NOW()
+ WHERE purpose = 'PRACTICE_REVIEW';
+
+UPDATE review_sweep_schedule
+   SET enabled = FALSE,
+       updated_at = NOW();
+
+UPDATE agent_job
+   SET status = 'CANCELLED',
+       completed_at = COALESCE(completed_at, NOW()),
+       worker_id = NULL,
+       error_message = 'Cancelled when staging data was cloned into a preview.',
+       cancellation_reason = NULL
+ WHERE status IN ('QUEUED', 'RUNNING');
+
+UPDATE agent_job
+   SET delivery_status = 'FAILED',
+       error_message = CONCAT_WS(E'\n', NULLIF(error_message, ''),
+           'Delivery paused when staging data was cloned into a preview.')
+ WHERE status = 'COMPLETED'
+   AND delivery_status = 'PENDING';
+
+UPDATE sync_job
+   SET status = 'CANCELLED',
+       cancel_requested = TRUE,
+       finished_at = COALESCE(finished_at, NOW()),
+       heartbeat_at = NULL,
+       error_summary = 'Cancelled when staging data was cloned into a preview.'
+ WHERE status IN ('PENDING', 'RUNNING');
+
+-- ─── 2. Re-home ──────────────────────────────────────────────────────────────────────────────────
+
+-- Cloned sessions were issued by the source instance to its users. A preview has no use for them,
+-- and they are the only thing that could carry a signed-in session across the clone.
+DELETE FROM issued_jwt;
+
+-- Left in place, this preview would mint its own tokens signed with the source instance's
+-- production signing key. Emptied, JwtSigningKeyService bootstraps a sealed signing identity that
+-- belongs to this preview alone.
+DELETE FROM jwt_signing_key;
+
+-- The cloned rows carry the source instance's OAuth apps, whose callback URLs are registered
+-- against the source's hostname — a provider rejects every sign-in that starts from a preview host.
+-- LoginProviderService seeds this table from this deployment's own environment when a registration
+-- id is absent, so emptying it hands the preview its own login apps. Accounts are unaffected:
+-- identity_link keys on identity_provider, not on this table.
+DELETE FROM login_provider;


### PR DESCRIPTION
## Description

A preview starts from a clone of another instance's database, and it has to read that clone with the **source instance's** `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` — the only key those rows decrypt with. That key also unseals the source's JWT signing key and decrypts its OAuth client secrets, so a preview inherited both. Two things follow:

- **Sign-in cannot work.** `login_provider` carries the source's OAuth apps, registered against the source's hostname. Spring derives the callback from the deployment's own issuer, so a preview asks the provider for `https://pr<N>.api.…/login/oauth2/code/github` and is told *"The redirect_uri is not associated with this application."* Seeding from the environment is seed-once by design, so the preview's own `GITHUB_OAUTH_*` never took effect — the cloned row already existed and won.
- **The preview signs tokens with the source's production signing key.** `jwt_signing_key` clones with everything else, and the shared encryption key unseals it.

## What changes

`seed-loader` re-homes the clone before the application server starts. Three tables are emptied so the application rebuilds each from *this* deployment's configuration on boot:

| Table | Rebuilt by | Why it cannot be inherited |
|---|---|---|
| `login_provider` | `LoginProviderService` seeds from `GITHUB_OAUTH_*` etc. when a registration id is absent | The source's callback URLs belong to the source's hostname |
| `jwt_signing_key` | `JwtSigningKeyService` bootstraps a sealed key | A preview must not sign with the source's production key |
| `issued_jwt` | — | Cloned sessions belong to the source instance's users |

Accounts are unaffected: `identity_link` keys on `identity_provider` (type + server URL), and no foreign key references `login_provider`. A cloned user signs in through the preview's own OAuth app and lands on the same account.

The policy moves out of a shell heredoc in `compose.app.yaml` into [`sanitize.sql`](docker/preview/sanitize.sql), organised under the two questions it answers — *a clone must not act*, and *a clone must not keep the source instance's identity*. It was six statements inline with no way to read it as SQL, and the second category doubles that.

`README.md` now states the encryption-key requirement, because a preview given any other key boots fine and then fails every credential-touching request with `AEADBadTagException: Tag mismatch`.

## How to test

Coolify parses the Compose file from `main` and stores it on the application, so a preview builds this
pull request's images but runs `main`'s seeder — **this change is not exercised by its own preview**.
That is now written down in the README, because it is not obvious and it decides how this gets
reviewed: by reading the SQL, and then by the first preview created after it merges.

`sanitize.sql` was dry-run against a real clone inside `BEGIN … ROLLBACK` — every statement valid,
`DELETE 1` from `jwt_signing_key`, `DELETE 3` from `login_provider` — and then applied for real to the
running PR #1443 preview, which is how that preview's sign-in was unblocked. On the next preview
created after this merges:

1. sign in — the flow reaches the provider with the preview stack's own client id;
2. `select registration_id, seeded_from_env, client_id from login_provider` shows the preview's apps;
3. `select kid from jwt_signing_key` differs from the seed source's.

It fails closed: if `sanitize.sql` is missing or any statement fails, the seed marker is not written
and the application server does not start, so the next deployment retries the clone.

Slack is not re-seeded, because the preview stack carries no Slack credentials. It is link-only, so no
sign-in button is lost; the README says so.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No new variable and no operator action: the preview stack already forwards `GITHUB_OAUTH_*`, and this makes the application use them. `MIGRATION.md` is untouched.
