### PR TITLE
fix(ci): publish an app-server image for every previewed pull request

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -113,11 +113,19 @@ jobs:
         env:
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          DOCKER_RESULT: ${{ needs.Docker.result }}
         run: |
           set -euo pipefail
 
           if [ -z "${COOLIFY_TOKEN}" ]; then
             echo "::notice::COOLIFY_API_TOKEN is not configured; skipping preview update."
+            exit 0
+          fi
+
+          # No image workflow, no SOURCE_COMMIT tag. Requesting the deployment anyway would only
+          # queue one that fails on `manifest unknown`, under a green check.
+          if [ "${DOCKER_RESULT}" != 'success' ]; then
+            echo "::notice::No application-server image was published for this commit (Docker: ${DOCKER_RESULT}); skipping preview update."
             exit 0
           fi
 
@@ -187,11 +195,18 @@ jobs:
   Docker:
     uses: ./.github/workflows/ci-docker-build.yml
     needs: [detect-changes]
+    # Coolify gives every same-repository pull request a preview and pins it to SOURCE_COMMIT, so
+    # every such pull request needs an application-server tag at its head commit — including one that
+    # touches only the preview stack or documentation. Without it the preview deployment fails with
+    # `manifest unknown` for an image that will never be published. application-server-build is a
+    # cached rebuild when server code did not change; the webapp and agent images stay gated by their
+    # own inputs, so this costs one cached build, not the whole matrix.
     if: |
       needs.detect-changes.outputs.should_skip != 'true' && (
         needs.detect-changes.outputs.any-code == 'true' ||
         needs.detect-changes.outputs.ci-config == 'true' ||
-        github.event_name != 'pull_request'
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.head.repo.full_name == github.repository
       )
     secrets: inherit
     with:


### PR DESCRIPTION
## Description

A pull request that changes no application code gets a preview that cannot start.

Coolify creates a preview for every same-repository pull request and pins the application server to `SOURCE_COMMIT`. The image build, however, was gated on `any-code` or `ci-config` having changed, so a pull request touching only `docker/preview/**`, `docs/**` or a changeset skipped it — and the preview then failed on:

```
appserver-pr-<N> Error manifest unknown
```

for an image that was never going to be published. `application-server-build` already carries the right intent — *"Every code PR receives an immutable app-server tag … previews can then use SOURCE_COMMIT uniformly instead of racing on a global IMAGE_TAG or failing because the commit tag does not exist"* — but the outer `Docker` gate never let it run. This restores that invariant for the case that motivates it.

The irony is the sharp edge: a pull request that changes the preview stack is exactly the one whose preview you want, and it was the one guaranteed not to get one.

Second defect, same path: `Preview / Coolify` queued the deployment unconditionally and reported success, so a preview that failed to start sat behind a green check. It now names the commit that has no image rather than requesting a deployment that cannot begin.

## What changes

- The `Docker` job also runs for same-repository pull requests. `application-server-build` is a cached rebuild when server code did not change, and the webapp and agent images stay gated by their own inputs — so this is one cached build, not the whole matrix. Fork pull requests are unaffected: they never receive previews.
- The preview step exits with a notice when no image was published for the head commit.

## How to test

This pull request touches only `.github/workflows/**`, which previously *did* trigger the build via `ci-config` — so the useful check is the opposite one: after this lands, open a pull request that touches only `docker/preview/**` or `docs/**` and confirm `Docker / App Server` runs and its preview comes up. [#1457](https://github.com/ls1intum/Hephaestus/pull/1457) is exactly that case and its preview currently fails this way.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No changeset: this changes CI only. Nothing under `server/`, `webapp/` or `docker/` moves, so there is no operator- or user-visible effect to describe.
