### PR TITLE
fix(server): stop the reconciler reaping what it cannot see

### DIFF
--- a/.changeset/sandbox-reconciler-safety.md
+++ b/.changeset/sandbox-reconciler-safety.md
@@ -1,0 +1,11 @@
+---
+---
+
+No user-facing or operator-facing effect. The sweep that removes abandoned agent sandboxes read
+"the job list cannot be read" as "there are no jobs" and deleted every sandbox in flight, and it
+judged a sandbox abandoned the moment it appeared rather than giving a starting one any grace. The
+same sweep also removed the network belonging to a live mentor session, because it matched networks
+by job and a session is not a job. It now stands down when it cannot see what is running, spares a
+sandbox that has only just started, and keeps a network as long as a container still uses it. None
+of this reached a release: agent sandboxes have never shipped, so there is no version an operator
+can be upgrading from where a review or a mentor session was cut short this way.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperations.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperations.java
@@ -17,6 +17,7 @@ import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxException;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxInfrastructureException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -394,7 +395,8 @@ public class DockerClientOperations
                         c.getId(),
                         c.getNames() != null && c.getNames().length > 0 ? c.getNames()[0] : "",
                         c.getLabels() != null ? c.getLabels() : Map.of(),
-                        c.getState() != null ? c.getState() : "unknown"
+                        c.getState() != null ? c.getState() : "unknown",
+                        c.getCreated() != null ? Instant.ofEpochSecond(c.getCreated()) : null
                     )
                 )
                 .toList();

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerOperations.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerOperations.java
@@ -1,7 +1,9 @@
 package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Shared value types for Docker sandbox operations.
@@ -48,7 +50,14 @@ public final class DockerOperations {
 
     public record WaitResult(int exitCode) {}
 
-    public record ContainerInfo(String id, String name, Map<String, String> labels, String state) {}
+    /** {@code createdAt} is null when the daemon reported none — an unknown age counts as young. */
+    public record ContainerInfo(
+        String id,
+        String name,
+        Map<String, String> labels,
+        String state,
+        @Nullable Instant createdAt
+    ) {}
 
     public record NetworkInfo(String id, String name) {}
 }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
