### PR TITLE
fix(server): report what a timed-out stream limit change actually did

### DIFF
--- a/.changeset/webhook-limit-update-reports-the-truth.md
+++ b/.changeset/webhook-limit-update-reports-the-truth.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+A webhook stream limit change that takes longer than the broker's reply now says what actually happened. Bounding a stream that has outgrown its new limit deletes the excess before the broker answers, so on a large stream the wait is proportional to the data being shed — long enough that startup gave up and reported the stream "left at its live configuration" while the broker went on to apply the change. An operator reading that was told the opposite of the truth: that nothing had happened, when tens of gigabytes had just been deleted. Startup now waits long enough for the change to land, and if it still cannot get an answer it reports the limits the stream actually has rather than assuming its own update failed.
+
+**Operators:** the new `HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT` defaults to `5m` and applies only at startup. Raise it if a stream is large enough that shedding the excess takes longer than that; it is deliberately separate from the health-check timeouts, which must stay short to be worth alerting on.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -128,6 +128,9 @@ HEPHAESTUS_WEBHOOK_STREAM_MAX_BYTES_GITHUB=10GB
 # deliberate start-up to apply it — for example when first bounding a stream that has already grown
 # past the new limit.
 HEPHAESTUS_WEBHOOK_STREAM_ALLOW_DESTRUCTIVE_LIMIT_UPDATES=false
+# How long one stream limit change may take. A bound that sheds messages deletes them before the
+# broker answers, so raise this on a stream too large to shed inside five minutes.
+HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT=5m
 
 # -----------------------------------------------------------------------------
 # MONITORING & SYNC

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -42,6 +42,9 @@ services:
       # Lowering a bound on a stream that has already outgrown it deletes the excess. Set true for
       # one deliberate start-up to apply it; startup otherwise logs what it would cost and declines.
       HEPHAESTUS_WEBHOOK_STREAM_ALLOW_DESTRUCTIVE_LIMIT_UPDATES: ${HEPHAESTUS_WEBHOOK_STREAM_ALLOW_DESTRUCTIVE_LIMIT_UPDATES:-false}
+      # Applying that bound sheds the excess before the broker replies, so the wait scales with the
+      # bytes deleted. Raise it on a stream large enough that 5 minutes is not enough.
+      HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT: ${HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT:-5m}
       # Shared webhook secret used for incoming HMAC / token verification.
       # WEBHOOK_EXTERNAL_URL is only used by auto-registration (server role) and is intentionally
       # not set on the webhook-server pod.

--- a/docs/admin/webhook-ingestion-operations.mdx
+++ b/docs/admin/webhook-ingestion-operations.mdx
@@ -124,6 +124,19 @@ To apply it deliberately:
 Leaving that flag set turns a one-time decision into standing permission for any future deploy to
 delete stored messages.
 
+Shedding the excess happens **before** the broker replies, so on a large stream the call takes as
+long as the deletion does. `HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT` (default `5m`) is how
+long startup waits; raise it if your stream is too large to shed inside that. If it still runs out,
+startup reports the limits the stream actually has rather than assuming its own update failed —
+which matters, because a timed-out update is one the broker may well have applied:
+
+```text
+Failed to reconcile JetStream stream limits: name=github changed=[maxBytes -1 -> 10737418240]
+— live configuration is now maxAge=PT4320H maxBytes=10737418240 maxMessages=-1
+```
+
+That line says the change **did** land. Confirm with `nats stream info github` before retrying.
+
 If instead you see a shape-drift error, the stream is not what this deployment expects and no bound
 is written onto it at all:
 
@@ -212,6 +225,29 @@ silent. Only a deployment that no longer exists ages out.
 retention, so a deployment offline past the stream's byte or age bound comes back to a cursor pointing
 at messages the stream no longer holds — `webhook.stream.unacknowledged.deletions` will say so on the
 first poll.
