### PR TITLE
fix(server): reconcile the consumer inactive threshold, durables only

### DIFF
--- a/.changeset/nats-reaper-reaches-existing-consumers.md
+++ b/.changeset/nats-reaper-reaches-existing-consumers.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+The consumer-expiry setting now takes effect on deployments that already had consumers, and no longer lengthens the lifetime of the short-lived ones. Setting it previously did nothing unless a consumer happened to be created afterwards, and where consumers were unnamed it extended how long they lingered instead of shortening it. A negative value is now rejected at startup rather than accepted.

--- a/docker/preview/.env.example
+++ b/docker/preview/.env.example
@@ -117,3 +117,7 @@ TANSTACK_DEVTOOLS_ENABLED=true
 # practice review can run. There is no portable default — read the host's group id with
 # `getent group docker | cut -d: -f3`.
 # DOCKER_GROUP_ID=999
+
+# How long a JetStream durable may go without a pull before the server deletes it. A preview is
+# deleted rather than shut down, so it never removes its own cursors. A bare number is hours.
+#HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD=72h

--- a/docker/preview/README.md
+++ b/docker/preview/README.md
@@ -12,7 +12,7 @@ copy of the staging database.
 | Seed data | One live `pg_dump` from `app-postgres-1` on first deploy | Realistic data without touching the staging data volume |
 | NATS | Shared staging `nats-server:4222` on `shared-network` | Previews see the same integration events as staging |
 | NATS consumer | `${SERVICE_NAME_APPSERVER}-consumer` | Every preview has an independent JetStream cursor |
-| Consumer lifetime | JetStream reaps the durable after 72h unbound | A deleted preview cannot delete its own cursors |
+| Consumer lifetime | JetStream reaps the durable after `HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD` with no pulls | A deleted preview cannot delete its own cursors |
 | App image | Immutable `${SOURCE_COMMIT}` tag from CI | The API and SPA both reflect the PR without a shared mutable tag |
 | Agent runtime | Enabled, one sandbox at a time | A selected workspace can run real reviews without exhausting the host |
 | Review automation | Paused in every cloned workspace | A clone cannot post reviews until an admin explicitly opts it in |

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -265,9 +265,8 @@ services:
       # competing for one and stealing each other's messages.
       NATS_DURABLE_CONSUMER_NAME: ${SERVICE_NAME_APPSERVER:-appserver}-consumer
       # A preview is deleted, not shut down, so it never removes the durables it created on the
