### PR TITLE
fix(server): re-establish the sandbox image before each run

### DIFF
--- a/.changeset/sandbox-image-self-heal.md
+++ b/.changeset/sandbox-image-self-heal.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice reviews recover on their own when the host reclaims the agent image. The image is only referenced while a review runs, so a host that prunes unused images removes it between reviews — and because it was fetched once at startup, every later review failed to start its container and retried into the same failure. The image is now re-established before each run.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
 import de.tum.cit.aet.hephaestus.agent.proxy.MentorProxyCredentialRegistry;
+import de.tum.cit.aet.hephaestus.agent.runtime.AgentImageProperties;
 import de.tum.cit.aet.hephaestus.agent.sandbox.InteractiveSandboxProperties;
 import de.tum.cit.aet.hephaestus.agent.sandbox.SandboxProperties;
 import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.DockerInteractiveSandboxAdapter;
@@ -133,12 +134,30 @@ public class DockerSandboxConfiguration {
     }
 
     @Bean
+    public SandboxImageGuard sandboxImageGuard(
+        DockerClientOperations ops,
+        AgentImageProperties agentImageProperties,
+        MeterRegistry meterRegistry
+    ) {
+        return image ->
+            ImagePullBootstrapperSupport.applyPolicy(
+                image,
+                agentImageProperties.pullPolicy(),
+                ops,
+                "sandbox.image.pull",
+                meterRegistry,
+                log
+            );
+    }
+
+    @Bean
     public SandboxContainerManager sandboxContainerManager(
         DockerClientOperations ops,
+        SandboxImageGuard imageGuard,
         SandboxProperties properties,
         ExecutorService dockerWaitExecutor
     ) {
-        return new SandboxContainerManager(ops, properties, dockerWaitExecutor);
+        return new SandboxContainerManager(ops, imageGuard, properties, dockerWaitExecutor);
     }
 
     @Bean

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxContainerManager.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxContainerManager.java
@@ -26,6 +26,7 @@ public class SandboxContainerManager {
     private static final int SIGKILL_EXIT_CODE = 137;
 
     private final DockerContainerOperations containerOps;
+    private final SandboxImageGuard imageGuard;
     private final SandboxProperties properties;
 
     /**
@@ -39,10 +40,12 @@ public class SandboxContainerManager {
 
     public SandboxContainerManager(
         DockerContainerOperations containerOps,
+        SandboxImageGuard imageGuard,
         SandboxProperties properties,
         ExecutorService dockerWaitExecutor
     ) {
         this.containerOps = containerOps;
+        this.imageGuard = imageGuard;
         this.properties = properties;
         this.dockerWaitExecutor = dockerWaitExecutor;
     }
@@ -53,6 +56,7 @@ public class SandboxContainerManager {
      * @return the container ID
      */
     public String createContainer(DockerOperations.ContainerSpec spec) {
+        imageGuard.ensurePresent(spec.image());
         return containerOps.createContainer(spec);
     }
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxImageGuard.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxImageGuard.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
+
+/**
+ * Establishes that a sandbox image is on the daemon before a container is created from it.
+ *
+ * <p>The image is referenced only while a job runs, so a host that prunes unused images reclaims it
+ * between jobs. Fetching it once at startup leaves the job's retry to fail identically, because
+ * nothing re-pulls.
+ */
+@FunctionalInterface
+public interface SandboxImageGuard {
+    void ensurePresent(String image);
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxLiveTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxLiveTest.java
@@ -80,7 +80,7 @@ class DockerSandboxLiveTest {
 
         dockerOps = new DockerClientOperations(dockerClient);
         dockerWaitExecutor = Executors.newCachedThreadPool();
-        containerManager = new SandboxContainerManager(dockerOps, properties, dockerWaitExecutor);
+        containerManager = new SandboxContainerManager(dockerOps, image -> {}, properties, dockerWaitExecutor);
         networkManager = new SandboxNetworkManager(dockerOps, properties);
         workspaceManager = new SandboxWorkspaceManager(dockerOps);
         ContainerSecurityPolicy securityPolicy = new ContainerSecurityPolicy(properties, null);

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/RepositoryTreeStagingLiveTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/RepositoryTreeStagingLiveTest.java
@@ -100,7 +100,7 @@ class RepositoryTreeStagingLiveTest {
         );
         DockerClientOperations dockerOps = new DockerClientOperations(dockerClient);
         dockerWaitExecutor = Executors.newCachedThreadPool();
-        containerManager = new SandboxContainerManager(dockerOps, properties, dockerWaitExecutor);
+        containerManager = new SandboxContainerManager(dockerOps, image -> {}, properties, dockerWaitExecutor);
         networkManager = new SandboxNetworkManager(dockerOps, properties);
         sandboxAdapter = new DockerSandboxAdapter(
             networkManager,

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxContainerManagerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxContainerManagerTest.java
@@ -12,6 +12,7 @@ import de.tum.cit.aet.hephaestus.agent.sandbox.SandboxProperties;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxException;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -28,13 +29,14 @@ class SandboxContainerManagerTest extends BaseUnitTest {
     private DockerContainerOperations containerOps;
 
     private SandboxContainerManager manager;
+    private SandboxProperties properties;
     private ExecutorService executor;
 
     private static final String CONTAINER_ID = "abc123";
 
     @BeforeEach
     void setUp() {
-        SandboxProperties properties = new SandboxProperties(
+        properties = new SandboxProperties(
             "unix:///var/run/docker.sock",
             false,
             null,
@@ -49,12 +51,43 @@ class SandboxContainerManagerTest extends BaseUnitTest {
             null
         );
         executor = Executors.newSingleThreadExecutor();
-        manager = new SandboxContainerManager(containerOps, properties, executor);
+        manager = new SandboxContainerManager(containerOps, image -> {}, properties, executor);
     }
 
     @AfterEach
     void tearDown() {
         executor.shutdownNow();
+    }
+
+    @Nested
+    class CreateContainer {
+
+        @Test
+        void shouldEnsureImageIsPresentWhenCreatingContainer() {
+            List<String> guarded = new ArrayList<>();
+            SandboxContainerManager guardedManager = new SandboxContainerManager(
+                containerOps,
+                guarded::add,
+                properties,
+                executor
+            );
+            DockerOperations.ContainerSpec spec = new DockerOperations.ContainerSpec(
+                "ghcr.io/example/agent:latest",
+                List.of("true"),
+                Map.of(),
+                null,
+                null,
+                null,
+                Map.of(),
+                null,
+                List.of()
+            );
+            when(containerOps.createContainer(spec)).thenReturn(CONTAINER_ID);
+
+            guardedManager.createContainer(spec);
+
+            assertThat(guarded).containsExactly("ghcr.io/example/agent:latest");
+        }
     }
 
     @Nested

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
@@ -126,7 +126,7 @@ class DockerInteractiveSandboxLiveTest {
 
         dockerOps = new DockerClientOperations(dockerClient);
         dockerWaitExecutor = Executors.newCachedThreadPool();
-        containerManager = new SandboxContainerManager(dockerOps, sandboxProperties, dockerWaitExecutor);
+        containerManager = new SandboxContainerManager(dockerOps, image -> {}, sandboxProperties, dockerWaitExecutor);
         networkManager = new SandboxNetworkManager(dockerOps, sandboxProperties);
         workspaceManager = new SandboxWorkspaceManager(dockerOps);
         securityPolicy = new ContainerSecurityPolicy(sandboxProperties, null);


### PR DESCRIPTION
## Description

The agent image is referenced **only while a job runs**, so a host that prunes unused images reclaims it between reviews. It was fetched once on `ApplicationReadyEvent`, which turns that into a permanent failure rather than a transient one:

```
Failed to create container from image: ghcr.io/ls1intum/hephaestus/agent-pi:latest
Requeuing job after classified sandbox-infrastructure failure (attempt 2)
retry_count = 3
```

The retry classification is correct and useless — nothing re-pulls, so every attempt hits the same missing image and the review never runs.

Observed on staging: `docker images | grep agent-pi` returned nothing, and a manual `docker pull` succeeded immediately (*"Downloaded newer image"*). The host had just crossed **80%** disk, which is exactly the configured `docker_cleanup_threshold` with `force_docker_cleanup = true`.

## What changes

Container creation applies the same pull policy the startup bootstrapper already uses, so no new mechanism is introduced. Under the default `IF_NOT_PRESENT` this is a local daemon lookup per job and a pull only when the image is genuinely gone; `NEVER` still refuses to fetch.

It goes through a one-method `SandboxImageGuard` rather than three more constructor parameters. My first attempt threaded `DockerImageOperations`, `ImagePullPolicy` and `MeterRegistry` into `SandboxContainerManager` and broke four test call sites — the same "one field, nine call sites" smell flagged in the review of #1456 earlier today, so I backed it out.

## Self-audit before opening

Held to the same bar as the other review findings:

| Finding in my own diff | Change |
|---|---|
| `SandboxImageGuard.NONE` — a no-op constant in production code used only by tests | Removed; tests supply `image -> {}` |
| `LoggerFactory.getLogger(...)` resolved inside the lambda, per job | Uses the configuration class's existing logger |
| Test named `shouldEstablishTheImageBeforeCreatingFromIt` | Renamed to `shouldEnsureImageIsPresentWhenCreatingContainer`, per `server/AGENTS.md` |
| Interface javadoc | Trimmed to the non-obvious why: fetching once at startup leaves the retry to fail identically |

## How to test

```
./mvnw test -P'!quick' -Dtest=SandboxContainerManagerTest
tests=12 failures=0
```

The new test asserts the guard is invoked with the spec's image before `createContainer`. End to end: with the image deleted from the host, a queued review now pulls and runs instead of exhausting its retries.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No operator action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox agent images are now re-established before each review run, preventing host image cleanup from blocking later reviews.
  * Container creation verifies that the required image is available before starting.
* **Tests**
  * Added coverage confirming image preparation is triggered with the requested container image.
  * Updated sandbox integration tests for the new image availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->