### PR TITLE
fix(docker): give the practice-review worker its git checkout

### DIFF
--- a/.changeset/practice-review-worker-checkout.md
+++ b/.changeset/practice-review-worker-checkout.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Turning on practice review no longer leaves the instance reporting itself as out of service. The worker that runs reviews was never given the git-checkout setting the rest of the deployment gets, so enabling reviews produced a deployment that reported `GIT_CHECKOUT_DISABLED` and reviewed nothing. The worker now reads the same setting as the application server.

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -356,6 +356,10 @@ services:
       # Agent job queue (practice review). The queue runs on PostgreSQL — this pod needs no NATS at
       # all (it runs no sync/webhook role), so no NATS_SERVER is set here.
       AGENT_ENABLED: ${AGENT_ENABLED:-false}
+      # PracticeReviewHealthIndicator runs in this role and reports OUT_OF_SERVICE with
+      # GIT_CHECKOUT_DISABLED when the checkout is off, so the worker needs the same flag the
+      # application server gets — the agent bind-mounts a repository it cannot otherwise obtain.
+      GIT_CHECKOUT_ENABLED: ${GIT_CHECKOUT_ENABLED:-false}
       HEPHAESTUS_FABRIC_ROOT: /data/git-repos
       HEPHAESTUS_FABRIC_GC_RETENTION_DAYS: ${HEPHAESTUS_FABRIC_GC_RETENTION_DAYS:-30}
       SANDBOX_DOCKER_HOST: ${SANDBOX_DOCKER_HOST:-unix:///var/run/docker.sock}


### PR DESCRIPTION
## Description

`GIT_CHECKOUT_ENABLED` is wired to `application-server` only. The **worker** is the role that runs agent jobs and bind-mounts a repository into the sandbox, and it is also where the health check looks:

```java
// PracticeReviewHealthIndicator — worker role
if (!gitProperties.enabled()) {
    return Health.outOfService()
        .withDetail("reviewsEnabled", true)
        .withDetail("reason", "GIT_CHECKOUT_DISABLED")
```

So an operator who sets `GIT_CHECKOUT_ENABLED=true` and `AGENT_ENABLED=true` — the documented way to turn practice review on — gets a deployment that reports itself **out of service** and reviews nothing, because the flag never reaches the container that reads it. Staging has `GIT_CHECKOUT_ENABLED=true` set today and its worker container has zero occurrences of the variable.

## What changes

The worker gets the same `${GIT_CHECKOUT_ENABLED:-false}` the application server has. The default is unchanged, so a deployment that has not opted in is unaffected.

## How to test

`docker compose -f docker/compose.app.yaml config` now renders the variable on both `application-server` and `application-worker`.

With `AGENT_ENABLED=true` and `GIT_CHECKOUT_ENABLED=true`, `/actuator/health` reports `reviewsEnabled: true` instead of `GIT_CHECKOUT_DISABLED`, and a queued review reaches the sandbox.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No new variable and no operator action: this makes an existing setting reach the container that reads it. `MIGRATION.md` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Practice reviews now respect the application’s Git checkout configuration, preventing checkout-related failures.
  - Worker health indicators and repository access now accurately reflect whether Git checkout is enabled.
  - When enabled, practice review workers can access the required application repository for reviews.

- **Documentation**
  - Added release documentation for the checkout configuration update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->