+
+## Making a change actually reach the broker
+
+Two things in the deployment path will silently leave your change unapplied.
+
+**The webhook receiver and NATS are in the core stack, and staging CD deploys the app only.** A
+change to `hephaestus.webhook.stream.*` ships with the application server but does not reach the
+container that bootstraps the streams until core is deployed. CI warns when `docker/compose.core.yaml`
+changes; deploy it with **Deploy to Staging** and `deploy-core: true`.
+
+**Compose does not recreate NATS when only its config changes.** The broker's configuration is a
+Compose `configs:` block whose content renders to a bind-mounted file. Changing the content does not
+change the container's spec, so `docker compose up -d` reports no drift and the running broker keeps
+the config it started with — `max_payload` and `max_file` included. Force it:
+
+```bash
+docker compose -f compose.core.yaml up -d --force-recreate nats-server
+docker exec core-nats-server-1 cat /etc/nats/nats-server.conf   # confirm the value you set
+```
+
+Recreating the broker is safe for stored messages — JetStream data lives in the volume — but
+in-flight deliveries during the restart are lost, and webhooks are not redeliverable. Reconciliation
+covers `MONITORING_TIMEFRAME` days afterwards.
 
 ## Where these settings live
 

--- a/scripts/check-env-roles.test.mjs
+++ b/scripts/check-env-roles.test.mjs
@@ -166,9 +166,12 @@ test("a compose file that yields no services is a failure, not a pass", () => {
 });
 
 test("compose defaults resolve the way an operator who sets nothing gets them", () => {
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: Compose interpolation syntax under test, not a template literal
 	assert.equal(composeDefault("${HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED:-false}"), "false");
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: Compose interpolation syntax under test, not a template literal
 	assert.equal(composeDefault("${HEPHAESTUS_RUNTIME_WEBHOOK_ENABLED-false}"), "false");
 	assert.equal(composeDefault('"false"'), "false");
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: Compose interpolation syntax under test, not a template literal
 	assert.equal(composeDefault("${WEBHOOK_SECRET}"), "");
 });
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookProperties.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookProperties.java
@@ -162,6 +162,14 @@ public record WebhookProperties(
          * immediately, so it is a decision an operator makes rather than one a deploy makes for them.
          */
         @DefaultValue("false") boolean allowDestructiveLimitUpdates,
+        /**
+         * How long startup waits for one stream limit update. Bounding a stream that has outgrown
+         * the new limit deletes the excess before the broker answers, so the work is proportional to
+         * the bytes being shed rather than to the size of the request — tens of GB take far longer
+         * than the request timeout the health probes want. This is deliberately separate from the
+         * consumer request timeout so a slow admin call cannot slow a readiness answer.
+         */
+        @DefaultValue("5m") Duration limitUpdateTimeout,
         /** How often the stream monitor reads stream and consumer state. */
         @DefaultValue("60s") Duration monitorInterval
     ) {
@@ -216,6 +224,11 @@ public record WebhookProperties(
                 requirePositive("stream.maxBytesByStream." + e.getKey(), e.getValue());
             }
             requirePositive("stream.storageBudget", storageBudget);
+            if (limitUpdateTimeout.isZero() || limitUpdateTimeout.isNegative()) {
+                throw new IllegalArgumentException(
+                    "stream.limitUpdateTimeout must be positive, got: " + limitUpdateTimeout
+                );
+            }
             if (monitorInterval.isZero() || monitorInterval.isNegative()) {
                 throw new IllegalArgumentException("stream.monitorInterval must be positive, got: " + monitorInterval);
             }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookJetStreamBootstrap.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookJetStreamBootstrap.java
@@ -248,14 +248,36 @@ public class WebhookJetStreamBootstrap {
             }
             return true;
         } catch (JetStreamApiException | IOException ex) {
-            // The stream exists and publishes still land at its live limits, so this is not worth
-            // failing a deploy over — the receiver stays up and the operator gets a loud record.
+            // A timeout here says the broker did not answer in time, not that it did nothing: shedding
+            // the excess a new bound deletes happens before the reply, so the update can land while the
+            // client gives up. Report the limits the stream actually has rather than assert an outcome.
             log.error(
-                "Failed to reconcile JetStream stream limits: name={} — stream left at its live configuration",
+                "Failed to reconcile JetStream stream limits: name={} changed={} — live configuration is now {}",
                 name,
+                plan.applied,
+                describeLiveLimits(name),
                 ex
             );
             return false;
+        }
+    }
+
+    /**
+     * The stream's limits as the broker reports them right now, for a failure that cannot say whether
+     * its own update landed. Never throws: it runs on a path that is already handling a failure, and
+     * an unreadable broker is itself the answer.
+     */
+    private String describeLiveLimits(String name) {
+        try {
+            StreamConfiguration live = jsm.getStreamInfo(name).getConfiguration();
+            return String.format(
+                "maxAge=%s maxBytes=%d maxMessages=%d",
+                live.getMaxAge(),
+                live.getMaxBytes(),
+                live.getMaxMsgs()
+            );
+        } catch (JetStreamApiException | IOException | RuntimeException ex) {
+            return "unreadable (" + ex.getClass().getSimpleName() + ") — check the broker directly";
         }
     }
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookProducerBeans.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookProducerBeans.java
@@ -9,9 +9,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.nats.client.Connection;
 import io.nats.client.JetStream;
 import io.nats.client.JetStreamManagement;
