### PR TITLE
fix(ci): report a cancelled run as a state the status API accepts

### DIFF
--- a/.changeset/ci-status-gate-cancelled.md
+++ b/.changeset/ci-status-gate-cancelled.md
@@ -1,0 +1,6 @@
+---
+---
+
+No user-facing or operator-facing effect. A cancelled CI run left the "All CI Passed" status stuck
+rather than reporting the cancellation, because the gate posted the run's outcome under a name
+GitHub's commit-status API rejects. Repository tooling only.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -392,12 +392,20 @@ jobs:
         with:
           script: |
             const sha = context.payload.pull_request?.head?.sha || context.sha;
-            const state = '${{ steps.evaluate.outputs.status }}' || 'failure';
+            const outcome = '${{ steps.evaluate.outputs.status }}' || 'failure';
+            // createCommitStatus accepts error, failure, pending or success and 422s on anything
+            // else, so a cancelled run has to be reported as one of them rather than by its name.
+            const REPORTED = {
+              success: ['success', 'All CI checks passed'],
+              failure: ['failure', 'One or more CI checks failed'],
+              cancelled: ['error', 'CI was cancelled before it finished'],
+            };
+            const [state, description] = REPORTED[outcome] ?? REPORTED.failure;
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: sha,
               state: state,
-              description: state === 'success' ? 'All CI checks passed' : 'One or more CI checks failed',
+              description: description,
               context: 'All CI Passed'
             });


### PR DESCRIPTION
## Description

The CI Status Gate posts its verdict as a commit status, passing the evaluated outcome straight through:

```js
const state = '${{ steps.evaluate.outputs.status }}' || 'failure';
await github.rest.repos.createCommitStatus({ ..., state: state, ... });
```

`createCommitStatus` accepts only `error`, `failure`, `pending` or `success`. The evaluate step also emits `cancelled` (`cicd.yml:244`), so a cancelled run sends a value the API rejects:

```
HttpError: Validation Failed — status: '422'
body: '{"state":"cancelled","description":"One or more CI checks failed","context":"All CI Passed"}'
##[error]Unhandled error: HttpError: Validation Failed
```

The job then dies on the unhandled error and the `All CI Passed` context is never updated, so the pull request keeps whatever status the superseded run left behind — usually a red one. **Cancellation is routine**: every force-push to an open PR cancels the in-progress run, so this fires constantly during any stacked or iterated work and reads as a CI failure on a diff that has none.

Found because it did exactly that to #1482 after a restack, where all 39 underlying checks passed.

Outcomes now map explicitly onto states the API accepts, with a description that says which of the three happened rather than calling everything that is not a success a failed check. The `?? REPORTED.failure` fallback preserves the previous fail-closed default for an outcome nobody anticipated.

## How to test

CI covers this. To see it directly: push to any open PR, then force-push again before the run finishes. On `main` the gate job ends with the 422 above and the `All CI Passed` status goes stale; with this change it posts `error` / "CI was cancelled before it finished" and the job succeeds.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

Empty changeset: repository CI tooling, nothing shipped changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZADQeSx6zQNNqsdu7AAqZ