### PR TITLE
fix(server): stage the timings sidecar the practice runner imports

### DIFF
--- a/.changeset/practice-review-runner-sidecar.md
+++ b/.changeset/practice-review-runner-sidecar.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews run again. The review agent was started without one of the helper scripts it loads, so every run failed inside the sandbox before it reached the model — the job was recorded as failed with no feedback produced.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -18,6 +18,7 @@ public final class PracticeRunnerProfile implements PiRunnerProfile {
     private static final List<String> SIDECARS = List.of(
         "pi-observation-normalize.mjs",
         "pi-runner-usage.mjs",
+        "pi-runner-timings.mjs",
         SandboxLayout.PROVIDER_HELPER_FILENAME
     );
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/RunnerProfileSidecarTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/runtime/RunnerProfileSidecarTest.java
@@ -1,0 +1,52 @@
+package de.tum.cit.aet.hephaestus.agent.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.agent.mentor.MentorRunnerProfile;
+import de.tum.cit.aet.hephaestus.agent.practice.PracticeRunnerProfile;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A runner script imports its sidecars with relative specifiers, so Node resolves them from the
+ * staged directory rather than the classpath: one missing from a profile is not a compile error and
+ * not a boot failure, but ERR_MODULE_NOT_FOUND inside the sandbox on every job it runs.
+ */
+@Tag("unit")
+class RunnerProfileSidecarTest {
+
+    private static final Pattern RELATIVE_IMPORT = Pattern.compile("from \"\\./([^\"]+)\"");
+
+    static Stream<PiRunnerProfile> profiles() {
+        return Stream.of(new PracticeRunnerProfile(), new MentorRunnerProfile());
+    }
+
+    @ParameterizedTest
+    @MethodSource("profiles")
+    void shouldStageEverySidecarItsRunnerImports(PiRunnerProfile profile) throws IOException {
+        assertThat(profile.sidecarScripts())
+            .as("sidecars staged beside %s", profile.runnerScript())
+            .containsAll(relativeImportsOf(profile.runnerScript()));
+    }
+
+    private static Set<String> relativeImportsOf(String script) throws IOException {
+        try (InputStream in = RunnerProfileSidecarTest.class.getResourceAsStream("/agent/" + script)) {
+            assertThat(in).as("%s is on the classpath", script).isNotNull();
+            Matcher matcher = RELATIVE_IMPORT.matcher(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+            Set<String> imports = new LinkedHashSet<>();
+            while (matcher.find()) {
+                imports.add(matcher.group(1));
+            }
+            return imports;
+        }
+    }
+}


### PR DESCRIPTION
## Description

The first practice review to reach the sandbox on staging died there:

```
Cannot find module '/workspace/pi-runner-timings.mjs'
imported from /workspace/.run-pi.mjs
Error [ERR_MODULE_NOT_FOUND]
```

`pi-runner.mjs` imports four sidecars with relative specifiers; `PracticeRunnerProfile` staged three of them. `pi-runner-timings.mjs` was missing.

Node resolves a relative specifier from the **staged directory**, not the classpath — so the omission is not a compile error, not a boot failure, and not visible to any health check. It is a container exiting 1 on every review, with the job recorded as failed and no feedback produced.

The field's own javadoc states the invariant that was broken:

> *"Imported by `SCRIPT` with a relative specifier, so each must be staged beside it."*

## What changes

One entry added to the sidecar list — and a test that derives the required set from the script rather than trusting a hand-maintained list, since a comment did not hold the line:

```java
assertThat(profile.sidecarScripts())
    .as("sidecars staged beside %s", profile.runnerScript())
    .containsAll(relativeImportsOf(profile.runnerScript()));
```

It is parameterised over both `PiRunnerProfile` implementations, so the mentor runner is covered by the same rule. Sidecars themselves import nothing relative today, so a direct scan is sufficient; if that changes the test would need to walk transitively.

## How to test

```
./mvnw test -P'!quick' -Dtest=RunnerProfileSidecarTest
tests=2 failures=0
```

And with the one-line fix reverted, to prove the guard is real rather than decorative:

```
[ERROR] RunnerProfileSidecarTest.shouldStageEverySidecarItsRunnerImports:38
        [sidecars staged beside pi-runner.mjs]
tests=2 failures=1
```

End to end on staging, the same review previously reached the sandbox and exited 1 in 4.5s. After this it should complete against the model.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No operator action.