### PR TITLE
fix(docker): make the git-checkout volume writable by the runtime user

### DIFF
--- a/.changeset/practice-review-writable-fabric.md
+++ b/.changeset/practice-review-writable-fabric.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews no longer fail on a deployment whose repository volume was created by an earlier release. The agent writes its evidence store under the git-checkout volume, and a volume created root-owned — or owned by the user id a previous image ran as — left that store unwritable, so the first review of an upgraded instance failed with a permission error instead of running. Ownership is now corrected before the application starts.

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -86,21 +86,25 @@ services:
         max-size: "50m"
         max-file: "5"
 
-  # A named volume is created root-owned, and one created by an earlier image keeps that image's
-  # uid. The buildpack image runs as `cnb` (1002:1001), so anything it must write under
-  # /data/git-repos — the git checkouts and the agent's content-addressed store — is unwritable
-  # until the ownership matches. That surfaces as AccessDeniedException on the first practice
-  # review rather than at startup, because nothing writes there until an agent job runs. Only
-  # entries with the wrong owner are touched, so an already-correct volume costs a metadata walk.
+  # A new named volume is created root-owned, and one created by an earlier image keeps that image's
+  # uid. The buildpack image runs as `cnb` (1002:1001), so nothing under /data/git-repos is writable
+  # until the ownership matches — and that surfaces when an agent job first writes there, not at
+  # startup. -h so a symlink inside a checkout is retargeted rather than followed out of the volume.
   volume-init:
-    image: alpine:3
+    image: alpine:3@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
     command:
       - sh
       - -c
-      - "find /data/git-repos ! -user 1002 -exec chown -h 1002:1001 {} + && chmod 0755 /data/git-repos"
+      - "chown -Rh 1002:1001 /data/git-repos && chmod 0755 /data/git-repos"
     volumes:
       - git-repos:/data/git-repos
     restart: "no"
+    network_mode: none
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
   # See docs/admin/agent-image-digests.md.
   release-pin-fetcher:
@@ -298,10 +302,8 @@ services:
       volume-init:
         condition: service_completed_successfully
     restart: unless-stopped
-    # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is
-    # root:docker 0660, so the sandbox runtime cannot reach the daemon without joining the host's
-    # docker group. There is no portable value: read the host's with
-    # `getent group docker | cut -d: -f3` and set DOCKER_GROUP_ID to it.
+    # Joins the host's docker group so the unprivileged image can reach root:docker 0660
+    # /var/run/docker.sock. Host-specific — see DOCKER_GROUP_ID in .env.example.
     group_add:
       - "${DOCKER_GROUP_ID:-999}"
     volumes:
@@ -435,10 +437,8 @@ services:
       volume-init:
         condition: service_completed_successfully
     restart: unless-stopped
-    # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is
-    # root:docker 0660, so the sandbox runtime cannot reach the daemon without joining the host's
-    # docker group. There is no portable value: read the host's with
-    # `getent group docker | cut -d: -f3` and set DOCKER_GROUP_ID to it.
+    # Joins the host's docker group so the unprivileged image can reach root:docker 0660
+    # /var/run/docker.sock. Host-specific — see DOCKER_GROUP_ID in .env.example.
     group_add:
       - "${DOCKER_GROUP_ID:-999}"
     volumes:

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -86,6 +86,22 @@ services:
         max-size: "50m"
         max-file: "5"
 
+  # A named volume is created root-owned, and one created by an earlier image keeps that image's
+  # uid. The buildpack image runs as `cnb` (1002:1001), so anything it must write under
+  # /data/git-repos — the git checkouts and the agent's content-addressed store — is unwritable
+  # until the ownership matches. That surfaces as AccessDeniedException on the first practice
+  # review rather than at startup, because nothing writes there until an agent job runs. Only
+  # entries with the wrong owner are touched, so an already-correct volume costs a metadata walk.
+  volume-init:
+    image: alpine:3
+    command:
+      - sh
+      - -c
+      - "find /data/git-repos ! -user 1002 -exec chown -h 1002:1001 {} + && chmod 0755 /data/git-repos"
+    volumes:
+      - git-repos:/data/git-repos
+    restart: "no"
+
   # See docs/admin/agent-image-digests.md.
   release-pin-fetcher:
     image: "ghcr.io/ls1intum/hephaestus/release-pin-fetcher:${IMAGE_TAG}"
@@ -279,6 +295,8 @@ services:
         condition: service_started
       release-pin-fetcher:
         condition: service_completed_successfully
+      volume-init:
+        condition: service_completed_successfully
     restart: unless-stopped
     # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is
     # root:docker 0660, so the sandbox runtime cannot reach the daemon without joining the host's
@@ -413,6 +431,8 @@ services:
       application-server:
         condition: service_started
       release-pin-fetcher:
+        condition: service_completed_successfully
+      volume-init:
         condition: service_completed_successfully
     restart: unless-stopped
     # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -197,18 +197,20 @@ services:
           cpus: "0.5"
           memory: 512M
 
