### PR TITLE
fix(ci): tighten the preview reconcile and its image signal

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -26,6 +26,11 @@ on:
         type: string
         default: "true"
 
+    outputs:
+      application-server-published:
+        description: "Whether an application-server image exists at this commit"
+        value: ${{ jobs.application-server-build.result == 'success' }}
+
 jobs:
   webapp-build:
     name: "Webapp"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          DOCKER_RESULT: ${{ needs.Docker.result }}
+          APP_SERVER_PUBLISHED: ${{ needs.Docker.outputs.application-server-published }}
         run: |
           set -euo pipefail
 
@@ -122,10 +122,10 @@ jobs:
             exit 0
           fi
 
-          # No image workflow, no SOURCE_COMMIT tag. Requesting the deployment anyway would only
-          # queue one that fails on `manifest unknown`, under a green check.
-          if [ "${DOCKER_RESULT}" != 'success' ]; then
-            echo "::notice::No application-server image was published for this commit (Docker: ${DOCKER_RESULT}); skipping preview update."
+          # Coolify pins the preview to SOURCE_COMMIT, so without that tag the deployment can only
+          # fail on `manifest unknown` — under a green check, since queueing one always succeeds.
+          if [ "${APP_SERVER_PUBLISHED}" != 'true' ]; then
+            echo "::notice::No application-server image for this commit; skipping preview update."
             exit 0
           fi
 
@@ -195,18 +195,15 @@ jobs:
   Docker:
     uses: ./.github/workflows/ci-docker-build.yml
     needs: [detect-changes]
-    # Coolify gives every same-repository pull request a preview and pins it to SOURCE_COMMIT, so
-    # every such pull request needs an application-server tag at its head commit — including one that
-    # touches only the preview stack or documentation. Without it the preview deployment fails with
-    # `manifest unknown` for an image that will never be published. application-server-build is a
-    # cached rebuild when server code did not change; the webapp and agent images stay gated by their
-    # own inputs, so this costs one cached build, not the whole matrix.
+    # Every same-repository pull request gets a Coolify preview pinned to SOURCE_COMMIT, so it needs
+    # an application-server tag at its head commit even when it touches only docs or the preview
+    # stack. The path filters below therefore gate fork pull requests only — forks get no preview.
     if: |
       needs.detect-changes.outputs.should_skip != 'true' && (
-        needs.detect-changes.outputs.any-code == 'true' ||
-        needs.detect-changes.outputs.ci-config == 'true' ||
         github.event_name != 'pull_request' ||
-        github.event.pull_request.head.repo.full_name == github.repository
+        github.event.pull_request.head.repo.full_name == github.repository ||
+        needs.detect-changes.outputs.any-code == 'true' ||
+        needs.detect-changes.outputs.ci-config == 'true'
       )
     secrets: inherit
     with:

--- a/.github/workflows/reconcile-previews.yml
+++ b/.github/workflows/reconcile-previews.yml
@@ -1,14 +1,10 @@
 name: Preview reconcile
 
-# `cleanup-preview.yml` deletes a preview when its pull request closes, and that is the fast path.
-# It is also the only path: it exits without doing anything when COOLIFY_API_TOKEN is unset, it never
-# runs for a fork, and it cannot reach Coolify if Coolify is down at that moment. Nothing afterwards
-# notices, so a preview that outlives its pull request keeps a cloned database and a git checkout —
-# roughly 4 GB — until someone goes looking. This asks the opposite question on a schedule: of the
-# pull requests that closed recently, does any still have a preview?
+# `cleanup-preview.yml` deletes a preview when its pull request closes. That request can fail — most
+# plausibly because Coolify was unreachable at the time — and nothing afterwards notices, so the
+# preview keeps its cloned database and git checkout indefinitely. This re-checks on a schedule.
 #
-# Deleting a preview for a closed pull request is idempotent, so a preview that was already cleaned
-# up answers 404 and costs one request. Open pull requests are never touched.
+# Deleting an already-deleted preview answers 404, so 404 is the expected result rather than a fault.
 
 on:
   schedule:
@@ -33,7 +29,7 @@ jobs:
     name: "Preview / Reconcile orphans"
     runs-on: ubuntu-latest
     if: vars.COOLIFY_URL != '' && vars.COOLIFY_APP_UUID != ''
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       COOLIFY_URL: ${{ vars.COOLIFY_URL }}
       COOLIFY_APP_UUID: ${{ vars.COOLIFY_APP_UUID }}
@@ -50,44 +46,52 @@ jobs:
             exit 0
           fi
 
-          cutoff=$(date -u -d "-${DAYS} days" +%s)
+          since=$(date -u -d "-${DAYS} days" +%Y-%m-%d)
           closed=$(gh pr list --repo "${GITHUB_REPOSITORY}" --state closed \
-            --limit 200 --json number,closedAt \
-            --jq "[.[] | select(.closedAt != null)] | sort_by(.number) | reverse | .[] | \"\(.number) \(.closedAt)\"")
+            --search "closed:>=${since}" --limit 500 --json number --jq '.[].number')
+          # --limit truncates; it is not the window. Passing --search also switches gh to
+          # relevance ordering, so a truncated page would drop arbitrary pull requests.
+          if [ "$(printf '%s\n' "${closed}" | grep -c .)" -ge 500 ]; then
+            echo "::error::More than 500 pull requests closed since ${since}; raise --limit."
+            exit 1
+          fi
 
           reclaimed=0
           checked=0
           failed=0
