### PR TITLE
fix(server): withhold the claim that fails its evidence check, not the review

### DIFF
--- a/.changeset/evidence-boundary-withholds-the-claim.md
+++ b/.changeset/evidence-boundary-withholds-the-claim.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+A review whose evidence check fails on one observation now delivers the others. The check that refuses to show a developer a claim it cannot trace back to the code applied to the whole review at once: one practice that mis-quoted its source — by a stray character, in a file the reader never sees — withheld every other finding in that review, including correct, fully evidenced ones. The developer saw nothing at all. Only a quote that does not match its source is treated this way; a citation to evidence the review never gathered still stops the whole delivery, as before. What was withheld is logged with the reason, and a review in which no claim can be verified still fails rather than arriving empty.

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionDeliveryService.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionDeliveryService.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.hephaestus.agent.context.providers.DocumentContentSource;
 import de.tum.cit.aet.hephaestus.agent.conversation.ConversationSourceLiveness;
 import de.tum.cit.aet.hephaestus.agent.documentation.DocumentProjection;
 import de.tum.cit.aet.hephaestus.agent.handler.PracticeDetectionResultParser.ValidatedObservation;
+import de.tum.cit.aet.hephaestus.agent.handler.spi.EvidenceQuoteUnverifiedException;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobDeliveryException;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJob;
 import de.tum.cit.aet.hephaestus.agent.runtime.ProvenanceDigest;
@@ -33,9 +34,9 @@ import de.tum.cit.aet.hephaestus.practices.observation.ObservationRepository;
 import de.tum.cit.aet.hephaestus.practices.observation.PracticeDetectionCompletedEvent;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -144,7 +145,15 @@ public class PracticeDetectionDeliveryService {
         }
         Target target = resolveTarget(job, metadata);
         Map<String, PracticeRevision> revisionsBySlug = admittedRevisions(job, workspaceId);
