### PR TITLE
fix(server): record the threads the composer is allowed to supersede

### DIFF
--- a/.changeset/composer-prepared-thread-keys.md
+++ b/.changeset/composer-prepared-thread-keys.md
@@ -1,0 +1,8 @@
+---
+---
+
+No user-facing or operator-facing effect. Practice-review feedback that replaces an earlier comment
+was discarded before delivery: the reviewer named the thread it was superseding, but the envelope it
+handed back listed no threads at all, so the reader dropped every superseding unit as a reference to
+something that did not exist. None of this reached a release: practice reviews have never shipped,
+so there is no version an operator can be upgrading from where feedback went missing this way.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/practice/PracticeRunnerProfile.java
@@ -19,6 +19,7 @@ public final class PracticeRunnerProfile implements PiRunnerProfile {
         "pi-observation-normalize.mjs",
         "pi-runner-usage.mjs",
         "pi-runner-timings.mjs",
+        "pi-runner-composition.mjs",
         SandboxLayout.PROVIDER_HELPER_FILENAME
     );
 

--- a/server/src/main/resources/agent/pi-runner-composition.mjs
+++ b/server/src/main/resources/agent/pi-runner-composition.mjs
@@ -1,0 +1,17 @@
+// Coherence rules the composed-feedback envelope must satisfy for the server to deliver what it
+// carries. Kept apart from pi-runner.mjs so they can be exercised without starting a review.
+
+/**
+ * Units the reader will discard. It resolves every SUPERSEDE against the envelope's own
+ * `preparedThreadKeys`, so a unit naming a thread the envelope does not list is feedback that was
+ * composed, accepted by the tool, and then dropped on the way out.
+ *
+ * The tool already refuses a SUPERSEDE whose key is not staged, so this can only be non-empty when
+ * the envelope and the tool disagree about which threads were staged.
+ */
+export function undeliverableUnits(envelope) {
+    const prepared = new Set(envelope?.preparedThreadKeys ?? []);
+    return (envelope?.units ?? []).filter(
+        (unit) => unit?.action === "SUPERSEDE" && !prepared.has(unit?.supersedesThreadKey),
+    );
+}

