### PR TITLE
fix(server): give docker wait a timeout the container can outlive

### DIFF
--- a/.changeset/sandbox-streaming-deadline.md
+++ b/.changeset/sandbox-streaming-deadline.md
@@ -1,0 +1,10 @@
+---
+---
+
+No user-facing or operator-facing effect. Waiting for an agent container to exit shared a Docker
+connection with ordinary requests, and that connection carried a socket timeout — so a review still
+working after thirty minutes had its wait torn down and was reported as failed. The wait now runs on
+its own connection whose timeout sits above the longest run a sandbox is allowed, which cannot cut a
+legitimate wait short but still reclaims the connection if the daemon stops answering. None of this
+reached a release: agent sandboxes have never shipped, so there is no version an operator can be
+upgrading from where a long review failed this way.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperations.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperations.java
@@ -17,6 +17,7 @@ import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxException;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxInfrastructureException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,9 @@ public class DockerClientOperations
     private static final Logger log = LoggerFactory.getLogger(DockerClientOperations.class);
     private static final int LOG_COLLECTION_TIMEOUT_SECONDS = 30;
 
+    /** A pull that has not finished by here is treated as failed; the RPC client's idle timeout sits above it. */
+    static final Duration IMAGE_PULL_TIMEOUT = Duration.ofMinutes(5);
+
     /**
      * Maximum log output to collect from a container (prevents OOM from runaway output). This is
      * the <em>collection</em> limit; see {@link DockerSandboxAdapter#MAX_LOG_EVENT_BYTES} for the
@@ -46,8 +50,12 @@ public class DockerClientOperations
 
     private final DockerClient dockerClient;
 
-    public DockerClientOperations(DockerClient dockerClient) {
+    /** `docker wait` is silent until the container exits, so it needs a socket timeout no RPC call wants. */
+    private final DockerClient streamingClient;
+
+    public DockerClientOperations(DockerClient dockerClient, DockerClient streamingClient) {
         this.dockerClient = dockerClient;
+        this.streamingClient = streamingClient;
     }
 
     @Override