-      # shared stream. JetStream reaps them once nothing has been bound for this long — one closed
-      # PR would otherwise leave its cursors, and their backlogs, behind for good. Long enough that
-      # a redeploy or a paused review session resumes on its own cursor rather than skipping ahead.
+      # shared stream. Long enough that a redeploy, or a testing session paused overnight, resumes
+      # on its own cursor instead of skipping ahead to the head of the stream.
       HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD: ${HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD:-72h}
       # Issuer is this deploy's own origin, so a preview's tokens validate against the deploy that
       # issued them (Hephaestus-native auth, ADR 0017).

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumer.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumer.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -672,17 +673,28 @@ public class IntegrationNatsConsumer {
                 ConsumerConfiguration config = existing.getConsumerInfo().getConsumerConfiguration();
                 Set<String> existingSubjects = new HashSet<>(config.getFilterSubjects());
                 Set<String> desiredSubjects = new HashSet<>(Arrays.asList(subjects));
-                if (existingSubjects.equals(desiredSubjects)) {
+                Duration desiredThreshold = consumerProperties.inactiveThreshold();
+                // A consumer created before the threshold was configured keeps its old lifetime
+                // until something rewrites it, so reconcile it here rather than only on create.
+                boolean thresholdMatches = Objects.equals(
+                    Objects.requireNonNullElse(config.getInactiveThreshold(), Duration.ZERO),
+                    desiredThreshold
+                );
+                if (existingSubjects.equals(desiredSubjects) && thresholdMatches) {
                     return existing;
                 }
                 log.info(
-                    "Updating durable consumer filter subjects: consumerName={}, oldCount={}, newCount={}",
+                    "Updating durable consumer: consumerName={}, oldSubjectCount={}, newSubjectCount={}, inactiveThreshold={}",
                     consumerName,
                     existingSubjects.size(),
-                    desiredSubjects.size()
+                    desiredSubjects.size(),
+                    desiredThreshold
                 );
                 return streamContext.createOrUpdateConsumer(
-                    ConsumerConfiguration.builder(config).filterSubjects(subjects).build()
+                    ConsumerConfiguration.builder(config)
+                        .filterSubjects(subjects)
+                        .inactiveThreshold(desiredThreshold)
+                        .build()
                 );
             } catch (JetStreamApiException e) {
                 // 10014 = consumer not found: expected on first start / after cleanup, fall through
@@ -726,15 +738,10 @@ public class IntegrationNatsConsumer {
             // means a JetStream-side observability tool (`nats stream info`) cannot see
             // the policy. Mirrors the value the poison handler uses to ACK-terminate.
             .maxDeliver(consumerProperties.poison().maxRedeliver());
-        // Server-side reaping for deployments that are deleted rather than shut down. A PR preview
-        // never gets to clean up after itself, so its durables would otherwise pile up on the
-        // shared stream one generation per closed PR. Unset for long-lived deployments, where a
-        // reaped durable would silently resume at DeliverPolicy.New and skip an outage's backlog.
-        if (consumerProperties.inactiveThreshold() != null) {
-            builder.inactiveThreshold(consumerProperties.inactiveThreshold());
-        }
         if (!isBlank(durableName)) {
-            builder.durable(durableName);
+            // Only a durable is worth reaping: JetStream already deletes an ephemeral seconds after
+            // its last pull, so a threshold here would lengthen that rather than bound it.
+            builder.durable(durableName).inactiveThreshold(consumerProperties.inactiveThreshold());
         }
         return builder.build();
     }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerProperties.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import org.jspecify.annotations.Nullable;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.convert.DurationUnit;
@@ -17,11 +17,10 @@ import org.springframework.validation.annotation.Validated;
  * NATS consumer tuning bound to {@code hephaestus.integration.consumer}. Read by every
  * consumer-side collaborator under {@code integration.consumer}.
  *
- * <p>{@code inactive-threshold} is unset by default, which is what a long-lived deployment wants:
- * a durable that outlives an outage resumes at its own cursor instead of skipping whatever arrived
- * while the pod was down. Set it only where the deployment itself is disposable — a PR preview
- * leaves its durables behind when the stack is deleted, and without a threshold those cursors
- * accumulate on the shared stream forever.
+ * <p>{@code inactive-threshold} lets JetStream delete a durable nothing has pulled from for that
+ * long; zero disables it. Set it only where the deployment is deleted rather than shut down, and so
+ * never deletes its own durables — elsewhere a reaped durable is recreated at
+ * {@link io.nats.client.api.DeliverPolicy#New} and loses whatever arrived during the outage.
  */
 @Validated
 @ConfigurationProperties(prefix = "hephaestus.integration.consumer")
@@ -38,13 +37,14 @@ public record NatsConsumerProperties(
     @DefaultValue("2s")
     @NotNull(message = "reconnect-delay must not be null")
     Duration reconnectDelay,
-    @DurationUnit(ChronoUnit.HOURS) @Nullable Duration inactiveThreshold,
+    @DurationUnit(ChronoUnit.HOURS)
+    @DefaultValue("0s")
+    @NotNull(message = "inactive-threshold must not be null")
+    @DurationMin(message = "inactive-threshold must not be negative")
+    Duration inactiveThreshold,
     @Valid PoisonProperties poison
 ) {
     public NatsConsumerProperties {
-        if (inactiveThreshold != null && (inactiveThreshold.isZero() || inactiveThreshold.isNegative())) {
-            throw new IllegalStateException("inactive-threshold must be positive when set");
-        }
         if (poison == null) {
             poison = new PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5));
         }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -599,6 +599,11 @@ hephaestus:
     # pure helper/subject classes may still load because they do no external work.
     # Flip `enabled` to `true` once credentials and redirect URLs are configured.
     integration:
+        consumer:
+            # Lets JetStream delete a durable nothing has pulled from for this long. 0 disables it;
+            # set it only where the deployment is deleted rather than shut down, and so never gets
+            # to delete its own durables. A bare number is hours.
+            inactive-threshold: ${HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD:0s}
         # ─── GitHub authentication (GitHubProperties) ───
         # Can be any OAuth token, such as the PAT.
         github:

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationNatsConsumerTest.java
@@ -65,13 +65,7 @@ class IntegrationNatsConsumerTest {
         NatsSubscriptionProvider subscriptions = mock(NatsSubscriptionProvider.class);
         IntegrationNatsConsumer consumer = new IntegrationNatsConsumer(
             new NatsConnectionProperties(true, "nats://localhost:4222", "heph", 7, null),
-            new NatsConsumerProperties(
-                Duration.ofMinutes(5),
-                500,
-                Duration.ofSeconds(2),
-                null,
-                new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
-            ),
+            NatsConsumerPropertiesFixture.defaults(),
             subscriptions,
             mock(IntegrationMessageDispatcher.class),
             mock(IntegrationPoisonHandler.class),
@@ -93,13 +87,7 @@ class IntegrationNatsConsumerTest {
         CountDownLatch restarted = new CountDownLatch(1);
         IntegrationNatsConsumer consumer = new IntegrationNatsConsumer(
             new NatsConnectionProperties(true, "nats://localhost:4222", "heph", 7, null),
-            new NatsConsumerProperties(
-                Duration.ofMinutes(5),
-                500,
-                Duration.ofSeconds(2),
-                null,
-                new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
-            ),
+            NatsConsumerPropertiesFixture.defaults(),
             scopeId -> Optional.empty(),
             mock(IntegrationMessageDispatcher.class),
             mock(IntegrationPoisonHandler.class),
@@ -132,13 +120,7 @@ class IntegrationNatsConsumerTest {
 
     @Test
     void newConsumerStartsAtNewMessagesInsteadOfReplayingStreamHistory() {
-        NatsConsumerProperties properties = new NatsConsumerProperties(
-            Duration.ofMinutes(5),
-            500,
-            Duration.ofSeconds(2),
-            null,
-            new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
-        );
+        NatsConsumerProperties properties = NatsConsumerPropertiesFixture.defaults();
 
         var config = IntegrationNatsConsumer.newConsumerConfiguration(
             new String[] { "slack.>" },
@@ -148,27 +130,28 @@ class IntegrationNatsConsumerTest {
 
         assertThat(config.getDeliverPolicy()).isEqualTo(DeliverPolicy.New);
         assertThat(config.getDurable()).isEqualTo("heph-slack");
-        assertThat(config.getInactiveThreshold()).isNull();
     }
 
     @Test
-    void disposableDeploymentLetsJetStreamReapItsDurableWhenTheStackIsDeleted() {
-        NatsConsumerProperties properties = new NatsConsumerProperties(
-            Duration.ofMinutes(5),
-            500,
-            Duration.ofSeconds(2),
-            Duration.ofHours(72),
-            new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
-        );
-
+    void shouldReapDurableWhenInactiveThresholdIsConfigured() {
         var config = IntegrationNatsConsumer.newConsumerConfiguration(
             new String[] { "github.>" },
-            properties,
-            "appserver-pr-1443-consumer"
+            NatsConsumerPropertiesFixture.withInactiveThreshold(Duration.ofHours(72)),
+            "heph-github"
         );
 
         assertThat(config.getInactiveThreshold()).isEqualTo(Duration.ofHours(72));
-        assertThat(config.getDurable()).isEqualTo("appserver-pr-1443-consumer");
+    }
+
+    @Test
+    void shouldLeaveEphemeralLifetimeAloneWhenInactiveThresholdIsConfigured() {
+        var config = IntegrationNatsConsumer.newConsumerConfiguration(
+            new String[] { "github.>" },
+            NatsConsumerPropertiesFixture.withInactiveThreshold(Duration.ofHours(72)),
+            null
+        );
+
+        assertThat(config.getInactiveThreshold()).isNull();
     }
 
     @Nested
@@ -229,13 +212,7 @@ class IntegrationNatsConsumerTest {
             when(message.getSubject()).thenReturn("github.acme.repo.issues");
             return new IntegrationNatsConsumer(
                 new NatsConnectionProperties(true, "nats://localhost:4222", "heph", 7, null),
-                new NatsConsumerProperties(
-                    Duration.ofMinutes(5),
-                    500,
-                    Duration.ofSeconds(2),
-                    null,
-                    new NatsConsumerProperties.PoisonProperties(10, Duration.ofMillis(1), Duration.ofSeconds(1))
-                ),
+                NatsConsumerPropertiesFixture.withFastPoisonBackoff(),
                 scopeId -> Optional.empty(),
                 dispatcher,
                 mock(IntegrationPoisonHandler.class),
@@ -371,13 +348,7 @@ class IntegrationNatsConsumerTest {
             FakeFleet(Set<String> failingStreams) {
                 super(
                     new NatsConnectionProperties(true, "nats://localhost:4222", "heph", 7, null),
-                    new NatsConsumerProperties(
-                        Duration.ofMinutes(5),
-                        500,
-                        Duration.ofSeconds(2),
-                        null,
-                        new NatsConsumerProperties.PoisonProperties(10, Duration.ofMillis(1), Duration.ofSeconds(1))
-                    ),
+                    NatsConsumerPropertiesFixture.withFastPoisonBackoff(),
                     scopeId ->
                         Optional.of(
                             new NatsSubscriptionInfo(

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationPoisonHandlerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/IntegrationPoisonHandlerTest.java
@@ -35,13 +35,7 @@ class IntegrationPoisonHandlerTest extends BaseUnitTest {
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        properties = new NatsConsumerProperties(
-            Duration.ofMinutes(5),
-            500,
-            Duration.ofSeconds(2),
-            null,
-            new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
-        );
+        properties = NatsConsumerPropertiesFixture.defaults();
         handler = new IntegrationPoisonHandler(properties, meterRegistry);
     }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerPropertiesFixture.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerPropertiesFixture.java
@@ -1,0 +1,35 @@
+package de.tum.cit.aet.hephaestus.integration.core.consumer;
+
+import java.time.Duration;
+
+/** Keeps a component added to the record from rippling through every test that builds one. */
+final class NatsConsumerPropertiesFixture {
+
+    private NatsConsumerPropertiesFixture() {}
+
+    static NatsConsumerProperties defaults() {
+        return withInactiveThreshold(Duration.ZERO);
+    }
+
+    static NatsConsumerProperties withInactiveThreshold(Duration inactiveThreshold) {
+        return build(
+            inactiveThreshold,
+            new NatsConsumerProperties.PoisonProperties(10, Duration.ofSeconds(2), Duration.ofMinutes(5))
+        );
+    }
+
+    /** Poison backoff short enough that a redelivery loop finishes inside a unit test. */
+    static NatsConsumerProperties withFastPoisonBackoff() {
+        return build(
+            Duration.ZERO,
+            new NatsConsumerProperties.PoisonProperties(10, Duration.ofMillis(1), Duration.ofSeconds(1))
+        );
+    }
+
+    private static NatsConsumerProperties build(
+        Duration inactiveThreshold,
+        NatsConsumerProperties.PoisonProperties poison
+    ) {
+        return new NatsConsumerProperties(Duration.ofMinutes(5), 500, Duration.ofSeconds(2), inactiveThreshold, poison);
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerPropertiesTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/consumer/NatsConsumerPropertiesTest.java
@@ -27,7 +27,7 @@ class NatsConsumerPropertiesTest extends BaseUnitTest {
                 Duration.ofMinutes(5),
                 500,
                 Duration.ofSeconds(2),
-                null,
+                Duration.ZERO,
                 null
             );
 
@@ -48,7 +48,7 @@ class NatsConsumerPropertiesTest extends BaseUnitTest {
                 Duration.ofMinutes(5),
                 500,
                 Duration.ofSeconds(2),
-                null,
+                Duration.ZERO,
                 custom
             );
 
@@ -104,6 +104,31 @@ class NatsConsumerPropertiesTest extends BaseUnitTest {
                     assertThat(props.poison().baseDelay()).isEqualTo(Duration.ofSeconds(4));
                     assertThat(props.poison().maxDelay()).isEqualTo(Duration.ofMinutes(1));
                 });
+        }
+
+        @Test
+        void shouldDisableReapingWhenInactiveThresholdIsUnset() {
+            runner().run(context ->
+                assertThat(context.getBean(NatsConsumerProperties.class).inactiveThreshold()).isZero()
+            );
+        }
+
+        @Test
+        void shouldReadBareInactiveThresholdAsHours() {
+            runner()
+                .withPropertyValues("hephaestus.integration.consumer.inactive-threshold=72")
+                .run(context ->
+                    assertThat(context.getBean(NatsConsumerProperties.class).inactiveThreshold()).isEqualTo(
+                        Duration.ofHours(72)
+                    )
+                );
+        }
+
+        @Test
+        void shouldRejectNegativeInactiveThreshold() {
+            runner()
+                .withPropertyValues("hephaestus.integration.consumer.inactive-threshold=-1h")
+                .run(context -> assertThat(context).hasFailed());
         }
     }
 }


### PR DESCRIPTION
## Description

A review of #1456 found three defects in the inactive-threshold it added. All three mean the feature does not do what its changeset promised.

**1. Applied to ephemeral consumers, where it makes the leak worse.** `builder.inactiveThreshold(...)` ran before the durable check. JetStream deletes an ephemeral seconds after its last pull (`JsDeleteWaitTimeDefault`), so setting `72h` on a deployment with a blank durable name extends its consumers from seconds to three days — the inverse of the intent, on exactly the disposable deployments the setting targets.

**2. Create-time only, silently.** `createOrUpdateConsumer` returns the existing consumer when the filter subjects already match, and the update path rebuilds from the config read back **from the server**, overriding only `filterSubjects`. So a deployment whose durable already existed never received the threshold — no log line, no error, forever. That contradicts the changeset's promise to operators and the preview README's table. Verified in `nats-server`: `InactiveThreshold` is not in `checkNewConsumerConfig`'s not-updatable list and `updateConfig` re-arms the timer on change, so this was never a server limitation.

**3. The null guard was dead code.** jnats `normalize()` maps `null` and `Duration.ZERO` identically, and `JsonUtils.addFieldAsNanos` omits both. The `if` bought nothing — which is also why `Duration.ZERO` is a safe "off" encoding, wire-identical to unset.

## What changes

- The threshold moves into the durable branch, with the ephemeral rule stated where it applies.
- An existing durable is reconciled onto the configured value, and the log line reports it.
- `@Nullable` + a hand-written `IllegalStateException` become `@DefaultValue("0s")` + `@DurationMin`, matching how every other field in the record validates. Hibernate Validator is already a dependency and the repo already uses its constraints.
- `hephaestus.integration.consumer.inactive-threshold` is declared in `application.yml`. That is what makes `check-env-defaults` report the preview's deliberate override instead of staying silent about a key absent from the application:

```
docker/preview/compose.app.yaml runs HEPHAESTUS_INTEGRATION_CONSUMER_INACTIVE_THRESHOLD at "72h" rather than "0s" — on purpose.
```

## Tests

The original commit asserted that a jnats builder round-trips a field, and skipped the `ApplicationContextRunner` harness sitting in the file it edited. Replaced with behaviour that can actually break:

| Test | Covers |
|---|---|
| `shouldReapDurableWhenInactiveThresholdIsConfigured` | defect 1, durable side |
| `shouldLeaveEphemeralLifetimeAloneWhenInactiveThresholdIsConfigured` | defect 1, ephemeral side |
| `shouldDisableReapingWhenInactiveThresholdIsUnset` | the `0s` default binds |
| `shouldReadBareInactiveThresholdAsHours` | `@DurationUnit(HOURS)` — the reason the annotation exists |
| `shouldRejectNegativeInactiveThreshold` | the new constraint fails the context |

A fixture replaces nine inline record constructions, so the next component added does not sweep nine call sites. Names follow `should[Behavior]When[Condition]` per `server/AGENTS.md`; the previous name claimed four things the test did not exercise.

`32 tests, 0 failures` across the three affected classes; `pnpm run check` passes.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No operator action: the default is unchanged in effect (`0s` is wire-identical to previously-unset), and the preview stack keeps setting its own value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for automatically removing inactive durable message consumers.
  * Inactivity cleanup is disabled by default and can be set using duration values.
  * Existing consumers now update when their inactivity settings change.
* **Bug Fixes**
  * Prevented invalid negative inactivity durations from being accepted during startup.
  * Ensured inactivity settings apply only to durable consumers.
* **Documentation**
  * Updated preview environment and deployment documentation to describe configurable consumer cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->