--- a/server/src/main/resources/agent/pi-runner.mjs
+++ b/server/src/main/resources/agent/pi-runner.mjs
@@ -29,6 +29,7 @@ import {
 import { loadProviderConfig, registerHephaestusProvider } from "./pi-provider.mjs";
 import { addAssistantUsage, extractUsageFromSession, newUsageLedger } from "./pi-runner-usage.mjs";
 import { deriveTimeouts } from "./pi-runner-timings.mjs";
+import { undeliverableUnits } from "./pi-runner-composition.mjs";
 
 const OUTPUT = "/workspace/out";
 const CWD = "/workspace";
@@ -718,11 +719,20 @@ function leanObservations(observations) {
 }
 
 function persistComposedFeedback() {
+    for (const unit of undeliverableUnits(composedFeedback)) {
+        console.error(
+            `[pi-runner] composed feedback the server cannot deliver: ${unit.channel}/${unit.practiceSlug} ` +
+                `supersedes '${unit.supersedesThreadKey}', which this envelope does not list as staged`,
+        );
+    }
     writeFileSync(FEEDBACK_PATH, JSON.stringify(composedFeedback, null, 2));
 }
 
 // The composer references admitted observations; it cannot author verdicts, citations, or locations.
 function buildFeedbackTool(practiceSlugs, request, observations, preparedThreadKeys) {
+    // The reader resolves supersession against the envelope's copy of this list and drops any unit
+    // naming a thread outside it, so the vocabulary is recorded here, where it is decided.
+    composedFeedback.preparedThreadKeys = preparedThreadKeys;
     const enabledChannels = CHANNELS.filter((channel) => request.channels[channel].enabled);
     const placementKinds = request.inContextPlacementKinds || [];
     const usedPerChannel = Object.fromEntries(CHANNELS.map((channel) => [channel, 0]));
@@ -1063,9 +1073,13 @@ async function main() {
     }
 
     const compositionRequest = loadCompositionRequest();
-    const preparedThreadKeys = stagedPreparedThreadKeys();
     const feedbackTool = compositionRequest
-        ? buildFeedbackTool(composablePracticeSlugs(), compositionRequest, reviewState.observations, preparedThreadKeys)
+        ? buildFeedbackTool(
+              composablePracticeSlugs(),
+              compositionRequest,
+              reviewState.observations,
+              stagedPreparedThreadKeys(),
+          )
         : null;
     const { session, extensionsResult } = await createAgentSession({
         cwd: CWD,

--- a/server/src/test/resources/agent/pi-runner-composition.spec.mjs
+++ b/server/src/test/resources/agent/pi-runner-composition.spec.mjs
@@ -1,0 +1,50 @@
+// Run locally with:
+//   pnpm run test:agents
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { undeliverableUnits } from "../../../main/resources/agent/pi-runner-composition.mjs";
+
+const supersede = (threadKey) => ({
+    action: "SUPERSEDE",
+    channel: "IN_CONTEXT",
+    practiceSlug: "writes-focused-pull-requests",
+    supersedesThreadKey: threadKey,
+});
+
+test("an envelope that lists the threads its units supersede delivers all of them", () => {
+    const envelope = { preparedThreadKeys: ["t-1", "t-2"], units: [supersede("t-1"), supersede("t-2")] };
+
+    assert.deepEqual(undeliverableUnits(envelope), []);
+});
+
+test("a superseding unit is undeliverable when the envelope lists no threads", () => {
+    // The incident: the tool was given the staged keys and accepted the unit, the envelope was not.
+    const envelope = { preparedThreadKeys: [], units: [supersede("t-1")] };
+
+    assert.deepEqual(undeliverableUnits(envelope), [supersede("t-1")]);
+});
+
+test("only the unit naming an unlisted thread is undeliverable", () => {
+    const envelope = { preparedThreadKeys: ["t-1"], units: [supersede("t-1"), supersede("t-9")] };
+
+    assert.deepEqual(undeliverableUnits(envelope), [supersede("t-9")]);
+});
+
+test("units that supersede nothing are unaffected by an empty thread list", () => {
+    const envelope = {
+        preparedThreadKeys: [],
+        units: [
+            { action: "NEW", channel: "IN_APP", practiceSlug: "p" },
+            { action: "WITHHOLD", channel: "IN_CHAT", practiceSlug: "p", withholdReason: "ALREADY_SAID" },
+        ],
+    };
+
+    assert.deepEqual(undeliverableUnits(envelope), []);
+});
+
+test("an envelope missing the fields entirely reports nothing rather than throwing", () => {
+    assert.deepEqual(undeliverableUnits({}), []);
+    assert.deepEqual(undeliverableUnits(undefined), []);
+});


### PR DESCRIPTION
## Description

Practice-review feedback that replaces an earlier comment never reached anyone. The runner read the prepared thread keys and handed them to the feedback tool as its supersession vocabulary, but never wrote them into the envelope it persists:

```js
const preparedThreadKeys = stagedPreparedThreadKeys();
const feedbackTool = compositionRequest
    ? buildFeedbackTool(composablePracticeSlugs(), compositionRequest, reviewState.observations, preparedThreadKeys)
    : null;
```

`FeedbackCompositionResultParser` resolves each unit's `threadKey` against the envelope's `preparedThreadKeys`, which stayed at its initialised `[]`. Every `SUPERSEDE` unit therefore resolved to a thread that did not exist and was dropped — composed by the reviewer, accepted by the tool, discarded on the way out.

Both sides were green throughout, which is the interesting part: `FeedbackCompositionResultParserTest` constructs its payload by hand, so the reader was tested thoroughly against a shape the producer never emitted.

**The fix is structural, not an added assignment.** The vocabulary is now recorded inside `buildFeedbackTool`, where it is decided, so there is one statement instead of two that had to agree. A thread key the tool accepts cannot be one the envelope omits.

### The invariant is checked, not just argued

`validateUnit` already refuses a SUPERSEDE whose `supersedesThreadKey` is not in the staged list, so **a stored SUPERSEDE unit the envelope cannot vouch for can only mean the two copies diverged.** There is no input that makes it legitimate, which makes it a zero-false-positive signal.

`undeliverableUnits` in the new `pi-runner-composition.mjs` applies the reader's own rule on the producer's side, and `persistComposedFeedback` reports every hit to stderr as it writes. A future re-split announces itself in the job log instead of quietly delivering nothing. It does not throw: the condition is a wiring error, not a data error, and adding a way for reviews to die is not worth defending a hypothetical.

The module exists because `pi-runner.mjs` has no exports and calls `main()` at module scope — the same reason `pi-runner-usage.mjs` and `pi-runner-timings.mjs` exist. The spec covers the incident directly: an envelope listing no threads with a unit that supersedes one.

**Honest limit:** the spec proves the detector works, not that the assignment happens. Re-splitting the two copies would be caught at runtime by the stderr report, not by a red test. The chain is structural fix → runtime detector → tested detector, which is stronger than any one of them, but it is not a compile-time guarantee and I am not claiming one.

## How to test

```bash
pnpm run test:agents
# 67 pass, 0 fail across 7 files
```

> Stacked on #1480. That PR replaces CI's four-file `node --test` list with directory arguments; without it the new spec would sit in the tree and never run.

End to end: run a practice review against a PR that already carries feedback on a thread, and confirm a superseding unit is delivered rather than dropped. The symptom before this change is a review that completes with units composed but nothing posted.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

The changeset is empty on purpose. Practice reviews have never shipped — `CHANGELOG.md` has no mention of them and the current version is `0.73.2` — so no operator has experienced this symptom, and a changelog entry saying feedback "is delivered again" would assert a release that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZADQeSx6zQNNqsdu7AAqZ