+import io.nats.client.JetStreamOptions;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 
 /**
  * The NATS <em>producer</em> cluster contributed by {@link WebhookConfiguration} on the
@@ -34,9 +36,28 @@ class WebhookProducerBeans {
     }
 
     @Bean
+    @Primary
     JetStreamManagement webhookJetStreamManagement(@Qualifier("natsConnection") Connection natsConnection)
         throws IOException {
         return natsConnection.jetStreamManagement();
+    }
+
+    /**
+     * The handle {@link WebhookJetStreamBootstrap} applies limit changes through. Separate from
+     * {@link #webhookJetStreamManagement} because the two want opposite timeouts: the health
+     * indicator and the monitor share that one and need it to fail fast, while bounding a stream
+     * that has outgrown its new limit sheds the excess before the broker answers and takes as long
+     * as the bytes require. Sharing one handle means either readiness waits on a delete or the
+     * delete reports a failure the broker is still completing.
+     */
+    @Bean
+    JetStreamManagement webhookAdminJetStreamManagement(
+        @Qualifier("natsConnection") Connection natsConnection,
+        WebhookProperties properties
+    ) throws IOException {
+        return natsConnection.jetStreamManagement(
+            JetStreamOptions.builder().requestTimeout(properties.stream().limitUpdateTimeout()).build()
+        );
     }
 
     @Bean
@@ -63,7 +84,10 @@ class WebhookProducerBeans {
     }
 
     @Bean
-    WebhookJetStreamBootstrap webhookJetStreamBootstrap(JetStreamManagement jsm, WebhookProperties properties) {
+    WebhookJetStreamBootstrap webhookJetStreamBootstrap(
+        @Qualifier("webhookAdminJetStreamManagement") JetStreamManagement jsm,
+        WebhookProperties properties
+    ) {
         return new WebhookJetStreamBootstrap(jsm, properties);
     }
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -612,6 +612,10 @@ hephaestus:
             # messages the stream already holds is withheld and logged rather than applied. Set this
             # once, deliberately, to let that through.
             allow-destructive-limit-updates: ${HEPHAESTUS_WEBHOOK_STREAM_ALLOW_DESTRUCTIVE_LIMIT_UPDATES:false}
+            # A bound that sheds messages deletes them before the broker replies, so the wait scales
+            # with the bytes shed, not with the request. Startup-only, and deliberately not the
+            # timeout the health probes use — those have to fail fast to be worth alerting on.
+            limit-update-timeout: ${HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT:5m}
             monitor-interval: 60s
         shutdown:
             # Drain budget for in-flight publishes after HTTP closes. Docker stop_grace_period

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookPropertiesFixture.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookPropertiesFixture.java
@@ -25,6 +25,7 @@ public final class WebhookPropertiesFixture {
             Map.of(),
             gibibytes(12),
             false,
+            Duration.ofMinutes(5),
             Duration.ofSeconds(60)
         );
     }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookPropertiesTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/core/webhook/WebhookPropertiesTest.java
@@ -78,6 +78,7 @@ class WebhookPropertiesTest extends BaseUnitTest {
             byStream,
             gibibytes(64),
             false,
+            Duration.ofMinutes(5),
             Duration.ofSeconds(60)
         );
     }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/webhook/JetStreamPublisherTopologyTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/webhook/JetStreamPublisherTopologyTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.webhook;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -14,6 +15,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.nats.client.Connection;
 import io.nats.client.JetStream;
 import io.nats.client.JetStreamManagement;