+          summary="${RUNNER_TEMP}/summary.md"
+          body="${RUNNER_TEMP}/response.json"
           {
             echo "| PR | Result |"
             echo "|---:|---|"
-          } > /tmp/summary.md
+          } > "${summary}"
 
-          while read -r number closed_at; do
+          while read -r number; do
             [ -n "${number:-}" ] || continue
-            [ "$(date -u -d "${closed_at}" +%s)" -ge "${cutoff}" ] || continue
             checked=$((checked + 1))
 
-            body=$(mktemp)
             status=$(curl -sS -o "${body}" -w '%{http_code}' -X DELETE \
               -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
               -H 'Accept: application/json' \
-              --retry 3 --retry-connrefused --max-time 60 \
+              --retry 3 --retry-connrefused --max-time 15 \
               "${COOLIFY_URL}/api/v1/applications/${COOLIFY_APP_UUID}/previews/${number}") || status=000
 
             case "${status}" in
               404)
-                : # already clean, which is the expected answer for almost every pull request
+                : # already clean
                 ;;
               2*)
                 reclaimed=$((reclaimed + 1))
-                echo "| #${number} | reclaimed — preview outlived its closed pull request |" >> /tmp/summary.md
-                echo "::warning::Reclaimed an orphaned preview for closed PR #${number}. Its cleanup on close did not run or did not reach Coolify."
+                echo "| #${number} | reclaimed |" >> "${summary}"
+                echo "::warning::Reclaimed an orphaned preview for closed PR #${number}; cleanup on close did not reach Coolify."
                 ;;
               *)
-                failed=$((failed + 1))
-                echo "| #${number} | FAILED — HTTP ${status} |" >> /tmp/summary.md
-                echo "::error::Coolify returned HTTP ${status} for PR #${number}: $(head -c 200 "${body}")"
+                # Stop on the first failure: an unreachable Coolify is one finding, not one per
+                # pull request. The summary below still reports what was reclaimed before it.
+                failed=1
+                echo "| #${number} | HTTP ${status} |" >> "${summary}"
+                echo "::error::Coolify returned HTTP ${status} for PR #${number}: $(head -c 200 "${body}" | tr '\n' ' ')"
+                break
                 ;;
             esac
           done <<< "${closed}"
@@ -98,9 +102,9 @@ jobs:
             echo "Checked **${checked}** pull requests closed in the last ${DAYS} days."
             echo
             if [ "${reclaimed}" -eq 0 ] && [ "${failed}" -eq 0 ]; then
-              echo "No orphaned previews. Cleanup on close is keeping up."
+              echo "No orphaned previews."
             else
-              cat /tmp/summary.md
+              cat "${summary}"
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
 


### PR DESCRIPTION
## Description

A review of #1461 and #1458 found the reconcile workflow's own justification was wrong, and that the preview guard reads the wrong signal.

**The header comment gave three reasons; two were false.** "It exits without doing anything when `COOLIFY_API_TOKEN` is unset" — this workflow does the same thing, so that is not a gap it closes. "It never runs for a fork" — `cleanup-preview.yml` and the Coolify preview job both gate on `head.repo.full_name == github.repository`, so a fork has no preview to leak. For a comment block whose only job is to justify the file, that is the worst place to be wrong. What survives is the real reason: the delete on close can fail and nothing notices.

**The image guard keyed on the aggregate of five build jobs.** `needs.Docker.result` is the reusable workflow's rollup, so a `postgres-build` failure suppressed a preview whose application-server image had published perfectly. `ci-docker-build.yml` now exposes that one job's result as an output and the guard reads it.

**The `if:` had two dead branches.** With the same-repo term added, `any-code` and `ci-config` gate fork pull requests *only* — while the condition still read like the `Quality`/`Security`/`Test` ones above it. Dominant terms now come first and the comment says what the path filters actually gate.

## Also fixed

| Issue | Change |
|---|---|
| `--limit 200` truncated a list ordered by `createdAt`, filtered on `closedAt` | Window moves server-side to `--search "closed:>="`; row count asserted against the limit |
| `--search` switches `gh` to relevance ordering, so truncation drops arbitrary PRs | That is exactly why the count is asserted rather than trusted |
| One unreachable Coolify produced one `::error::` per PR | Stops on first failure — but still writes the summary, so the run reports what it reclaimed before stopping |
| A newline in a response body truncates a workflow annotation | Body flattened with `tr` |
| `mktemp` inside the loop leaked a file per iteration; `/tmp` instead of `RUNNER_TEMP` | Hoisted, and moved to `RUNNER_TEMP` |
| `timeout-minutes: 10` against a worst case of 53 × `--max-time 60` | `--max-time 15`, timeout 20 |
| Narrative in comments and summary rows | Cut |

## How to test

`date -d` is GNU-only, so the step script was extracted and run on a Linux host against a stubbed Coolify:

| Scenario | Result |
|---|---|
| All previews already gone (404) | `checked=3 reclaimed=0 failed=0`, exit 0, summary reads "No orphaned previews." |
| One orphan (200) | `reclaimed=1`, warning raised, summary row written |
| Coolify error (500) | stops immediately, **summary still written** with both the reclaimed row and the failure row, exit 1 |

That last one is the regression I introduced while applying the review and caught before shipping: failing fast originally skipped the summary, leaving a red X with no record.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No changeset: CI only, nothing under `server/`, `webapp/` or `docker/`.