@@ -83,10 +91,13 @@ public class DockerClientOperations
         try {
             log.info("Pulling Docker image: {}", image);
             long startMs = System.currentTimeMillis();
-            boolean completed = dockerClient.pullImageCmd(image).start().awaitCompletion(5, TimeUnit.MINUTES);
+            boolean completed = dockerClient
+                .pullImageCmd(image)
+                .start()
+                .awaitCompletion(IMAGE_PULL_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
             long durationMs = System.currentTimeMillis() - startMs;
             if (!completed) {
-                log.warn("Docker pull timed out after 5 min: image={}", image);
+                log.warn("Docker pull timed out after {}: image={}", IMAGE_PULL_TIMEOUT, image);
                 return false;
             }
             log.info("Pulled Docker image in {} ms: {}", durationMs, image);
@@ -249,7 +260,7 @@ public class DockerClientOperations
     @Override
     public DockerOperations.WaitResult waitContainer(String containerId) {
         try {
-            var callback = dockerClient.waitContainerCmd(containerId).start();
+            var callback = streamingClient.waitContainerCmd(containerId).start();
             try {
                 int exitCode = callback.awaitStatusCode();
                 log.debug("Container {} exited with code {}", containerId, exitCode);

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfiguration.java
@@ -14,6 +14,7 @@ import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.InteractiveSan
 import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.InteractiveSandboxRegistry;
 import de.tum.cit.aet.hephaestus.agent.sandbox.docker.interactive.StdinWriteWatchdog;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.InteractiveSandboxService;
+import de.tum.cit.aet.hephaestus.agent.sandbox.spi.ResourceLimits;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxException;
 import de.tum.cit.aet.hephaestus.agent.sandbox.spi.SandboxManager;
 import de.tum.cit.aet.hephaestus.core.runtime.RuntimeRole;
@@ -27,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -55,16 +57,55 @@ public class DockerSandboxConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(DockerSandboxConfiguration.class);
 
-    /** Connections per container: create/start, wait, logs/copy. */
-    private static final int CONNECTIONS_PER_CONTAINER = 3;
+    /** RPC connections per container: create/start, logs, and a copy-out lease held while it is read. */
+    private static final int RPC_CONNECTIONS_PER_CONTAINER = 3;
 
     private static final Duration HTTP_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
 
-    /** docker wait/logs can block for the full container lifetime. */
-    private static final Duration HTTP_RESPONSE_TIMEOUT = Duration.ofMinutes(30);
+    /**
+     * Idle timeout, not a deadline: Apache installs responseTimeout as the socket timeout for the
+     * whole exchange, so it bounds the gap between reads and a call that keeps producing bytes runs
+     * as long as it likes. Every RPC call carries its own budget, so this only has to reclaim the
+     * connection when the daemon goes silent — generous enough that a slow image layer or a large
+     * archive upload never trips it.
+     */
+    static final Duration HTTP_RESPONSE_TIMEOUT = Duration.ofMinutes(30);
+
+    /**
+     * `docker wait` sends nothing until the container exits, so for it the idle timeout is a ceiling
+     * on the container's life. Sitting above {@link ResourceLimits#MAX_RUNTIME} it can never cut a
+     * legitimate wait short, while still reclaiming a connection the daemon has abandoned —
+     * docker-java's reader thread only ever gets an interrupt, which a blocking read ignores.
+     */
+    static final Duration HTTP_STREAMING_RESPONSE_TIMEOUT = ResourceLimits.MAX_RUNTIME.plusMinutes(10);
+
+    /** Calls whose response body is the stream. One wait per container, and nothing else. */
+    @Bean(name = "dockerStreamingClient", destroyMethod = "close")
+    public DockerClient dockerStreamingClient(SandboxProperties properties) {
+        return buildClient(
+            properties,
+            HTTP_STREAMING_RESPONSE_TIMEOUT,
+            properties.maxConcurrentContainers(),
+            "streaming"
+        );
+    }
 
     @Bean(destroyMethod = "close")
     public DockerClient dockerClient(SandboxProperties properties) {
+        return buildClient(
+            properties,
+            HTTP_RESPONSE_TIMEOUT,
+            properties.maxConcurrentContainers() * RPC_CONNECTIONS_PER_CONTAINER,
+            "rpc"
+        );
+    }
+
+    private DockerClient buildClient(
+        SandboxProperties properties,
+        Duration responseTimeout,
+        int maxConnections,
+        String kind
+    ) {
         var configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder()
             .withDockerHost(properties.dockerHost())
             .withDockerTlsVerify(properties.tlsVerify());
@@ -78,24 +119,30 @@ public class DockerSandboxConfiguration {
         var httpClient = new ApacheDockerHttpClient.Builder()
             .dockerHost(config.getDockerHost())
             .sslConfig(config.getSSLConfig())
-            .maxConnections(properties.maxConcurrentContainers() * CONNECTIONS_PER_CONTAINER)
+            .maxConnections(maxConnections)
             .connectionTimeout(HTTP_CONNECTION_TIMEOUT)
-            .responseTimeout(HTTP_RESPONSE_TIMEOUT)
+            .responseTimeout(responseTimeout)
             .build();
 
         DockerClient client = DockerClientImpl.getInstance(config, httpClient);
         log.info(
-            "Docker sandbox client configured: host={}, tlsVerify={}",
+            "Docker sandbox client configured: kind={}, host={}, tlsVerify={}, responseTimeout={}, maxConnections={}",
+            kind,
             properties.dockerHost(),
-            properties.tlsVerify()
+            properties.tlsVerify(),
+            responseTimeout,
+            maxConnections
         );
 
         return client;
     }
 
     @Bean
-    public DockerClientOperations dockerClientOperations(DockerClient dockerClient) {
-        return new DockerClientOperations(dockerClient);
+    public DockerClientOperations dockerClientOperations(
+        DockerClient dockerClient,
+        @Qualifier("dockerStreamingClient") DockerClient dockerStreamingClient
+    ) {
+        return new DockerClientOperations(dockerClient, dockerStreamingClient);
     }
 
     @Bean

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperationsTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerClientOperationsTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.github.dockerjava.api.DockerClient;
@@ -52,11 +53,14 @@ class DockerClientOperationsTest extends BaseUnitTest {
     @Mock
     private DockerClient dockerClient;
 
+    @Mock
+    private DockerClient streamingClient;
+
     private DockerClientOperations ops;
 
     @BeforeEach
     void setUp() {
-        ops = new DockerClientOperations(dockerClient);
+        ops = new DockerClientOperations(dockerClient, streamingClient);
     }
 
     @Nested
@@ -498,13 +502,26 @@ class DockerClientOperationsTest extends BaseUnitTest {
         void shouldReturnExitCode() {
             WaitContainerCmd cmd = mock(WaitContainerCmd.class);
             WaitContainerResultCallback callback = mock(WaitContainerResultCallback.class);
-            when(dockerClient.waitContainerCmd("ctr-1")).thenReturn(cmd);
+            when(streamingClient.waitContainerCmd("ctr-1")).thenReturn(cmd);
             when(cmd.start()).thenReturn(callback);
             when(callback.awaitStatusCode()).thenReturn(42);
 
             DockerOperations.WaitResult result = ops.waitContainer("ctr-1");
 
             assertThat(result.exitCode()).isEqualTo(42);
+        }
+
+        @Test
+        void shouldNotUseTheRpcClientWhenWaitingForAContainer() {
+            WaitContainerCmd cmd = mock(WaitContainerCmd.class);
+            WaitContainerResultCallback callback = mock(WaitContainerResultCallback.class);
+            when(streamingClient.waitContainerCmd("ctr-1")).thenReturn(cmd);
+            when(cmd.start()).thenReturn(callback);
+            when(callback.awaitStatusCode()).thenReturn(0);
+
+            ops.waitContainer("ctr-1");
+
+            verifyNoInteractions(dockerClient);
         }
     }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfigurationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxConfigurationTest.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.hephaestus.agent.sandbox.docker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.tum.cit.aet.hephaestus.agent.sandbox.spi.ResourceLimits;
+import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
+import org.junit.jupiter.api.Test;
+
+class DockerSandboxConfigurationTest extends BaseUnitTest {
+
+    @Test
+    void shouldOutliveTheLongestSandboxWhenWaitingForAContainerToExit() {
+        // `docker wait` is silent until the container exits, so this timeout is a ceiling on the
+        // container's life. At or below MAX_RUNTIME it would cut a legitimate wait short.
+        assertThat(DockerSandboxConfiguration.HTTP_STREAMING_RESPONSE_TIMEOUT).isGreaterThan(
+            ResourceLimits.MAX_RUNTIME
+        );
+    }
+
+    @Test
+    void shouldGiveOrdinaryRequestsMoreThanTheLongestBudgetedCallCanTake() {
+        // pullImage budgets itself 5 minutes; a shorter idle timeout would pre-empt that budget.
+        assertThat(DockerSandboxConfiguration.HTTP_RESPONSE_TIMEOUT).isGreaterThan(
+            DockerClientOperations.IMAGE_PULL_TIMEOUT
+        );
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxLiveTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/DockerSandboxLiveTest.java
@@ -78,7 +78,7 @@ class DockerSandboxLiveTest {
             new ApacheDockerHttpClient.Builder().dockerHost(URI.create("unix:///var/run/docker.sock")).build()
         );
 
-        dockerOps = new DockerClientOperations(dockerClient);
+        dockerOps = new DockerClientOperations(dockerClient, dockerClient);
         dockerWaitExecutor = Executors.newCachedThreadPool();
         containerManager = new SandboxContainerManager(dockerOps, image -> {}, properties, dockerWaitExecutor);
         networkManager = new SandboxNetworkManager(dockerOps, properties);

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/RepositoryTreeStagingLiveTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/RepositoryTreeStagingLiveTest.java
@@ -98,7 +98,7 @@ class RepositoryTreeStagingLiveTest {
             DefaultDockerClientConfig.createDefaultConfigBuilder().build(),
             new ApacheDockerHttpClient.Builder().dockerHost(URI.create("unix:///var/run/docker.sock")).build()
         );
-        DockerClientOperations dockerOps = new DockerClientOperations(dockerClient);
+        DockerClientOperations dockerOps = new DockerClientOperations(dockerClient, dockerClient);
         dockerWaitExecutor = Executors.newCachedThreadPool();
         containerManager = new SandboxContainerManager(dockerOps, image -> {}, properties, dockerWaitExecutor);
         networkManager = new SandboxNetworkManager(dockerOps, properties);

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/sandbox/docker/interactive/DockerInteractiveSandboxLiveTest.java
@@ -124,7 +124,7 @@ class DockerInteractiveSandboxLiveTest {
             new ApacheDockerHttpClient.Builder().dockerHost(URI.create("unix:///var/run/docker.sock")).build()
         );
 
-        dockerOps = new DockerClientOperations(dockerClient);
+        dockerOps = new DockerClientOperations(dockerClient, dockerClient);
         dockerWaitExecutor = Executors.newCachedThreadPool();
         containerManager = new SandboxContainerManager(dockerOps, image -> {}, sandboxProperties, dockerWaitExecutor);
         networkManager = new SandboxNetworkManager(dockerOps, sandboxProperties);


### PR DESCRIPTION
> Stacked on #1481. The two changes are independent and can be reviewed in either order — the stack exists so they do not conflict in `DockerSandboxConfiguration.java` and `DockerClientOperations.java`.

## Description

`waitContainer` shared the RPC Docker client, whose Apache builder carries `responseTimeout(30m)`. Apache installs that as the socket timeout for the whole exchange, and `GET /containers/{id}/wait` sends **zero bytes** until the container exits — so for that one call, an idle timeout is a ceiling on the container's life. A review still working at thirty minutes had its wait torn down and was reported as failed.

**It is an idle timeout, not a deadline.** Apache is explicit: *"response timeout is not a deadline. Its absolute value can be exceeded."* An exchange that keeps producing bytes runs indefinitely under any value. That is precisely why no other call is affected, and it is worth stating because it is the opposite of what the name suggests:

| Call | Why 30 minutes never binds |
| --- | --- |
| `pullImageCmd` | self-bounds at `awaitCompletion(5, MINUTES)`; layers stream continuously |
| `logContainerCmd` | `withFollowStream(false)`, bounded at 30s; body streams continuously |
| `copyArchiveFrom/ToContainer` | streams continuously |
| `waitContainerCmd` | **silent until exit — idle time equals elapsed time** |

### Why a second client

docker-java gives no per-request escape. `ApacheDockerHttpClientImpl` applies `RequestConfig` only through `HttpClientBuilder.setDefaultRequestConfig`, and `ApacheDockerHttpClient.execute(Request)` is a bare `super.execute(request)` with no per-request `setConfig`. `WaitContainerCmd` has no `withTimeout`. A second client is the only way to hold two socket-timeout profiles, and it follows the local pattern (`sandboxExecutor` is qualified the same way).

### Why the streaming client is bounded, not unbounded

The obvious move — `responseTimeout(null)` — restores docker-java's infinite `SO_TIMEOUT`, and that removes the last recovery path. If the daemon holds the socket open and stops answering, `DefaultInvocationBuilder.executeAndStream` spawns its own reader thread whose only shutdown mechanism is `Thread.interrupt()`, and **an interrupt does not unblock a blocking `Socket.read()`**. That thread and its pooled connection are lost for good; after `maxConnections` such events every wait blocks on the 3-minute `connectionRequestTimeout` default before failing.

`ResourceLimits.MAX_RUNTIME` already caps a sandbox at one hour (the constructor rejects anything longer), so `MAX_RUNTIME + 10min` cannot cut a legitimate wait short and still reclaims an abandoned socket. The bound is derived from the constant, not chosen.

### Pool sizing follows

`dockerWaitExecutor` is fixed at `maxConcurrentContainers` and `waitContainer` is the streaming client's only call site, so one connection per container is the hard bound there — the old `×3` was unreachable headroom on a pool that cannot be exhausted. The RPC pool keeps `×3`, which now genuinely covers create/start, logs, and a copy-out lease held open while `SandboxWorkspaceManager` reads it. Pools are lazy, so this is a ceiling, not an allocation; docker-java's own default is `Integer.MAX_VALUE`.

### RPC stays at 30 minutes

Under idle semantics it is inert for every bounded call and exists only to reclaim a connection from a silent daemon. Cutting it looks tidy but `copyArchiveToContainer` blocks on the response read for the whole upload, and without a measurement of workspace archive sizes that would be an unforced risk. Left as-is; the javadoc that previously described it backwards is corrected.

## How to test

```bash
cd server && ./mvnw test -P'!quick' -Dtest='DockerClientOperationsTest,DockerSandboxConfigurationTest'
# DockerClientOperationsTest 21 tests, DockerSandboxConfigurationTest 2 tests, 0 failures
```

The suite now injects two distinct mocks and `shouldNotUseTheRpcClientWhenWaitingForAContainer` asserts `verifyNoInteractions(dockerClient)`. Passing one mock twice would have made the split unobservable — a revert of the routing would not have turned anything red.

**Both timeouts are now constrained by a test rather than by a comment.** `DockerSandboxConfigurationTest` asserts the streaming timeout exceeds `ResourceLimits.MAX_RUNTIME` and the RPC timeout exceeds the image-pull budget. The 5-minute pull budget was an unnamed inline literal, so it becomes `IMAGE_PULL_TIMEOUT` and the relationship is checkable at all. Mutation-tested — hard-coding the streaming timeout to 30 minutes, or cutting the RPC timeout to 1 minute, each turns the suite red. That second one is not hypothetical: **I made exactly that change earlier in this branch's history and caught it by manual audit.** It is now caught by CI.

The socket behaviour itself is not unit-testable without a live daemon and a wait longer than the timeout, so it is not tested here. On a live worker, a review exceeding 30 minutes previously failed at exactly the 30-minute mark with the container still running.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

Empty changeset: agent sandboxes have never shipped, so no operator has had a long review fail this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZADQeSx6zQNNqsdu7AAqZ