+import io.nats.client.JetStreamOptions;
 import io.nats.client.api.DiscardPolicy;
 import io.nats.client.api.RetentionPolicy;
 import io.nats.client.api.StorageType;
@@ -62,6 +64,8 @@ class JetStreamPublisherTopologyTest {
             when(jsm.getStreamInfo(anyString())).thenReturn(info);
             when(connection.jetStream()).thenReturn(jetStream);
             when(connection.jetStreamManagement()).thenReturn(jsm);
+            // The bootstrap takes its own handle with a longer request timeout than the probes want.
+            when(connection.jetStreamManagement(any(JetStreamOptions.class))).thenReturn(jsm);
             return connection;
         } catch (Exception e) {
             throw new IllegalStateException("failed to build NATS connection stub", e);

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookJetStreamBootstrapTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookJetStreamBootstrapTest.java
@@ -96,6 +96,7 @@ class WebhookJetStreamBootstrapTest extends BaseUnitTest {
                 Map.of("github", gibibytes(8)),
                 gibibytes(12),
                 false,
+                Duration.ofMinutes(5),
                 Duration.ofSeconds(60)
             )
         );
@@ -135,6 +136,7 @@ class WebhookJetStreamBootstrapTest extends BaseUnitTest {
                 // Four streams at 4 GiB need 16, and the broker is told it may hold 8.
                 gibibytes(8),
                 false,
+                Duration.ofMinutes(5),
                 Duration.ofSeconds(60)
             )
         );
@@ -157,6 +159,7 @@ class WebhookJetStreamBootstrapTest extends BaseUnitTest {
                 Map.of(),
                 gibibytes(8),
                 false,
+                Duration.ofMinutes(5),
                 Duration.ofSeconds(60)
             )
         );
@@ -437,6 +440,46 @@ class WebhookJetStreamBootstrapTest extends BaseUnitTest {
             .hasMessageContaining("Failed to inspect JetStream stream");
     }
 
