### PR TITLE
ci: stop CI installing the git hooks it does not need

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yml
+++ b/.github/actions/setup-pnpm-node/action.yml
@@ -4,6 +4,14 @@ description: "Installs pnpm via SHA-pinned pnpm/action-setup and Node.js via SHA
 runs:
   using: "composite"
   steps:
+    # Git hooks are a developer-machine guardrail; every check they run is already a required job
+    # here. Installing them on a runner only couples workflows that push — the changesets version PR,
+    # the OpenAPI autocommit — to whatever toolchain `pnpm run check` happens to need, and a bot push
+    # then fails for a reason that has nothing to do with what it pushed.
+    - name: Disable git hooks
+      shell: bash
+      run: echo "HUSKY=0" >> "$GITHUB_ENV"
+
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       with:


### PR DESCRIPTION
## Description

`prepare: husky` runs on every `pnpm install`, including on CI runners. So each runner wires the
developer `pre-push` hook, which runs `pnpm run check` — and any workflow that pushes inherits a
dependency on whatever that check happens to need.

That went wrong when `check` gained `test:agents`: the changesets **Version PR** workflow began
failing on `bun: not found` while pushing a version bump, and has been red since. The release PR has
not been maintained for three commits, with 190 changesets queued behind it. The failure had nothing
to do with what the workflow was pushing.

Git hooks are a developer-machine guardrail. Every check they run is already a required job here, so
running them again inside a bot push adds no safety — only coupling. This disables them in the shared
`setup-pnpm-node` action, which covers both workflows that push (`version-pr`, `openapi-autocommit`)
in one place, rather than provisioning a toolchain per workflow to satisfy a hook that should not run
there at all.

## How to test

CI covers this: the Version PR workflow either maintains the release PR again or it does not.

`HUSKY=0` is husky's documented switch and this repo is on 9.1.7, where `husky/index.js:9` reads
`if (process.env.HUSKY === '0') return 'HUSKY=0 skip install'` — so hooks are never installed on the
runner and the push runs none. I checked the installed source rather than relying on the docs.

## Checklist

- [ ] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [ ] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

No changeset: `verify-changesets` scopes `SHIPPED_PATHS` to `server`, `webapp` and `docker`, and this
touches only `.github/`. Nothing about the shipped artefact changes.

## Notes for reviewers

The regression is mine, from #1491 — that PR added `test:agents` to `check` without noticing `pre-push`
runs `check` on runners too.

Worth a second opinion on scope: disabling hooks for all seven workflows that use this action is
deliberate, on the reasoning that CI's real gates are its jobs. The narrower alternative is `HUSKY: 0`
on the two pushing workflows, which fixes today's failure and leaves the next one to be discovered the
same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated environment setup by disabling Git hooks during workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->