### PR TITLE
fix(docker): fail a preview whose cloned deliveries are still pending

### DIFF
--- a/.changeset/preview-policy-covers-pending-deliveries.md
+++ b/.changeset/preview-policy-covers-pending-deliveries.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+A pull request preview now refuses to start if a cloned feedback delivery is still pending. The startup check covered triggers, bindings and running jobs but not the one row that can still reach a real pull request — a completed review whose delivery had not gone out yet — so a preview could come up believing it was silenced while holding a deliverable result.

--- a/docker/preview/README.md
+++ b/docker/preview/README.md
@@ -28,11 +28,10 @@ already seeded PR preserves changes made while testing. A new preview volume get
 verifies it took effect and only then writes the seed marker. A clone is another instance's live
 database, so the policy answers two questions, and it is organised by them.
 
-The SQL is inline in `compose.app.yaml` rather than a mounted `.sql` file. Coolify materialises a
-relative bind mount as an empty managed *directory*, and `psql < <directory>` reads nothing and exits
-0 — which once let a preview start on a clone that had kept every trigger, binding and credential of
-the instance it came from, behind a seed marker claiming otherwise. The marker is now written only
-against the database's own answer: any live trigger, binding, job, or inherited identity fails the
+The SQL is inline in `compose.app.yaml` rather than a mounted `.sql` file: Coolify materialises a
+relative bind mount as an empty managed *directory*, which `psql <` reads as zero bytes and exits 0
+on. The seed marker is therefore written against the database's own answer rather than against an
+exit code — any live trigger, binding, job, pending delivery, or inherited identity fails the
 deployment.
 
 ### Silence — a clone must not act
@@ -64,7 +63,8 @@ rebuilt from this deployment's own configuration:
 
 `LoginProviderService` seeds `login_provider` from the environment whenever a registration id is
 absent, so emptying the table hands the preview its own login apps on the next boot — which is why the
-preview stack needs `GITHUB_OAUTH_*` (and any other provider it should offer) pointed at an OAuth app
+preview stack needs `GH_OAUTH_CLIENT_ID`/`GH_OAUTH_CLIENT_SECRET` (and any other provider it should
+offer) pointed at an OAuth app
 whose callback covers the preview hostnames. A provider with no credentials in the preview environment
 is simply not offered; Slack, being link-only, is normally absent for that reason.
 
@@ -80,8 +80,9 @@ a cloned user signs in through the preview's own OAuth app and lands on the same
 4. Set `PREVIEW_SEED_SOURCE_CONTAINER=app-postgres-1` if the staging Compose project/container name
    ever changes. The source user defaults to `root` and database to `hephaestus`.
 5. Set `HEPHAESTUS_SECURITY_ENCRYPTION_KEY` to the **seed source instance's** key, and point
-   `GITHUB_OAUTH_CLIENT_ID`/`_SECRET` at an OAuth app whose callback covers the preview hostnames —
-   see the re-home policy above for both.
+   `GH_OAUTH_CLIENT_ID`/`GH_OAUTH_CLIENT_SECRET` at an OAuth app whose callback covers the preview
+   hostnames — see the re-home policy above for both. The `GH_` prefix is deliberate: GitHub Actions
+   reserves `GITHUB_`, and the Compose file maps these onto the application's `GITHUB_OAUTH_*` inputs.
 6. Assign the web and API services sibling wildcard domains. With the current template these are
    `pr<id>.hephaestus.felixdietrich.com` and `pr<id>.api.hephaestus.felixdietrich.com`.
 7. Leave the preview `IMAGE_TAG` unset. Coolify injects `SOURCE_COMMIT`, and CI publishes the matching
@@ -120,11 +121,16 @@ that makes it. Reviewing a change here means reading it; the first
 preview that actually runs it is the next one created after the change is merged and Coolify has
 re-read `main`.
 
-The Docker socket mount is privileged access to the host Docker daemon even though it is mounted
-read-only. It is intentionally confined to the trusted preview application and used only for
-`pg_dump`, restore, and sandbox execution. Coolify's `SERVICE_NAME_POSTGRES` is a network alias, so
-the seeder resolves the physical target container only when exactly one container has both its own
-Compose project label and that service label.
+## Host access
+
+Both the seeder and the application server mount `/var/run/docker.sock`. The seeder's `:ro` is a
+filesystem flag on a socket inode — it prevents unlinking, not any daemon command — so treat every
+one of these mounts as root on the host, confined to the trusted preview application and used only
+for `pg_dump`, restore, and sandbox execution.
+
+Coolify's `SERVICE_NAME_POSTGRES` is a network alias, so the seeder resolves the physical target
+container only when exactly one container carries both its own Compose project label and that
+service label.
 
 ## Failure behavior
 

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -115,10 +115,8 @@ services:
           -U hephaestus -d hephaestus \
           --exit-on-error --no-owner --no-privileges < /tmp/seed.dump
 
