### PR TITLE
fix(docker): let the agent sandbox reach the Docker daemon

### DIFF
--- a/.changeset/agent-sandbox-reaches-docker.md
+++ b/.changeset/agent-sandbox-reaches-docker.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": minor
+---
+
+Practice reviews can now actually start. The application server and worker run unprivileged, so every attempt to launch an agent sandbox was refused by the Docker socket with a permission error and no review ever ran. They now join the host's Docker group.
+
+**Operators:** set `DOCKER_GROUP_ID` to the group id that owns `/var/run/docker.sock` on your host — `getent group docker | cut -d: -f3` prints it. There is no portable default, so a deployment that leaves it unset keeps failing the same way it does today.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -238,6 +238,13 @@ GITLAB_WORKSPACE_CREATION=false
 # GIT_CHECKOUT_ENABLED enabled together. The agent job queue runs on PostgreSQL, not NATS —
 # NATS_ENABLED below is unrelated to practice review; it only gates webhook-driven sync ingest.
 
+# Supplementary group the application server and worker join so they can reach the Docker socket
+# the agent sandbox runs containers through. The image runs unprivileged and the socket is
+# root:docker 0660, so without this every sandbox start fails with "permission denied" and no
+# practice review can run. There is no portable default — read the host's group id with
+# `getent group docker | cut -d: -f3`.
+# DOCKER_GROUP_ID=999
+
 # Docker daemon endpoint (default: local socket)
 # SANDBOX_DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -275,6 +275,12 @@ services:
       release-pin-fetcher:
         condition: service_completed_successfully
     restart: unless-stopped
+    # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is
+    # root:docker 0660, so the sandbox runtime cannot reach the daemon without joining the host's
+    # docker group. There is no portable value: read the host's with
+    # `getent group docker | cut -d: -f3` and set DOCKER_GROUP_ID to it.
+    group_add:
+      - "${DOCKER_GROUP_ID:-999}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - git-repos:/data/git-repos
@@ -404,6 +410,12 @@ services:
       release-pin-fetcher:
         condition: service_completed_successfully
     restart: unless-stopped
+    # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is
+    # root:docker 0660, so the sandbox runtime cannot reach the daemon without joining the host's
+    # docker group. There is no portable value: read the host's with
+    # `getent group docker | cut -d: -f3` and set DOCKER_GROUP_ID to it.
+    group_add:
+      - "${DOCKER_GROUP_ID:-999}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - git-repos:/data/git-repos

--- a/docker/preview/.env.example
+++ b/docker/preview/.env.example
@@ -110,3 +110,10 @@ TANSTACK_DEVTOOLS_ENABLED=true
 # rollout testing are supported. Enable one workspace's review model binding and trigger in the UI.
 
 # HEPHAESTUS_AGENT_IMAGE_REFERENCE=ghcr.io/ls1intum/hephaestus/agent-pi@sha256:<digest>  # preview override only
+
+# Supplementary group the application server and worker join so they can reach the Docker socket
+# the agent sandbox runs containers through. The image runs unprivileged and the socket is
+# root:docker 0660, so without this every sandbox start fails with "permission denied" and no
+# practice review can run. There is no portable default — read the host's group id with
+# `getent group docker | cut -d: -f3`.
+# DOCKER_GROUP_ID=999

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -347,6 +347,12 @@ services:
       WEBHOOK_EXTERNAL_URL: ${WEBHOOK_EXTERNAL_URL:-https://staging.hephaestus.aet.cit.tum.de}
       THC_PORT: "8080"
       THC_PATH: /actuator/health/liveness
+    # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is
+    # root:docker 0660, so the sandbox runtime cannot reach the daemon without joining the host's
+    # docker group. There is no portable value: read the host's with
+    # `getent group docker | cut -d: -f3` and set DOCKER_GROUP_ID to it.
+    group_add:
+      - "${DOCKER_GROUP_ID:-999}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - git-repos:/data/git-repos


### PR DESCRIPTION
## Description

The application server and worker mount `/var/run/docker.sock` to run agent sandboxes, but the buildpack image runs unprivileged and the socket is `root:docker 0660`. Every sandbox start is refused:

```
SandboxReconciler: Failed to scan for orphaned containers:
java.net.BindException: Permission denied
```

Staging logged 1,469 such lines in 24 hours, and its `agent_job` table is **empty** — no practice review has ever run there, and none could. This is not a staging misconfiguration: nothing in either Compose file grants the group, so it applies to every Compose deployment, self-hosted ones included.

## What changes

`application-server` and `application-worker` (and the preview stack's `appserver`) join the host's Docker group via `group_add`.

There is no portable group id — it is 998 on one host and 999 on another — so `DOCKER_GROUP_ID` is documented in both `.env.example` files rather than guessed at. A deployment that leaves it unset lands exactly where it is today, so this cannot regress anyone.

## How to test

Verified on the staging host with the same unprivileged uid the image runs as:

```
$ docker run --rm -u 1002:1001 -v /var/run/docker.sock:/var/run/docker.sock docker:cli docker version
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock

$ docker run --rm -u 1002:1001 --group-add 998 -v /var/run/docker.sock:/var/run/docker.sock docker:cli docker version
27.0.3
```

After deploying with `DOCKER_GROUP_ID` set, `SandboxReconciler` stops logging permission errors and a practice review triggered on a workspace with an enabled binding reaches the sandbox instead of failing to start it.

Both Compose files render (`docker compose config`).

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

The changeset carries an `**Operators:**` line: set `DOCKER_GROUP_ID` to the group that owns the socket. `MIGRATION.md` is untouched because leaving it unset changes nothing about the current behaviour — it does not break an existing deployment, it just does not fix it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Practice reviews can now start successfully when agent sandboxes require Docker access.
  * Unprivileged application and worker processes can access the Docker socket when configured correctly.

* **Documentation**
  * Added deployment guidance for setting `DOCKER_GROUP_ID` to the host Docker group ID.
  * Documented configuration for standard and preview environments, including the required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->