### PR TITLE
fix(docker): share SCM credentials with the role that runs reviews

### DIFF
--- a/.changeset/worker-scm-credentials.md
+++ b/.changeset/worker-scm-credentials.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews can now read the change they are reviewing. The role that runs a review had no GitHub credentials, so it could not fetch the commit the review was pinned to; every review finished as "insufficient evidence" without ever asking a model. The SCM credentials and the local-checkout setting are now shared by both application roles, so a value the operator sets reaches whichever role needs it.

--- a/docker/compose.app.yaml
+++ b/docker/compose.app.yaml
@@ -21,6 +21,17 @@ x-practice-review-env: &practice-review-env
   SIGNAL_LEDGER_PENDING_LAPSE_AFTER: ${SIGNAL_LEDGER_PENDING_LAPSE_AFTER:-7d}
   SIGNAL_LEDGER_SWEEP_BATCH_SIZE: ${SIGNAL_LEDGER_SWEEP_BATCH_SIZE:-200}
 
+# Both application roles reach the SCM: the server clones on a push, the worker fetches the commit a
+# review pins before it can read a diff. Anchored for the same reason as the block above — a role
+# without these authenticates as nobody, and the review that needed the diff reports insufficient
+# evidence rather than failing.
+x-scm-access-env: &scm-access-env
+  GH_APP_ID: ${GH_APP_ID:-0}
+  GH_APP_PRIVATE_KEY: ${GH_APP_PRIVATE_KEY}
+  GH_APP_PRIVATE_KEY_LOCATION: ${GH_APP_PRIVATE_KEY_LOCATION:-}
+  GH_AUTH_TOKEN: ${GH_AUTH_TOKEN}
+  GIT_CHECKOUT_ENABLED: ${GIT_CHECKOUT_ENABLED:-false}
+
 services:
   webapp:
     image: "ghcr.io/ls1intum/hephaestus/webapp:${IMAGE_TAG}"