-        # The policy is inline rather than a mounted .sql file: Coolify materialises a relative bind
-        # mount as an empty managed directory, and `psql < <directory>` reads nothing and exits 0 —
-        # a clone that silently kept every trigger, binding and credential of the instance it came
-        # from. The verification below is what actually holds the line; see README.md.
+        # Inline rather than a mounted .sql file: Coolify materialises a relative bind mount as an
+        # empty managed directory, which `psql <` reads as zero bytes and exits 0 on.
         echo "Applying the preview policy"
         docker exec -i "$$PREVIEW_PG" psql -v ON_ERROR_STOP=1 -U hephaestus -d hephaestus <<'SQL'
         -- 1. Silence: a clone must not act.
@@ -158,18 +156,16 @@ services:
                error_summary = 'Cancelled when staging data was cloned into a preview.'
          WHERE status IN ('PENDING', 'RUNNING');
 
-        -- 2. Re-home: a clone must not keep the source instance's identity. Each table is rebuilt
-        -- from this deployment's own configuration on boot. identity_link keys on identity_provider,
-        -- not on login_provider, so accounts survive.
+        -- 2. Re-home: a clone must not keep the source instance's identity. login_provider and
+        -- jwt_signing_key are reseeded from this deployment's own config on boot; issued_jwt is
+        -- simply dropped. Accounts survive — identity_link keys on identity_provider.
         DELETE FROM issued_jwt;
         DELETE FROM jwt_signing_key;
         DELETE FROM login_provider;
         SQL
 
-        # The marker is a promise that the policy is in force, so it is written only against the
-        # database's own answer. Anything that leaves a live trigger, binding, job or inherited
-        # identity behind fails the deployment instead of starting an application server on a clone
-        # that can act as the instance it was copied from.
+        # The marker promises the policy is in force, so verify against the database rather than
+        # against psql's exit code — see the bind-mount note above for why those differ.
         echo "Verifying the preview policy took effect"
         LIVE=$$(docker exec "$$PREVIEW_PG" psql -tAX -v ON_ERROR_STOP=1 -U hephaestus -d hephaestus -c "
           SELECT (SELECT count(*) FROM workspace
@@ -177,6 +173,8 @@ services:
                + (SELECT count(*) FROM workspace_agent_binding WHERE enabled AND purpose = 'PRACTICE_REVIEW')
                + (SELECT count(*) FROM review_sweep_schedule WHERE enabled)
                + (SELECT count(*) FROM agent_job WHERE status IN ('QUEUED', 'RUNNING'))
+               + (SELECT count(*) FROM agent_job
+                   WHERE status = 'COMPLETED' AND delivery_status = 'PENDING')
                + (SELECT count(*) FROM sync_job WHERE status IN ('PENDING', 'RUNNING'))
                + (SELECT count(*) FROM login_provider)
                + (SELECT count(*) FROM jwt_signing_key)


### PR DESCRIPTION
## Description

Three defects found reviewing the preview policy, one of them a fail-open in the check that exists to fail closed.

**1. The verification skipped the highest-consequence row.** The policy marks a cloned `COMPLETED` job whose `delivery_status` is `PENDING` as failed — the README calls this out as what stops delivery recovery publishing a staging result to a real pull request. The verification that gates the seed marker never counted it. So the single row that can reach GitHub was the one the fail-closed gate did not cover, while `README.md` claimed *"any live trigger, binding, job, or inherited identity fails the deployment"*.

**2. The setup step named variables the stack does not read.** It said `GITHUB_OAUTH_CLIENT_ID`/`_SECRET`; the Compose file reads `GH_OAUTH_CLIENT_ID`/`GH_OAUTH_CLIENT_SECRET`, because GitHub Actions reserves the `GITHUB_` prefix for secret names. An operator following the runbook literally gets a preview with no GitHub sign-in — exactly the failure the re-home work set out to fix.

**3. The socket paragraph was wrong.** It described the Docker socket as "mounted read-only". Only the seeder mounts `:ro`; the application server's mount is read-write. And `:ro` on a socket inode is a filesystem flag — it prevents unlinking, it does not block any daemon command. Describing it as a boundary understates what the mount grants.

## What changes

- The verification counts pending deliveries.
- The README names the real variables and explains why the prefix differs.
- The socket text says what the mount actually grants, under its own heading, with the unrelated network-alias note separated from it.
- Comment trimming in the same regions: an incident retelling in the Compose file and the README, and a re-home comment that claimed all three tables are "rebuilt on boot" when `issued_jwt` is only dropped.

## How to test

Coolify parses the Compose file from `main`, so this is not exercised by its own preview — the next preview created after it merges runs it. The check is a single `SELECT`; with a cloned pending delivery present it returns non-zero and the seeder exits before writing the marker.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No operator action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview deployments now refuse to start when cloned feedback deliveries are still pending.
  * Preview setup now verifies that inherited pending deliveries are cleared before marking the environment ready.

* **Documentation**
  * Clarified preview seed validation and OAuth configuration requirements.
  * Expanded guidance on Docker socket host-access considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->