+    @Test
+    void aTimedOutUpdateReportsTheLimitsTheStreamActuallyHasRatherThanAssertingItChangedNothing(CapturedOutput output)
+        throws Exception {
+        // Shedding what a new bound deletes happens before the broker replies, so a client timeout
+        // and a successful update look identical from here. Staging showed exactly that: the update
+        // landed, the client gave up, and the old message told the operator nothing had happened.
+        StreamInfo before = countBoundOnly(state(GIBIBYTE / 2, 10, 1));
+        StreamInfo after = existing(builder -> builder.maxBytes(4_294_967_296L).maxMessages(-1), state(0, 0, 1));
+        JetStreamManagement jsm = mock(JetStreamManagement.class);
+        when(jsm.getStreamInfo(anyString())).thenReturn(before, after);
+        when(jsm.updateStream(any())).thenThrow(new IOException("Timeout or no response waiting for NATS"));
+
+        new WebhookJetStreamBootstrap(jsm, allowingDestructiveUpdates()).bootstrap();
+
+        assertThat(output.getAll())
+            .as("the operator needs the broker's answer, not the client's assumption")
+            .contains("live configuration is now")
+            .contains("maxBytes=4294967296")
+            .doesNotContain("stream left at its live configuration");
+    }
+
+    @Test
+    void aTimedOutUpdateAgainstAnUnreadableBrokerSaysSoInsteadOfGuessing(CapturedOutput output) throws Exception {
+        // The re-read runs on a path that is already failing; if it fails too, silence would be the
+        // one outcome worse than either error.
+        StreamInfo before = countBoundOnly(state(GIBIBYTE / 2, 10, 1));
+        JetStreamManagement jsm = mock(JetStreamManagement.class);
+        // Bootstrap walks every stream: the first pair of calls is the one under test — read, then the
+        // re-read that fails. Later streams read normally so the loop reaches its end.
+        when(jsm.getStreamInfo(anyString()))
+            .thenReturn(before)
+            .thenThrow(new IOException("broker gone"))
+            .thenReturn(before);
+        when(jsm.updateStream(any())).thenThrow(new IOException("Timeout or no response waiting for NATS"));
+
+        new WebhookJetStreamBootstrap(jsm, allowingDestructiveUpdates()).bootstrap();
+
+        assertThat(output.getAll()).contains("unreadable").contains("check the broker directly");
+    }
+
     private WebhookProperties allowingDestructiveUpdates() {
         WebhookProperties.Stream s = properties.stream();
         return WebhookPropertiesFixture.with(
@@ -448,6 +491,7 @@ class WebhookJetStreamBootstrapTest extends BaseUnitTest {
                 Map.of(),
                 s.storageBudget(),
                 true,
+                s.limitUpdateTimeout(),
                 s.monitorInterval()
             )
         );

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookProducerWiringTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/integration/core/webhook/WebhookProducerWiringTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.hephaestus.integration.core.webhook;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -16,6 +17,7 @@ import io.nats.client.Connection;
 import io.nats.client.JetStream;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.JetStreamManagement;
+import io.nats.client.JetStreamOptions;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -79,6 +81,8 @@ class WebhookProducerWiringTest extends BaseUnitTest {
             Connection connection = mock(Connection.class);
             // Lenient throughout: the role-off case builds the same connection and touches none of it.
             lenient().when(connection.jetStreamManagement()).thenReturn(jsm);
+            // The bootstrap takes its own handle with a longer request timeout than the probes want.
+            lenient().when(connection.jetStreamManagement(any(JetStreamOptions.class))).thenReturn(jsm);
             lenient().when(connection.jetStream()).thenReturn(mock(JetStream.class));
             lenient().when(connection.getMaxPayload()).thenReturn(26_214_400L);
             return connection;


### PR DESCRIPTION
## Description

Deploying #1501 to staging turned up a defect in it. Applying the GitHub stream's new 10 GiB bound
meant shedding 21.5 GB, and JetStream does that **before** it replies — so the call took longer than
the client would wait:

```
java.io.IOException: Timeout or no response waiting for NATS JetStream server
ERROR ... Failed to reconcile JetStream stream limits: name=github — stream left at its live configuration
```

That last clause was false. NATS finished the deletion; the stream went from 2,000,000 messages /
32.30 GB to 653,812 / 10.74 GB. The log told the operator nothing had happened at the exact moment
tens of gigabytes went away — the one failure mode this subsystem exists to make impossible.

Two changes:

**Startup waits long enough.** It now takes its own JetStream handle rather than sharing the one the
health indicator and stream monitor use, because the two want opposite timeouts. A probe has to fail
fast or it is not worth alerting on; an admin call has to outlast the bytes it is deleting. Sharing
one handle means choosing between readiness that blocks on a delete and a delete that reports failure
while the broker is still working. `HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT` defaults to `5m`.

**A failure reports what it can verify, not what it assumes.** When the update still cannot be
confirmed, startup re-reads the stream and logs the limits actually in force:

```
Failed to reconcile JetStream stream limits: name=github changed=[maxBytes -1 -> 10737418240]
— live configuration is now maxAge=PT4320H maxBytes=10737418240 maxMessages=-1
```

If that re-read also fails it says so ("unreadable — check the broker directly") rather than
guessing. The old message asserted an outcome the code never checked.

## How to test

```bash
# the timeout must be positive
HEPHAESTUS_WEBHOOK_STREAM_LIMIT_UPDATE_TIMEOUT=0s ./mvnw spring-boot:run   # refused at startup
```

Server suite: **6,713 tests, 0 failures** (2 new). `pnpm run check` green, both env gates pass.

Both new tests are mutation-proven: restoring the old `stream left at its live configuration` message
fails them, and the fix passes. That mattered here — a test that only asserted "an error was logged"
would have passed against the bug.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

## Notes for reviewers

`webhookJetStreamManagement` is now `@Primary` so every existing injection keeps resolving; only the
bootstrap asks for the admin handle by name. The two wiring tests that build a fake `Connection`
needed the new overload stubbed — worth noting that **they caught this**, failing the context rather
than letting a null bean through.

The runbook gains a section on the two things that silently stop a change reaching the broker, both
hit while verifying #1501 on staging: the webhook receiver and NATS live in the core stack, which
staging CD does not auto-deploy; and Compose will not recreate NATS when only its `configs:` content
changes, because the container spec is unchanged — the config ships and never loads.