@@ -167,11 +178,7 @@ services:
       GITLAB_OAUTH_CLIENT_SECRET: ${GITLAB_OAUTH_CLIENT_SECRET:-}
       GITLAB_OAUTH_BASE_URL: ${GITLAB_OAUTH_BASE_URL:-https://gitlab.com}
       GITLAB_OAUTH_DISPLAY_NAME: ${GITLAB_OAUTH_DISPLAY_NAME:-GitLab}
-      GH_APP_ID: ${GH_APP_ID:-0}
-      GH_APP_PRIVATE_KEY: ${GH_APP_PRIVATE_KEY}
-      GH_APP_PRIVATE_KEY_LOCATION: ${GH_APP_PRIVATE_KEY_LOCATION:-}
       GH_APP_INSTALLATION_URL: ${GH_APP_INSTALLATION_URL:-}
-      GH_AUTH_TOKEN: ${GH_AUTH_TOKEN}
       # Default on: the integration event flow needs NATS in prod (the code-level fallback is off for local dev).
       NATS_ENABLED: ${NATS_ENABLED:-true}
       NATS_DURABLE_CONSUMER_NAME: ${NATS_DURABLE_CONSUMER_NAME:-hephaestus}
@@ -258,9 +265,7 @@ services:
       # a loopback provider URL may be SAVED, the worker's proxy decides whether it may be DIALLED.
       # Leave false in production.
       HEPHAESTUS_LLM_EGRESS_ALLOW_LOOPBACK: ${HEPHAESTUS_LLM_EGRESS_ALLOW_LOOPBACK:-false}
-      # Git checkout (bind-mount repos into agent containers)
-      GIT_CHECKOUT_ENABLED: ${GIT_CHECKOUT_ENABLED:-false}
-      <<: *practice-review-env
+      <<: [*practice-review-env, *scm-access-env]
       GITLAB_WORKSPACE_CREATION: ${GITLAB_WORKSPACE_CREATION:-false}
       # LLM providers are registered at runtime (Instance admin → AI models), not via env vars —
       # the proxy reads each connection's base URL/auth from the catalog per request.
@@ -348,7 +353,7 @@ services:
       JAVA_TOOL_OPTIONS: "-XX:MaxDirectMemorySize=${APP_MAX_DIRECT_MEMORY:-128M}"
       APP_VERSION: ${IMAGE_TAG}
       SPRING_PROFILES_ACTIVE: prod,worker
-      <<: *practice-review-env
+      <<: [*practice-review-env, *scm-access-env]
       HEPHAESTUS_TRUSTED_PROXIES: ${HEPHAESTUS_TRUSTED_PROXIES:-}
       HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST: ${HEPHAESTUS_AGENT_IMAGE_REQUIRE_DIGEST:-true}
       HEPHAESTUS_HUB_URL: ws://application-server:8080/api/workers/connect
@@ -356,10 +361,6 @@ services:
       # Agent job queue (practice review). The queue runs on PostgreSQL — this pod needs no NATS at
       # all (it runs no sync/webhook role), so no NATS_SERVER is set here.
       AGENT_ENABLED: ${AGENT_ENABLED:-false}
-      # PracticeReviewHealthIndicator runs in this role and reports OUT_OF_SERVICE with
-      # GIT_CHECKOUT_DISABLED when the checkout is off, so the worker needs the same flag the
-      # application server gets — the agent bind-mounts a repository it cannot otherwise obtain.
-      GIT_CHECKOUT_ENABLED: ${GIT_CHECKOUT_ENABLED:-false}
       HEPHAESTUS_FABRIC_ROOT: /data/git-repos
       HEPHAESTUS_FABRIC_GC_RETENTION_DAYS: ${HEPHAESTUS_FABRIC_GC_RETENTION_DAYS:-30}
       SANDBOX_DOCKER_HOST: ${SANDBOX_DOCKER_HOST:-unix:///var/run/docker.sock}


### PR DESCRIPTION
## Description

The worker fetches the commit a review pins before it can read a diff, but `GH_APP_ID`, `GH_APP_PRIVATE_KEY` and `GH_AUTH_TOKEN` were forwarded to the application server only. Confirmed on staging:

| Variable | `application-server` | `application-worker` |
|---|---|---|
| `GH_APP_ID` | len 7 | **absent** |
| `GH_APP_PRIVATE_KEY` | len 1674, 27 lines | **absent** |
| `GH_AUTH_TOKEN` | len 40 | **absent** |

So the worker minted no installation token, the fetch was skipped, and every practice review ended the same way:

```
Failed to mint GitHub App installation token: installationId=97640040
Head commit 807afc09 not found locally (no fetch possible)
Completed agent job without model execution, outcome=INSUFFICIENT_EVIDENCE
```

Reviews ran, produced nothing, and reported success — the worst shape for a silent failure.

## What changes

`GIT_CHECKOUT_ENABLED` had already drifted the same way and was fixed by repeating the line per role. That was the wrong shape, and this file says so at the top:

> *"Anchored rather than repeated because forwarding a key to only one of them is silent — the role that does not receive it falls back to the built-in default and the operator's setting does nothing."*

Both now sit in `x-scm-access-env`, which both roles merge via `<<: [*practice-review-env, *scm-access-env]`. The duplicated line and its comment are removed.

`GH_APP_INSTALLATION_URL` deliberately stays on the server — it is a link rendered during workspace creation, not a credential. Verified with `docker compose config`:

```
application-server  GH_APP_ID ✓  GH_APP_PRIVATE_KEY ✓  GH_AUTH_TOKEN ✓  GIT_CHECKOUT_ENABLED ✓  GH_APP_INSTALLATION_URL ✓
application-worker  GH_APP_ID ✓  GH_APP_PRIVATE_KEY ✓  GH_AUTH_TOKEN ✓  GIT_CHECKOUT_ENABLED ✓  GH_APP_INSTALLATION_URL ✗
```

## How to test

After deploying, the worker mints a token and the fetch succeeds, so a review reaches evidence collection instead of `INSUFFICIENT_EVIDENCE`. The failing log lines above disappear.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No new variable and no operator action — this makes values the operator already sets reach the role that needs them.