@@ -20,6 +20,7 @@ import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -186,9 +187,10 @@ public class DockerSandboxConfiguration {
         AgentJobRepository jobRepository,
         SandboxContainerManager containerManager,
         SandboxNetworkManager networkManager,
-        MeterRegistry meterRegistry
+        MeterRegistry meterRegistry,
+        Clock clock
     ) {
-        return new SandboxReconciler(jobRepository, containerManager, networkManager, meterRegistry);
+        return new SandboxReconciler(jobRepository, containerManager, networkManager, meterRegistry, clock);
     }
 
     @Bean

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconciler.java
@@ -7,7 +7,11 @@ import de.tum.cit.aet.hephaestus.core.WorkspaceAgnostic;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -40,22 +44,30 @@ public class SandboxReconciler {
     private static final Logger log = LoggerFactory.getLogger(SandboxReconciler.class);
     private static final String MDC_RECONCILER_TYPE = "reconciler.type";
 
+    /** A sandbox younger than this is never reaped, so a starting job is not mistaken for an abandoned one. */
+    private static final Duration REAP_GRACE = Duration.ofMinutes(2);
+
     private final AgentJobRepository jobRepository;
     private final SandboxContainerManager containerManager;
     private final SandboxNetworkManager networkManager;
     private final Counter orphanedContainers;
     private final Counter orphanedNetworks;
+    private final Counter completedSweeps;
+    private final Counter skippedSweeps;
     private final Timer reconciliationDuration;
+    private final Clock clock;
 
     public SandboxReconciler(
         AgentJobRepository jobRepository,
         SandboxContainerManager containerManager,
         SandboxNetworkManager networkManager,
-        MeterRegistry meterRegistry
+        MeterRegistry meterRegistry,
+        Clock clock
     ) {
         this.jobRepository = jobRepository;
         this.containerManager = containerManager;
         this.networkManager = networkManager;
+        this.clock = clock;
         this.orphanedContainers = Counter.builder("sandbox.reconciler.orphaned")
             .tag("resource", "container")
             .description("Orphaned containers removed")
@@ -63,6 +75,14 @@ public class SandboxReconciler {
         this.orphanedNetworks = Counter.builder("sandbox.reconciler.orphaned")
             .tag("resource", "network")
             .description("Orphaned networks removed")
+            .register(meterRegistry);
+        this.completedSweeps = Counter.builder("sandbox.reconciler.sweeps")
+            .tag("outcome", "completed")
+            .description("Reconciliation sweeps that ran to completion")
+            .register(meterRegistry);
+        this.skippedSweeps = Counter.builder("sandbox.reconciler.sweeps")
+            .tag("outcome", "skipped")
+            .description("Reconciliation sweeps skipped because an inventory they depend on was unreadable")
             .register(meterRegistry);
         this.reconciliationDuration = Timer.builder("sandbox.reconciler.duration")
             .description("Duration of periodic reconciliation sweeps")
@@ -87,19 +107,35 @@ public class SandboxReconciler {
 
     /** Clean up Docker resources left from previous runs — don't wait for periodic sweep. */
     private void cleanupOrphanedDockerResources() {
-        Set<UUID> activeJobIds;
+        activeJobIds().ifPresent(this::sweep);
+    }
+
+    /** Containers are swept first: what survives there decides which networks are still in use. */
+    private void sweep(Set<UUID> activeJobIds) {
+        cleanupOrphanedContainers(activeJobIds).ifPresent(inUse -> {
+            cleanupOrphanedNetworks(activeJobIds, inUse);
+            completedSweeps.increment();
+        });
+    }
+
+    /**
+     * The jobs that may legitimately own a sandbox, or empty when that set cannot be read. Empty is
+     * not the empty set: a sweep that cannot see the jobs would treat every live sandbox as an orphan.
+     */
+    private Optional<Set<UUID>> activeJobIds() {
         try {
-            activeJobIds = jobRepository
-                .findByStatusIn(List.of(AgentJobStatus.QUEUED, AgentJobStatus.RUNNING))
-                .stream()
-                .map(AgentJob::getId)
-                .collect(Collectors.toSet());
+            return Optional.of(
+                jobRepository
+                    .findByStatusIn(List.of(AgentJobStatus.QUEUED, AgentJobStatus.RUNNING))
+                    .stream()
+                    .map(AgentJob::getId)
+                    .collect(Collectors.toSet())
+            );
         } catch (Exception e) {
-            log.warn("Could not query active jobs — cleaning ALL managed resources: {}", e.getMessage());
-            activeJobIds = Set.of(); // If DB is down, treat everything as orphaned
+            log.warn("Skipping sandbox reconciliation — active jobs are unreadable: {}", e.getMessage());
+            skippedSweeps.increment();
+            return Optional.empty();
         }
-        cleanupOrphanedContainers(activeJobIds);
-        cleanupOrphanedNetworks(activeJobIds);
     }
 
     /** Periodic sweep: clean up orphaned Docker resources. */
@@ -114,58 +150,78 @@ public class SandboxReconciler {
             reconciliationDuration.record(() -> {
                 log.trace("Sandbox reconciler: periodic sweep");
 
-                Set<UUID> activeJobIds;
-                try {
-                    activeJobIds = jobRepository
-                        .findByStatusIn(List.of(AgentJobStatus.QUEUED, AgentJobStatus.RUNNING))
-                        .stream()
-                        .map(AgentJob::getId)
-                        .collect(Collectors.toSet());
-                } catch (Exception e) {
-                    log.warn("Could not query active jobs — cleaning ALL managed resources: {}", e.getMessage());
-                    activeJobIds = Set.of();
-                }
-
-                cleanupOrphanedContainers(activeJobIds);
-                cleanupOrphanedNetworks(activeJobIds);
+                activeJobIds().ifPresent(this::sweep);
             });
         } finally {
             MDC.remove(MDC_RECONCILER_TYPE);
         }
     }
 
-    private void cleanupOrphanedContainers(Set<UUID> activeJobIds) {
+    /**
+     * Removes abandoned containers and reports the ids whose networks are still in use, or empty when
+     * the container inventory is unreadable — the network sweep would then have nothing to spare from.
+     */
+    private Optional<Set<UUID>> cleanupOrphanedContainers(Set<UUID> activeJobIds) {
+        Set<UUID> inUse = new HashSet<>();
         try {
             List<DockerOperations.ContainerInfo> containers = containerManager.listManagedContainers();
             for (DockerOperations.ContainerInfo container : containers) {
+                if (SandboxLabels.KIND_INTERACTIVE.equals(container.labels().get(SandboxLabels.KIND))) {
+                    // A mentor session names its network by session id, which is never an agent-job id.
+                    parseUuid(container.labels().get(SandboxLabels.SESSION_ID)).ifPresent(inUse::add);
+                    continue;
+                }
                 String jobIdStr = container.labels().get(SandboxLabels.JOB_ID);
                 if (jobIdStr == null) {
                     continue;
                 }
                 try {
                     UUID jobId = UUID.fromString(jobIdStr);
-                    if (!activeJobIds.contains(jobId)) {
-                        log.warn("Removing orphaned container: id={}, jobId={}", container.id(), jobId);
-                        containerManager.forceRemove(container.id());
-                        orphanedContainers.increment();
+                    if (activeJobIds.contains(jobId) || isYoung(container)) {
+                        inUse.add(jobId);
+                        continue;
                     }
+                    log.warn("Removing orphaned container: id={}, jobId={}", container.id(), jobId);
+                    containerManager.forceRemove(container.id());
+                    orphanedContainers.increment();
                 } catch (IllegalArgumentException e) {
                     log.warn("Container {} has invalid job-id label: {}", container.id(), jobIdStr);
                 } catch (Exception e) {
+                    // Still there, so its network is still in use.
+                    inUse.add(UUID.fromString(jobIdStr));
                     log.warn("Failed to cleanup orphaned container {}: {}", container.id(), e.getMessage());
                 }
             }
         } catch (Exception e) {
-            log.warn("Failed to scan for orphaned containers: {}", e.getMessage());
+            log.warn("Skipping sandbox reconciliation — managed containers are unreadable: {}", e.getMessage());
+            skippedSweeps.increment();
+            return Optional.empty();
+        }
+        return Optional.of(inUse);
+    }
+
+    /** The job set is read before the container list, so a sandbox started in between is not in it. */
+    private boolean isYoung(DockerOperations.ContainerInfo container) {
+        return container.createdAt() == null || container.createdAt().isAfter(clock.instant().minus(REAP_GRACE));
+    }
+
+    private static Optional<UUID> parseUuid(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(UUID.fromString(value));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
         }
     }
 
-    private void cleanupOrphanedNetworks(Set<UUID> activeJobIds) {
+    private void cleanupOrphanedNetworks(Set<UUID> activeJobIds, Set<UUID> inUse) {
         try {
             List<DockerOperations.NetworkInfo> networks = networkManager.listOrphanedNetworks();
 
             for (DockerOperations.NetworkInfo network : networks) {
-                // Extract job ID from network name "agent-net-{jobId}"
+                // The suffix is a job id, or a mentor session id for an interactive sandbox.
                 String name = network.name();
                 if (!name.startsWith(SandboxNetworkManager.NETWORK_PREFIX)) {
                     continue;
@@ -173,7 +229,7 @@ public class SandboxReconciler {
                 String jobIdStr = name.substring(SandboxNetworkManager.NETWORK_PREFIX.length());
                 try {
                     UUID jobId = UUID.fromString(jobIdStr);
-                    if (!activeJobIds.contains(jobId)) {
+                    if (!activeJobIds.contains(jobId) && !inUse.contains(jobId)) {
                         log.warn("Removing orphaned network: id={}, name={}", network.id(), name);
                         // Disconnect app-server before removing — Docker refuses to remove
                         // networks with connected containers. Normal cleanup may have failed

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxContainerManagerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxContainerManagerTest.java
@@ -12,6 +12,7 @@ import de.tum.cit.aet.hephaestus.agent.sandbox.SandboxProperties;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxException;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -247,7 +248,7 @@ class SandboxContainerManagerTest extends BaseUnitTest {
         @Test
         void shouldListByManagedLabel() {
             when(containerOps.listContainersByLabel("hephaestus.managed", "true")).thenReturn(
-                List.of(new DockerOperations.ContainerInfo("c1", "/test", Map.of(), "running"))
+                List.of(new DockerOperations.ContainerInfo("c1", "/test", Map.of(), "running", Instant.EPOCH))
             );
 
             var containers = manager.listManagedContainers();

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconcilerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/SandboxReconcilerTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,6 +13,10 @@ import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobStatus;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -32,13 +37,50 @@ class SandboxReconcilerTest extends BaseUnitTest {
     @Mock
     private SandboxNetworkManager networkManager;
 
+    private static final Instant NOW = Instant.parse("2026-08-21T10:00:00Z");
+    /** Older than the grace window, so a fixture is reapable unless it opts out. */
+    private static final Instant LONG_AGO = NOW.minus(Duration.ofDays(1));
+
     private SandboxReconciler reconciler;
     private SimpleMeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        reconciler = new SandboxReconciler(jobRepository, containerManager, networkManager, meterRegistry);
+        reconciler = new SandboxReconciler(
+            jobRepository,
+            containerManager,
+            networkManager,
+            meterRegistry,
+            Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    private static DockerOperations.ContainerInfo container(String id, UUID jobId, Instant createdAt) {
+        return new DockerOperations.ContainerInfo(
+            id,
+            "test",
+            Map.of(SandboxLabels.MANAGED, "true", SandboxLabels.JOB_ID, jobId.toString()),
+            "running",
+            createdAt
+        );
+    }
+
+    private static DockerOperations.ContainerInfo mentorContainer(String id, UUID sessionId) {
+        return new DockerOperations.ContainerInfo(
+            id,
+            "test",
+            Map.of(
+                SandboxLabels.MANAGED,
+                "true",
+                SandboxLabels.KIND,
+                SandboxLabels.KIND_INTERACTIVE,
+                SandboxLabels.SESSION_ID,
+                sessionId.toString()
+            ),
+            "running",
+            LONG_AGO
+        );
     }
 
     @Nested
@@ -68,14 +110,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
 
             when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
             when(containerManager.listManagedContainers()).thenReturn(
-                List.of(
-                    new DockerOperations.ContainerInfo(
-                        "orphaned-ctr",
-                        "test",
-                        Map.of("hephaestus.job-id", orphanedJobId.toString()),
-                        "exited"
-                    )
-                )
+                List.of(container("orphaned-ctr", orphanedJobId, LONG_AGO))
             );
             when(networkManager.listOrphanedNetworks()).thenReturn(
                 List.of(new DockerOperations.NetworkInfo("net-1", "agent-net-" + orphanedJobId))
@@ -96,14 +131,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
             // containerId NOT set — label-based matching should still find the container
 
             when(containerManager.listManagedContainers()).thenReturn(
-                List.of(
-                    new DockerOperations.ContainerInfo(
-                        "active-container",
-                        "test",
-                        Map.of("hephaestus.managed", "true", "hephaestus.job-id", jobId.toString()),
-                        "running"
-                    )
-                )
+                List.of(container("active-container", jobId, LONG_AGO))
             );
             when(jobRepository.findByStatusIn(any())).thenReturn(List.of(activeJob));
             when(networkManager.listOrphanedNetworks()).thenReturn(List.of());
@@ -136,14 +164,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
             when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
 
             when(containerManager.listManagedContainers()).thenReturn(
-                List.of(
-                    new DockerOperations.ContainerInfo(
-                        orphanedContainerId,
-                        "test",
-                        Map.of("hephaestus.job-id", orphanedJobId.toString()),
-                        "exited"
-                    )
-                )
+                List.of(container(orphanedContainerId, orphanedJobId, LONG_AGO))
             );
 
             when(networkManager.listOrphanedNetworks()).thenReturn(List.of());
@@ -168,14 +189,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
             when(jobRepository.findByStatusIn(any())).thenReturn(List.of(activeJob));
 
             when(containerManager.listManagedContainers()).thenReturn(
-                List.of(
-                    new DockerOperations.ContainerInfo(
-                        containerId,
-                        "test",
-                        Map.of("hephaestus.job-id", activeJobId.toString()),
-                        "running"
-                    )
-                )
+                List.of(container(containerId, activeJobId, LONG_AGO))
             );
 
             when(networkManager.listOrphanedNetworks()).thenReturn(List.of());
@@ -215,20 +229,7 @@ class SandboxReconcilerTest extends BaseUnitTest {
             when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
 
             when(containerManager.listManagedContainers()).thenReturn(
-                List.of(
-                    new DockerOperations.ContainerInfo(
-                        "ctr-1",
-                        "t1",
-                        Map.of("hephaestus.job-id", jobId1.toString()),
-                        "exited"
-                    ),
-                    new DockerOperations.ContainerInfo(
-                        "ctr-2",
-                        "t2",
-                        Map.of("hephaestus.job-id", jobId2.toString()),
-                        "exited"
-                    )
-                )
+                List.of(container("ctr-1", jobId1, LONG_AGO), container("ctr-2", jobId2, LONG_AGO))
             );
 
             doThrow(new RuntimeException("stuck container")).when(containerManager).forceRemove("ctr-1");
@@ -241,47 +242,144 @@ class SandboxReconcilerTest extends BaseUnitTest {
         }
 
         @Test
-        void shouldContinueNetworkCleanupOnContainerScanFailure() {
-            UUID orphanedJobId = UUID.randomUUID();
-
+        void shouldReapNoNetworksWhenTheContainerInventoryCannotBeRead() {
             when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
-
             when(containerManager.listManagedContainers()).thenThrow(new RuntimeException("Docker unreachable"));
-
-            when(networkManager.listOrphanedNetworks()).thenReturn(
-                List.of(new DockerOperations.NetworkInfo("net-1", "agent-net-" + orphanedJobId))
-            );
+            // Orphaned by the job set alone; only the unreadable inventory can spare it.
+            lenient()
+                .when(networkManager.listOrphanedNetworks())
+                .thenReturn(List.of(new DockerOperations.NetworkInfo("net-live", "agent-net-" + UUID.randomUUID())));
 
             reconciler.periodicReconciliation();
 
-            verify(networkManager).removeNetwork("net-1");
+            verify(networkManager, never()).removeNetwork(any());
+            assertThat(meterRegistry.counter("sandbox.reconciler.sweeps", "outcome", "skipped").count()).isEqualTo(1.0);
         }
 
         @Test
-        void shouldRemoveEvenRunningContainersWhenTheDbQueryFails() {
-            UUID orphanedJobId = UUID.randomUUID();
+        void shouldReapNothingWhenTheActiveJobSetCannotBeRead() {
+            UUID jobId = UUID.randomUUID();
 
+            // Resources that a sweep running on an empty job set would reap, so the assertions below
+            // distinguish "stood down" from "ran and found nothing".
             when(jobRepository.findByStatusIn(any())).thenThrow(new RuntimeException("DB unreachable"));
+            lenient()
+                .when(containerManager.listManagedContainers())
+                .thenReturn(List.of(container("ctr-live", jobId, LONG_AGO)));
+            lenient()
+                .when(networkManager.listOrphanedNetworks())
+                .thenReturn(List.of(new DockerOperations.NetworkInfo("net-live", "agent-net-" + jobId)));
 
+            reconciler.periodicReconciliation();
+
+            verify(containerManager, never()).forceRemove(any());
+            verify(networkManager, never()).disconnectAppServer(any());
+            verify(networkManager, never()).removeNetwork(any());
+            assertThat(meterRegistry.counter("sandbox.reconciler.sweeps", "outcome", "skipped").count()).isEqualTo(1.0);
+        }
+
+        @Test
+        void shouldNotReapAContainerWhenItIsYoungerThanTheGraceWindow() {
+            when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
             when(containerManager.listManagedContainers()).thenReturn(
-                List.of(
-                    new DockerOperations.ContainerInfo(
-                        "ctr-1",
-                        "test",
-                        Map.of("hephaestus.job-id", orphanedJobId.toString()),
-                        "running"
-                    )
-                )
+                List.of(container("ctr-young", UUID.randomUUID(), NOW.minus(Duration.ofSeconds(119))))
             );
+            when(networkManager.listOrphanedNetworks()).thenReturn(List.of());
 
+            reconciler.periodicReconciliation();
+
+            verify(containerManager, never()).forceRemove(any());
+        }
+
+        @Test
+        void shouldReapAContainerWhenItIsOlderThanTheGraceWindow() {
+            when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
+            when(containerManager.listManagedContainers()).thenReturn(
+                List.of(container("ctr-old", UUID.randomUUID(), NOW.minus(Duration.ofSeconds(121))))
+            );
+            when(networkManager.listOrphanedNetworks()).thenReturn(List.of());
+
+            reconciler.periodicReconciliation();
+
+            verify(containerManager).forceRemove("ctr-old");
+        }
+
+        @Test
+        void shouldNotReapAContainerWhenTheDaemonReportedNoCreationTime() {
+            when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
+            when(containerManager.listManagedContainers()).thenReturn(
+                List.of(container("ctr-ageless", UUID.randomUUID(), null))
+            );
+            when(networkManager.listOrphanedNetworks()).thenReturn(List.of());
+
+            reconciler.periodicReconciliation();
+
+            verify(containerManager, never()).forceRemove(any());
+        }
+
+        @Test
+        void shouldKeepANetworkWhenALiveMentorSessionOwnsIt() {
+            UUID sessionId = UUID.randomUUID();
+
+            when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
+            when(containerManager.listManagedContainers()).thenReturn(
+                List.of(mentorContainer("ctr-mentor", sessionId))
+            );
             when(networkManager.listOrphanedNetworks()).thenReturn(
-                List.of(new DockerOperations.NetworkInfo("net-1", "agent-net-" + orphanedJobId))
+                List.of(new DockerOperations.NetworkInfo("net-mentor", "agent-net-" + sessionId))
             );
 
             reconciler.periodicReconciliation();
 
-            verify(containerManager).forceRemove("ctr-1");
-            verify(networkManager).removeNetwork("net-1");
+            verify(networkManager, never()).disconnectAppServer(any());
+            verify(networkManager, never()).removeNetwork(any());
+        }
+
+        @Test
+        void shouldKeepANetworkWhenItsContainerIsInsideTheGraceWindow() {
+            UUID jobId = UUID.randomUUID();
+
+            when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
+            when(containerManager.listManagedContainers()).thenReturn(
+                List.of(container("ctr-young", jobId, NOW.minus(Duration.ofSeconds(30))))
+            );
+            when(networkManager.listOrphanedNetworks()).thenReturn(
+                List.of(new DockerOperations.NetworkInfo("net-young", "agent-net-" + jobId))
+            );
+
+            reconciler.periodicReconciliation();
+
+            verify(networkManager, never()).removeNetwork(any());
+        }
+
+        @Test
+        void shouldKeepANetworkWhenItsContainerCouldNotBeRemoved() {
+            UUID jobId = UUID.randomUUID();
+
+            when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
+            when(containerManager.listManagedContainers()).thenReturn(List.of(container("ctr-stuck", jobId, LONG_AGO)));
+            doThrow(new RuntimeException("stuck container")).when(containerManager).forceRemove("ctr-stuck");
+            when(networkManager.listOrphanedNetworks()).thenReturn(
+                List.of(new DockerOperations.NetworkInfo("net-stuck", "agent-net-" + jobId))
+            );
+
+            reconciler.periodicReconciliation();
+
+            verify(networkManager, never()).removeNetwork(any());
+        }
+
+        @Test
+        void shouldCountASweepThatRanToCompletion() {
+            when(jobRepository.findByStatusIn(any())).thenReturn(List.of());
+            when(containerManager.listManagedContainers()).thenReturn(List.of());
+            when(networkManager.listOrphanedNetworks()).thenReturn(List.of());
+
+            reconciler.periodicReconciliation();
+
+            assertThat(meterRegistry.counter("sandbox.reconciler.sweeps", "outcome", "completed").count()).isEqualTo(
+                1.0
+            );
+            assertThat(meterRegistry.counter("sandbox.reconciler.sweeps", "outcome", "skipped").count()).isZero();
         }
 
         @Test


### PR DESCRIPTION
## Description

The sweep that removes abandoned agent sandboxes treated an unreadable job list as an empty one:

```java
catch (Exception e) {
    log.warn("Could not query active jobs — cleaning ALL managed resources: {}", e.getMessage());
    activeJobIds = Set.of(); // If DB is down, treat everything as orphaned
}
```

Every live sandbox then matched "no job owns this" and was force-removed. From the incident that found it — a practice review 14 model calls and 209,017 input tokens in:

```
WARN  SandboxReconciler - Could not query active jobs — cleaning ALL managed resources: ...
WARN  SandboxReconciler - Removing orphaned container: id=..., jobId=...
ERROR AgentJobExecutor  - Sandbox exited with code 137
WARN  SandboxContainerManager - Failed to collect logs: 404 No such container
```

The container was gone before log collection ran, so the kill destroyed the evidence of itself and the incident read as if the review had crashed on its own.

**An unreadable set is not an empty set.** `activeJobIds()` returns `Optional.empty()` on failure and both call sites skip the sweep. No backoff, no circuit breaker: the operation is already periodic and idempotent, so the next `@Scheduled` tick *is* the retry. This is what Kubernetes' garbage collector does literally (`if len(newResources) == 0 { skip; return }`), and what the node lifecycle controller does when it cannot see the fleet — it stops evicting rather than evicting on a partial view.

### Three more ways the sweep could reap something live

All in the same two methods.

**It judged a container abandoned the instant it appeared.** The job set is read before the container list, so a sandbox started between the two reads is legitimately absent from it. Containers now carry `createdAt` from the same `listContainers` payload — no extra `inspect` round-trip — and one younger than `REAP_GRACE` (2 min, matching `AgentJobZombieSweeper.ORPHAN_STARTUP_GRACE`) is left alone. `Container.getCreated()` is nullable, and an unknown age counts as **young**: the one case the check cannot judge must not be the case it kills.

**It removed the network of a live mentor session.** Interactive sandboxes name their network `agent-net-{sessionId}` (`DockerInteractiveSandboxAdapter:141`) and the sweep matched network suffixes against job ids. A session id is never a job id, so on every 60-second tick it called `disconnectAppServer` on every live session's network — severing the agent from the LLM proxy it reaches on that IP, well inside the 300s idle TTL. The container pass now reports which ids are still in use, session ids included, and the network pass honours them. That also closes the mismatch where a spared young container promptly lost its network.

**It cleaned networks after failing to read the container inventory.** The same defect one level down, caught by CodeRabbit on this PR after the first push: `cleanupOrphanedContainers` swallowed a `listManagedContainers()` failure and returned an empty in-use set, which the network pass could not distinguish from "nothing is running". It now returns `Optional.empty()` on that failure and the network sweep is skipped with it. `shouldContinueNetworkCleanupOnContainerScanFailure` asserted the old behaviour and is replaced by `shouldReapNoNetworksWhenTheContainerInventoryCannotBeRead`. A container whose removal fails also stays in the in-use set — it is still there, so it is still using its network.

### Metric

`sandbox.reconciler.skipped` becomes `sandbox.reconciler.sweeps` tagged `outcome=completed|skipped`. It matches how `sandbox.executions` is already tagged, and gives the skip counter the denominator it needs to be alertable — "the sweep stood down and is reaping nothing" is a silent-degradation signal, and a bare failure counter has no ratio.

### Test that pinned the bug

`shouldRemoveEvenRunningContainersWhenTheDbQueryFails` encoded the fatal behaviour as intended and is replaced by `shouldReapNothingWhenTheActiveJobSetCannotBeRead`. The suite moves to `Clock.fixed` (matching 14 other call sites in this repo) so the grace window is pinned at 119s/121s rather than being unfalsifiable against wall-clock, and a fixture factory replaces seven open-coded `ContainerInfo` literals.

## How to test

```bash
cd server && ./mvnw test -P'!quick' -Dtest='SandboxReconcilerTest,SandboxContainerManagerTest,DockerClientOperationsTest'
# SandboxReconcilerTest      18 tests, 0 failures
# SandboxContainerManagerTest 12 tests, 0 failures
# DockerClientOperationsTest  21 tests, 0 failures
```

On a live worker: stop PostgreSQL while a review is running. Before, the next sweep force-removes the container and the job dies with exit 137; after, the log reads `Skipping sandbox reconciliation — active jobs are unreadable` and the review completes.

### Every guard is mutation-tested

A test that cannot fail is not a guard, so each invariant was reverted individually against the suite:

| Reverted invariant | Suite |
|---|---|
| Unreadable job set treated as empty | ❌ red |
| Unreadable container inventory treated as empty | ❌ red |
| Mentor-session network sparing removed | ❌ red |
| Unknown creation time becomes reapable | ❌ red |
| Failed removal drops the container from the in-use set | ❌ red |

**Two of these passed on the first attempt and had to be fixed.** An unstubbed Mockito collection returns empty, so `shouldReapNothingWhenTheActiveJobSetCannotBeRead` and `shouldReapNoNetworksWhenTheContainerInventoryCannotBeRead` were asserting that nothing was reaped from an inventory that was empty anyway — they proved nothing was *found*, not that the sweep stood down. Both now stage a container and a network the sweep would reap if the guard were gone.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

Empty changeset: agent sandboxes have never shipped — `CHANGELOG.md` has no mention of them, `SandboxReconciler` postdates every release, and the current version is `0.73.2`. No operator has had a review or a mentor session cut short this way, so an entry claiming a symptom removed would assert a release that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZADQeSx6zQNNqsdu7AAqZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cleanup when sandbox or job information cannot be read safely.
  * Added a grace period for newly created sandboxes and protected interactive sandboxes from premature removal.
  * Preserved networks still used by active or recently created containers.
  * Improved handling of containers with unavailable creation timestamps.

* **Tests**
  * Added coverage for safe cleanup behavior, grace periods, and network preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