-  # Docker creates named volumes as root:root; the buildpack image runs as `cnb` (1002:1001) and
-  # needs to write git checkouts and Tomcat access logs. Every deploy gets fresh volumes, so the
-  # ownership fix has to run on every deploy too.
+  # A new named volume is created root-owned, and one created by an earlier image keeps that image's
+  # uid. The buildpack image runs as `cnb` (1002:1001), so nothing under /data/git-repos is writable
+  # until the ownership matches — and that surfaces when an agent job first writes there, not at
+  # startup. -h so a symlink inside a checkout is retargeted rather than followed out of the volume.
   volume-init:
-    image: alpine:3
+    image: alpine:3@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
     command:
       - sh
       - -c
-      - chown -R 1002:1001 /data/git-repos && chmod 0755 /data/git-repos
+      - "chown -Rh 1002:1001 /data/git-repos && chmod 0755 /data/git-repos"
     volumes:
       - git-repos:/data/git-repos
     restart: "no"
+    network_mode: none
 
   # The service name must stay dash-free. Coolify stores a service's configured domain under the
   # service name but looks it up with dashes replaced by underscores, so a dashed name never
@@ -346,10 +348,8 @@ services:
       WEBHOOK_EXTERNAL_URL: ${WEBHOOK_EXTERNAL_URL:-https://staging.hephaestus.aet.cit.tum.de}
       THC_PORT: "8080"
       THC_PATH: /actuator/health/liveness
-    # The image runs unprivileged (the buildpack's `cnb` user) while /var/run/docker.sock is
-    # root:docker 0660, so the sandbox runtime cannot reach the daemon without joining the host's
-    # docker group. There is no portable value: read the host's with
-    # `getent group docker | cut -d: -f3` and set DOCKER_GROUP_ID to it.
+    # Joins the host's docker group so the unprivileged image can reach root:docker 0660
+    # /var/run/docker.sock. Host-specific — see DOCKER_GROUP_ID in .env.example.
     group_add:
       - "${DOCKER_GROUP_ID:-999}"
     volumes:

--- a/docker/self-host/.env.example
+++ b/docker/self-host/.env.example
@@ -108,6 +108,12 @@ GH_AUTH_TOKEN=
 #AGENT_ENABLED=false
 #HEPHAESTUS_FABRIC_GC_RETENTION_DAYS=30
 #GIT_CHECKOUT_ENABLED=false
+
+# Supplementary group the app joins so the agent sandbox can reach the Docker socket. The image runs
+# unprivileged and the socket is root:docker 0660, so a wrong value fails every sandbox start with
+# "permission denied" — at first review, not at boot. Read your host's id with
+# `getent group docker | cut -d: -f3`; the 999 default is right on many Debian hosts and wrong on others.
+#DOCKER_GROUP_ID=999
 #PRACTICE_REVIEW_FOR_ALL=false
 #SANDBOX_MAX_CONCURRENT=1
 


### PR DESCRIPTION
## Description

The first practice review ever executed on staging failed like this:

```
Agent job failed: jobId=140efc9b…, error=Failed to lock CAS blob 0a603c06…
java.io.UncheckedIOException: Failed to lock CAS blob …
    at ContentAddressedStore.lockBlob(ContentAddressedStore.java:245)
Caused by: java.nio.file.AccessDeniedException: /data/git-repos/cas
```

A named volume is created root-owned, and one created by an earlier image keeps that image's uid. Staging's `app_git-repos` is owned by **100:101** at mode `0755` while the buildpack image runs as **1002:1001**, so the agent cannot create its content-addressed store under the volume.

Nothing writes there until an agent job runs, which is why this never showed up before: the deployment reports healthy, the health indicator is green, and the failure appears only when someone finally enables reviews. The preview stack already carries a `volume-init` for exactly this reason — the production stack does not.

## What changes

A one-shot `volume-init` that both application roles wait on, matching the preview stack:

```
find /data/git-repos ! -user 1002 -exec chown -h 1002:1001 {} + && chmod 0755 /data/git-repos
```

Two deliberate details:

- **`! -user 1002`** — only entries with the wrong owner are touched, so an already-correct volume costs one metadata walk rather than a recursive rewrite of every deploy. Staging's tree is 6 GB across 216 repositories.
- **`chown -h`** — the tree contains dangling symlinks (vendored framework directories with `Versions/Current` pointing at nothing). Without `-h`, `chown` follows them, fails with `No such file or directory`, and exits non-zero, which would make the init container fail the deploy. Verified on the live volume: it errored without `-h`, and reported zero remaining wrong-owner entries with it.

## How to test

On the affected volume:

```
$ docker run --rm -v app_git-repos:/data alpine:3 \
    sh -c 'find /data ! -user 1002 -exec chown -h 1002:1001 {} + && chmod 0755 /data'
$ find /var/lib/docker/volumes/app_git-repos/_data ! -user 1002 | wc -l
0
```

The agent then creates `/data/git-repos/cas` (`drwxr-xr-x 1002 1001`) on the next job, and the `AccessDeniedException` is gone — confirmed on staging, where the following review reached evidence collection instead of failing at sandbox preparation.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No new variable and no operator action — the init runs as part of the stack. `MIGRATION.md` is untouched.