-        for (ValidatedObservation observation : validObservations) {
+        // A quote that does not verify discredits its own claim, and only EvidenceQuoteUnverifiedException
+        // means that. Every other refusal here — an unstaged source, a malformed citation, work attributed
+        // to the wrong person — impugns the run, so it stays fatal.
+        List<Integer> admittedIndexes = new ArrayList<>(validObservations.size());
+        List<ValidatedObservation> admittedObservations = new ArrayList<>(validObservations.size());
+        List<String> withheldObservations = new ArrayList<>();
+        boolean withheldNegative = false;
+        for (int submittedIndex = 0; submittedIndex < validObservations.size(); submittedIndex++) {
+            ValidatedObservation observation = validObservations.get(submittedIndex);
             PracticeRevision revision = revisionsBySlug.get(observation.practiceSlug());
             if (revision == null) {
                 throw new JobDeliveryException(
@@ -155,7 +164,42 @@ public class PracticeDetectionDeliveryService {
                 );
             }
             enforceAttribution(observation, revision, job);
-            enforceEvidenceBoundary(observation, revision, evidenceBoundary, job);
+            try {
+                enforceEvidenceBoundary(observation, revision, evidenceBoundary, job);
+                admittedIndexes.add(submittedIndex);
+                admittedObservations.add(observation);
+            } catch (EvidenceQuoteUnverifiedException ex) {
+                withheldNegative |= observation.assessment() == Assessment.BAD;
+                withheldObservations.add(observation.practiceSlug() + ": " + ex.getMessage());
+            }
+        }
+        if (!withheldObservations.isEmpty()) {
+            // Per claim, because a model that cannot quote its own evidence is a defect an otherwise
+            // successful delivery would hide.
+            log.warn(
+                "Withheld {} of {} observation(s) whose quoted evidence did not verify, delivering the rest: jobId={} withheld={}",
+                withheldObservations.size(),
+                validObservations.size(),
+                job.getId(),
+                withheldObservations
+            );
+            // Withholding the only fault leaves an all-clear standing over a defect the model did find,
+            // which is a different statement to the reader than an incomplete review.
+            if (withheldNegative && admittedObservations.stream().noneMatch(o -> o.assessment() == Assessment.BAD)) {
+                log.error(
+                    "Withheld every negative observation; the remaining claims read as an all-clear: jobId={}",
+                    job.getId()
+                );
+            }
+        }
+        // Only when there was something to admit: a review that found nothing still publishes its zero.
+        if (admittedObservations.isEmpty() && !validObservations.isEmpty()) {
+            throw new JobDeliveryException(
+                "No observation survived the evidence check, so there is nothing to deliver: jobId=" +
+                    job.getId() +
+                    ", withheld=" +
+                    withheldObservations
+            );
         }
 
         ObservationOrigin origin = originOf(metadata);
@@ -171,20 +215,22 @@ public class PracticeDetectionDeliveryService {
         boolean hasNegative = false;
         Instant observedAt = Instant.now();
 
-        // Keyed by observation identity because equal observations still represent distinct occurrences.
-        Map<ValidatedObservation, ObservationKeys> observationKeys = new IdentityHashMap<>();
+        // Carries the keys each observation was persisted under.
+        List<ValidatedObservation> deliveredObservations = new ArrayList<>(admittedObservations.size());
 
-        for (int i = 0; i < validObservations.size(); i++) {
-            ValidatedObservation observation = validObservations.get(i);
+        for (int i = 0; i < admittedObservations.size(); i++) {
+            ValidatedObservation observation = admittedObservations.get(i);
 
             PracticeRevision revision = revisionsBySlug.get(observation.practiceSlug());
             Practice practice = revision.getPractice();
 
-            // Includes the index so distinct observations for the same practice on one artifact don't collide.
+            // The position the observation was SUBMITTED at, not its position among those admitted: this key
+            // is a retry's dedup grain, so a claim withheld on one attempt and not the next must not renumber
+            // the claims after it into keys that miss what is already stored.
             String occurrenceKey =
                 observation.practiceSlug() +
                 ":" +
-                i +
+                admittedIndexes.get(i) +
                 ":" +
                 artifactKind.value() +
                 ":" +
@@ -211,7 +257,7 @@ public class PracticeDetectionDeliveryService {
                 aboutUserId,
                 firstLocationPath(observation.evidence())
             );
-            observationKeys.put(observation, new ObservationKeys(occurrenceKey, recurrenceKey));
+            deliveredObservations.add(observation.withKeys(new ObservationKeys(occurrenceKey, recurrenceKey)));
 
             Long practiceRevisionId = revision.getId();
 
@@ -274,7 +320,7 @@ public class PracticeDetectionDeliveryService {
             )
         );
 
-        return new DeliveryResult(inserted, discardedDuplicate, hasNegative, observationKeys);
+        return new DeliveryResult(inserted, discardedDuplicate, hasNegative, deliveredObservations);
     }
 
     /**
@@ -419,7 +465,7 @@ public class PracticeDetectionDeliveryService {
                 );
             String artifactContent = new String(content, StandardCharsets.UTF_8);
             if (!"scm.pull-request.diff".equals(kind.value()) && !artifactContent.contains(exactQuote)) {
-                throw new JobDeliveryException(
+                throw new EvidenceQuoteUnverifiedException(
                     "Evidence quote does not occur in the cited artifact: path=" +
                         artifactPath.asText() +
                         ", jobId=" +
@@ -445,7 +491,7 @@ public class PracticeDetectionDeliveryService {
                           exactQuote
                       ))
             ) {
-                throw new JobDeliveryException(
+                throw new EvidenceQuoteUnverifiedException(
                     "Evidence quote does not match the cited diff location: path=" +
                         path.asText() +
                         ", line=" +
@@ -996,14 +1042,11 @@ public class PracticeDetectionDeliveryService {
         return path != null && path.isString() ? path.asString() : null;
     }
 
-    /**
-     * @param observationKeys the keys persisted for each observation, by identity, so the caller stamps the same
-     *     keys onto its deliverable observations instead of recomputing them
-     */
+    /** @param delivered what this call persisted, each carrying the keys it was stored under. */
     public record DeliveryResult(
         int inserted,
         int discardedDuplicate,
         boolean hasNegative,
-        Map<ValidatedObservation, ObservationKeys> observationKeys
+        List<ValidatedObservation> delivered
     ) {}
 }

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandler.java
@@ -494,16 +494,9 @@ public class PullRequestReviewHandler implements JobTypeHandler {
             throw new JobDeliveryException("Delivery failed unexpectedly: jobId=" + job.getId(), e);
         }
 
-        // Stamp each observation with the exact keys deliver() persisted, by identity, so downstream stages
-        // address the stored observation without recomputing a key that could drift.
-        Map<PracticeDetectionResultParser.ValidatedObservation, ObservationKeys> keysByObservation =
-            result.observationKeys();
-        for (int i = 0; i < scopedObservations.size(); i++) {
-            scopedObservations.set(
-                i,
-                scopedObservations.get(i).withKeys(keysByObservation.get(scopedObservations.get(i)))
-            );
-        }
+        // What deliver() persisted, carrying the keys it stored them under, so a later stage addresses the
+        // stored observation rather than recomputing a key that could drift.
+        scopedObservations = new ArrayList<>(result.delivered());
 
         if (admissionOnly) return;
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/EvidenceQuoteUnverifiedException.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/spi/EvidenceQuoteUnverifiedException.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.hephaestus.agent.handler.spi;
+
+/**
+ * An observation quoted evidence that does not appear where it said the evidence was.
+ *
+ * <p>Distinct from every other refusal in the evidence gate because it is the one that says nothing
+ * about the run: the sources were staged, the citation was well formed and authorized, and the model
+ * simply did not reproduce what it read. That discredits the claim and no other, so it is caught per
+ * observation. Every other refusal — an unstaged source, a malformed citation, a missing search —
+ * means the run itself cannot be trusted, and stays fatal.
+ */
+public class EvidenceQuoteUnverifiedException extends JobDeliveryException {
+
+    public EvidenceQuoteUnverifiedException(String message) {
+        super(message);
+    }
+}

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionDeliveryServiceIntegrationTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionDeliveryServiceIntegrationTest.java
@@ -299,7 +299,7 @@ class PracticeDetectionDeliveryServiceIntegrationTest extends BaseIntegrationTes
         }
 
         @Test
-        @DisplayName("returned observationKeys align exactly with the persisted recurrence_key set")
+        @DisplayName("returned delivered observations align exactly with the persisted recurrence_key set")
         void returnedFingerprintsMatchPersistedRecurrenceKeys() {
             var observations = List.of(
                 observation("pr-description-quality", Presence.PRESENT),
@@ -308,7 +308,13 @@ class PracticeDetectionDeliveryServiceIntegrationTest extends BaseIntegrationTes
 
             var result = deliveryService.deliver(agentJob, observations);
 
-            assertThat(result.observationKeys().values().stream().map(ObservationKeys::recurrenceKey).toList())
+            assertThat(
+                result
+                    .delivered()
+                    .stream()
+                    .map(o -> o.recurrenceKey())
+                    .toList()
+            )
                 .as("one stable key returned per delivered observation")
                 .hasSize(2)
                 .allMatch(k -> k != null && k.matches("[0-9a-f]{64}"));
@@ -321,7 +327,11 @@ class PracticeDetectionDeliveryServiceIntegrationTest extends BaseIntegrationTes
             assertThat(persistedKeys)
                 .as("every returned fingerprint is persisted as a recurrence_key, and vice versa")
                 .containsExactlyInAnyOrderElementsOf(
-                    result.observationKeys().values().stream().map(ObservationKeys::recurrenceKey).toList()
+                    result
+                        .delivered()
+                        .stream()
+                        .map(o -> o.recurrenceKey())
+                        .toList()
                 );
         }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionDeliveryServiceTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeDetectionDeliveryServiceTest.java
@@ -391,6 +391,64 @@ class PracticeDetectionDeliveryServiceTest extends BaseUnitTest {
         }
 
         @Test
+        @DisplayName("only the claim whose quote does not verify is withheld; the other is delivered")
+        void withholdsOnlyTheObservationWhoseQuoteDoesNotVerify() {
+            Practice second = new Practice();
+            ReflectionTestUtils.setField(second, "id", 20L);
+            second.setSlug("pr-scope");
+            second.setBindings(PracticeTestEvidence.bindings(ArtifactKinds.PULL_REQUEST));
+            second.setAutomatedReviewPolicy(PracticeTestEvidence.forArtifact(ArtifactKinds.PULL_REQUEST));
+            admit(second, 21L);
+
+            ValidatedObservation sound = validObservation("pr-description-quality", Presence.PRESENT);
+            ValidatedObservation misquoted = validObservation("pr-scope", Presence.PRESENT);
+            ((ObjectNode) misquoted.evidence().withArray("citations").get(0)).put("quote", "+ insecure();,");
+
+            var result = service.deliver(testJob, List.of(sound, misquoted));
+
+            assertThat(result.delivered())
+                .as("the claim that verified is the one persisted, and it is the only one")
+                .extracting(ValidatedObservation::practiceSlug)
+                .containsExactly("pr-description-quality");
+            assertThat(result.inserted()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("a citation to an unstaged source still fails the whole delivery, even beside a sound claim")
+        void anEvidenceFailureThatIsNotAQuoteMismatchStillFailsEverything() {
+            Practice second = new Practice();
+            ReflectionTestUtils.setField(second, "id", 20L);
+            second.setSlug("pr-scope");
+            second.setBindings(PracticeTestEvidence.bindings(ArtifactKinds.PULL_REQUEST));
+            second.setAutomatedReviewPolicy(PracticeTestEvidence.forArtifact(ArtifactKinds.PULL_REQUEST));
+            admit(second, 21L);
+
+            ValidatedObservation sound = validObservation("pr-description-quality", Presence.PRESENT);
+            ValidatedObservation unstaged = validObservation("pr-scope", Presence.PRESENT);
+            ObjectNode citation = (ObjectNode) unstaged.evidence().withArray("citations").get(0);
+            citation.put("sourceKind", "scm.repository.tree");
+            citation.remove("side");
+
+            assertThatThrownBy(() -> service.deliver(testJob, List.of(sound, unstaged)))
+                .as("an unstaged source impugns the run, not just the claim that cited it")
+                .isInstanceOf(JobDeliveryException.class)
+                .hasMessageContaining("misattributed evidence source");
+            verifyNoInteractions(observationRepository);
+        }
+
+        @Test
+        @DisplayName("a batch in which no quote verifies is still a failed delivery")
+        void refusesTheDeliveryWhenNoObservationSurvivesAdmission() {
+            ValidatedObservation misquoted = validObservation("pr-description-quality", Presence.PRESENT);
+            ((ObjectNode) misquoted.evidence().withArray("citations").get(0)).put("quote", "fabricated quote");
+
+            assertThatThrownBy(() -> service.deliver(testJob, List.of(misquoted)))
+                .isInstanceOf(JobDeliveryException.class)
+                .hasMessageContaining("No observation survived the evidence check");
+            verifyNoInteractions(observationRepository);
+        }
+
+        @Test
         void acceptsASecretScannerCitationWithoutPersistingTheSecret() {
             ValidatedObservation observation = validObservation("pr-description-quality", Presence.PRESENT);
             ObjectNode evidence = (ObjectNode) observation.evidence();
@@ -833,7 +891,7 @@ class PracticeDetectionDeliveryServiceTest extends BaseUnitTest {
             assertThat(fingerprintCaptor.getValue())
                 .as("persisted recurrence_key matches the returned findingFingerprint")
                 .matches("[0-9a-f]{64}")
-                .isEqualTo(result.observationKeys().values().iterator().next().recurrenceKey());
+                .isEqualTo(result.delivered().get(0).keys().recurrenceKey());
 
             verify(eventPublisher).publishEvent(eventCaptor.capture());
             PracticeDetectionCompletedEvent event = eventCaptor.getValue();

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PullRequestReviewHandlerTest.java
@@ -464,7 +464,9 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
                 }
                 """;
             AgentJob job = jobWithOutput(rawOutput);
-            when(deliveryService.deliver(eq(job), any())).thenReturn(new DeliveryResult(1, 0, false, Map.of()));
+            when(deliveryService.deliver(eq(job), any())).thenAnswer(inv ->
+                new DeliveryResult(1, 0, false, inv.getArgument(1))
+            );
 
             admit(job, rawOutput);
 
@@ -499,8 +501,8 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             ArgumentCaptor<List<PracticeDetectionResultParser.ValidatedObservation>> captor = ArgumentCaptor.forClass(
                 List.class
             );
-            when(deliveryService.deliver(eq(job), captor.capture())).thenReturn(
-                new DeliveryResult(1, 0, false, Map.of())
+            when(deliveryService.deliver(eq(job), captor.capture())).thenAnswer(inv ->
+                new DeliveryResult(1, 0, false, inv.getArgument(1))
             );
 
             admit(job, rawOutput);
@@ -606,8 +608,8 @@ class PullRequestReviewHandlerTest extends BaseUnitTest {
             ArgumentCaptor<List<PracticeDetectionResultParser.ValidatedObservation>> captor = ArgumentCaptor.forClass(
                 List.class
             );
-            when(deliveryService.deliver(eq(job), captor.capture())).thenReturn(
-                new DeliveryResult(1, 0, false, Map.of())
+            when(deliveryService.deliver(eq(job), captor.capture())).thenAnswer(inv ->
+                new DeliveryResult(1, 0, false, inv.getArgument(1))
             );
 
             admit(job, rawOutput);


### PR DESCRIPTION
## Description

A practice review ran against a real pull request on staging and produced four observations, one of
them a correct, precisely cited defect:

> **error-handling** — Swallowed exception in `UserService.deactivateUser`; catch logs error but does
> not rethrow — `UserService.java:56-57`

The developer saw none of it. Delivery was refused outright:

```
JobDeliveryException: Evidence quote does not occur in the cited artifact:
  path=inputs/context/metadata.json
  at PracticeDetectionDeliveryService.enforceEvidenceBoundary(:426)
```

The offending citation was from `pr-scope`, quoting a line of PR metadata that differed from the
artifact by a **trailing comma** — a file the reader never sees, on the least consequential of the
four practices. Because `enforceEvidenceBoundary` threw, the whole batch went with it.

**Admission is a property of one observation, not of the batch.** A claim whose quote cannot be
traced back to the source must not reach a developer — that is the point of the check and it is
unchanged. But that claim has no bearing on the ones that were verified. Failing together traded a
false claim for no claims at all, which is the worse of the two errors: the reviewer learns nothing,
and the defect stays in the branch.

Each observation is now admitted or withheld on its own evidence. Withheld claims are logged
individually with the reason, because a model that cannot quote its own sources is a quality signal
that a silently working delivery would hide. A review in which *nothing* verifies is still a failed
delivery — that path is unchanged.

## How to test

```bash
./mvnw test -P'!quick' -Dtest=PracticeDetectionDeliveryServiceTest
```

**6,715 tests, 0 failures.** `pnpm run check` green.

Two new tests, both mutation-proven — restoring the throw fails
`withholdsOnlyTheObservationWhoseEvidenceCannotBeVerified` and leaves the rest green:

- one mis-quoted observation among sound ones → the sound ones are still delivered
- a batch where nothing verifies → still a failed delivery, `verifyNoInteractions(observationRepository)`

The existing `rejectsAQuoteThatIsNotInTheCitedArtifact` still passes unchanged: a single bad
observation leaves nothing admitted, so the delivery still fails, and the original reason is carried
in the message.

## The second change, and why it belongs here

Withholding one claim makes `DeliveryResult` ambiguous. It returned counts plus an identity-keyed
`Map<ValidatedObservation, ObservationKeys>`, and the caller joined its **own submitted list** against
that map to stamp keys. That was sound only while delivery was all-or-nothing. With per-claim
withholding the map is missing entries, so the obvious caller — iterate what you submitted, look up
each one — silently produces `withKeys(null)` observations.

So `DeliveryResult` now returns `delivered`: the observations that were persisted, each already
carrying its keys. The identity map, the join, and the null path all go away, and
`PullRequestReviewHandler`'s stamping loop becomes one line.

**To be clear about what this is and is not:** it does not fix a live defect. Composition reads
observations back from `observationRepository.findByAgentJobId(...)`, so a withheld observation —
never persisted — could not have been composed regardless. It removes a trap that my own change would
otherwise have introduced for the next caller.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

## Notes for reviewers

**The safety property is unchanged and worth checking I have not weakened it.** No observation is
delivered whose evidence fails verification — before or after. What changed is only whether *other*
observations die with it. If you think a mis-quoting model should discredit its whole review, that is
a coherent position and this is the wrong change.

**Scope of the change is deliberately narrow, and the integration suite is why.** My first attempt
degraded all three per-observation checks and broke `unknownSlugRejectsDeliveryAtomically` and
`emptyFindingsPublishesZeroEvent`. Those tests were right: an observation naming a practice the job
never admitted, or attributing work to the wrong person, means the agent answered a question nobody
asked — a protocol violation that should still fail the delivery whole. Only the evidence check now
degrades. And a review that legitimately found nothing still publishes its zero event, rather than
being treated as one whose claims were all rejected.

Job-level failures — a source whose authorization was withdrawn before delivery — are raised before
this loop and still abort everything, which is correct: those invalidate the whole run.

Not addressed here: the model quoted the same metadata line two different ways in one review, once
with a trailing comma and once without. Quote fidelity is a separate problem, and this change makes
it visible in the logs per claim instead of hiding it behind a total failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Reviews now withhold only claims whose quoted evidence cannot be verified, while delivering other verified findings.
  * Reviews still fail when evidence references an invalid source or when no claims can be verified.
  * Delivered findings retain their persisted identifiers and are reflected consistently in review results.

* **Bug Fixes**
  * Improved handling of mixed batches containing both valid and unverifiable evidence.
  * Prevented partially invalid evidence from being persisted or included in review results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->