### PR TITLE
ci: harden workflow diagnostics and remove configuration warnings

### DIFF
--- a/.github/actions/setup-caches/action.yml
+++ b/.github/actions/setup-caches/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Set up JDK 21
       if: startsWith(inputs.cache-type, 'application-server-') || contains(fromJSON('["webapp-e2e", "server-contracts"]'), inputs.cache-type)
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
       with:
         distribution: "temurin"
         java-version: "21"
@@ -27,7 +27,7 @@ runs:
       # failures because the cached classes don't match the current sources. Codegen
       # runs in ~5s — much cheaper than that failure mode.
       if: startsWith(inputs.cache-type, 'application-server-') || contains(fromJSON('["webapp-e2e", "server-contracts"]'), inputs.cache-type)
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.m2/repository
@@ -37,7 +37,7 @@ runs:
 
     - name: Cache Playwright browsers
       if: inputs.cache-type == 'webapp-storybook'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/ms-playwright
         key: ${{ inputs.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -46,7 +46,7 @@ runs:
 
     - name: Cache Storybook build
       if: contains(fromJSON('["webapp-visual", "webapp-storybook"]'), inputs.cache-type)
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           webapp/storybook-static

--- a/.github/workflows/cd-docs-teardown.yml
+++ b/.github/workflows/cd-docs-teardown.yml
@@ -23,7 +23,7 @@ jobs:
       PREVIEW_URL: ls1intum-hephaestus-docs-pr-${{ github.event.number }}.surge.sh
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             .github/actions/setup-pnpm-node

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -39,9 +39,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-pnpm-node
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             docs/.docusaurus
@@ -54,7 +54,7 @@ jobs:
       - run: pnpm --filter docs run build
         env:
           DOCUSAURUS_BASE_URL: "/"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-build-preview
           path: docs/build
@@ -65,9 +65,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-pnpm-node
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             docs/.docusaurus
@@ -80,7 +80,7 @@ jobs:
       - run: pnpm --filter docs run build
         env:
           DOCUSAURUS_BASE_URL: "/Hephaestus/"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-build-production
           path: docs/build
@@ -94,7 +94,7 @@ jobs:
     env:
       PREVIEW_URL: ls1intum-hephaestus-docs-pr-${{ github.event.number }}.surge.sh
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Need: composite action, Node version, lockfile (for actions/setup-node cache key).
           sparse-checkout: |
@@ -102,7 +102,7 @@ jobs:
             .node-version
             pnpm-lock.yaml
           sparse-checkout-cone-mode: false
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-build-preview
           path: docs-build
@@ -120,7 +120,7 @@ jobs:
             🔗 **[View Docs Preview](https://${{ env.PREVIEW_URL }})**
 
             <sub>Preview for commit ${{ github.event.pull_request.head.sha }}. Updates automatically on new commits.</sub>
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const sha = context.payload.pull_request?.head?.sha || context.sha;
@@ -143,7 +143,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-build-production
           path: docs-build

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -90,7 +90,7 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 2

--- a/.github/workflows/ci-compose-validate.yml
+++ b/.github/workflows/ci-compose-validate.yml
@@ -24,7 +24,7 @@ jobs:
     name: "Render compose stacks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Render the self-hosted stack
         working-directory: docker/self-host

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -203,7 +203,7 @@ jobs:
       contents: read
     steps:
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci-profile.yml
+++ b/.github/workflows/ci-profile.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -29,7 +29,8 @@ jobs:
           os: ${{ runner.os }}
 
       - name: Restore performance history
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        if: github.ref_name == github.event.repository.default_branch
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ci-profile-history
           key: ci-profile-history-${{ github.run_id }}
@@ -53,7 +54,7 @@ jobs:
           ci-metrics/server-integration.log ci-metrics/server-integration-resource.txt
 
       - name: Enforce performance budgets
-        if: success()
+        if: success() && github.ref_name == github.event.repository.default_branch
         run: |
           node scripts/check-ci-performance.ts ci-metrics/server-integration-profile.json ci-profile-history
           mkdir -p ci-profile-history
@@ -69,7 +70,7 @@ jobs:
 
       - name: Upload profile
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: server-integration-profile-${{ github.run_id }}
           path: |

--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.should_run.outputs.run == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The depths are QUOTED. Unquoted, `cond && 0 || 1` always yields 1, because the number 0
           # is falsy in GitHub expressions; the non-empty string '0' is truthy.
@@ -254,7 +254,7 @@ jobs:
 
       - name: Upload webapp test metrics
         if: steps.should_run.outputs.run == 'true' && matrix.check == 'webapp-quality' && always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-metrics-webapp-unit
           path: ci-metrics/webapp-unit.json

--- a/.github/workflows/ci-security-scan.yml
+++ b/.github/workflows/ci-security-scan.yml
@@ -24,7 +24,7 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.should_run.outputs.run == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Chromatic TurboSnap compares the stories job against its merge base.
           fetch-depth: ${{ matrix.test-type == 'webapp-storybook' && '0' || '1' }}
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload test metrics
         if: steps.should_run.outputs.run == 'true' && always() && (startsWith(matrix.test-type, 'application-server-') || matrix.test-type == 'webapp-storybook')
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-metrics-${{ matrix.test-type }}
           path: ci-metrics/*.json
@@ -198,7 +198,7 @@ jobs:
 
       - name: "Create Storybook status check"
         if: steps.should_run.outputs.run == 'true' && matrix.test-type == 'webapp-storybook' && always() && startsWith(steps.chromatic.outputs.storybookUrl, 'http')
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -232,7 +232,7 @@ jobs:
 
       - name: Upload webapp E2E diagnostics
         if: steps.should_run.outputs.run == 'true' && failure() && matrix.test-type == 'webapp-e2e'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: webapp-e2e-results
           path: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,17 +35,17 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           do_not_skip: '["workflow_dispatch", "push", "merge_group"]'
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |
@@ -165,10 +165,9 @@ jobs:
               - 'scripts/run-mvnw.ts'
               - '.github/workflows/ci-quality-gates.yml'
 
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: webapp_image_source
         with:
-          predicate-quantifier: every
           filters: |
             webapp-image-source:
               - 'webapp/src/**'
@@ -203,7 +202,7 @@ jobs:
     steps:
       - name: Link the preview deployments page on the PR
         if: vars.COOLIFY_PROJECT_UUID != '' && vars.COOLIFY_ENVIRONMENT_UUID != ''
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { COOLIFY_URL, COOLIFY_PROJECT_UUID, COOLIFY_ENVIRONMENT_UUID, COOLIFY_APP_UUID } = process.env;
@@ -347,7 +346,7 @@ jobs:
           show-waiting-runner: true
 
       - name: Summarize workflow performance
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const run = await github.rest.actions.getWorkflowRun({
@@ -541,7 +540,7 @@ jobs:
 
       - name: Create commit status
         if: always()
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const sha = context.payload.pull_request?.head?.sha || context.sha;

--- a/.github/workflows/openapi-autocommit.yml
+++ b/.github/workflows/openapi-autocommit.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm + Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -88,7 +88,7 @@ jobs:
       pull-requests: write
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       tag_name: ${{ steps.cut.outputs.tag_name }}
       sha: ${{ steps.cut.outputs.sha }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Pin to the exact commit CI/CD built — never main's tip, which may
           # already carry a newer version bump (that would skip this release).
@@ -149,7 +149,7 @@ jobs:
       application-server-digest: ${{ steps.retag.outputs.application-server-digest }}
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -218,7 +218,7 @@ jobs:
           done
 
       - name: Check out the released tree
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.release.outputs.sha }}
           fetch-depth: 1
@@ -352,7 +352,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Production Deploy
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GH_PAT }}
           script: |

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -76,7 +76,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -86,7 +86,7 @@ jobs:
       # - linux/arm64 builds on ubuntu-24.04-arm (aarch64)
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         with:
           # Use TUM's Docker Hub mirror to avoid rate limits (standard ls1intum approach)
           # See: https://github.com/ls1intum/.github/blob/main/.github/workflows/build-and-push-docker-image.yml
@@ -95,7 +95,7 @@ jobs:
               mirrors = ["https://docker-mirror.ase.in.tum.de:8765"]
 
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.registry }}/${{ inputs.image-name }}
           tags: ${{ inputs.single-arch && steps.tags.outputs.tags || '' }}
@@ -146,7 +146,9 @@ jobs:
       - name: Build and push (Dockerfile)
         id: build
         if: ${{ !inputs.use-buildpacks }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: ${{ inputs.docker-context }}
           file: ${{ inputs.docker-file }}
@@ -165,14 +167,14 @@ jobs:
       # like the Dockerfile path.
       - name: Set up JDK 21
         if: inputs.use-buildpacks
-        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: 21
 
       - name: Cache Maven dependencies
         if: inputs.use-buildpacks
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: m2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pom.xml') }}
@@ -257,7 +259,7 @@ jobs:
 
       - name: Upload SBOM
         if: inputs.use-buildpacks
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-${{ steps.prep.outputs.image_name }}-${{ steps.prep.outputs.platform_pair }}
           path: ${{ runner.temp }}/sbom/
@@ -303,7 +305,7 @@ jobs:
       - name: Upload Trivy SARIF to GitHub code scanning
         if: inputs.use-buildpacks && steps.install-trivy.outcome == 'success'
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@be1102e4461872bb6506cd26561a31b56671ace0 # v3.30.9
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.30.9
         with:
           sarif_file: ${{ runner.temp }}/trivy.sarif
           category: trivy-image-${{ steps.prep.outputs.platform_pair }}
@@ -379,7 +381,7 @@ jobs:
 
       - name: Upload digest
         if: ${{ !inputs.single-arch }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ steps.prep.outputs.image_name }}-${{ steps.prep.outputs.platform_pair }}
           path: ${{ runner.temp }}/digests/*
@@ -405,21 +407,21 @@ jobs:
           echo "image_name=${image//\//-}" >> $GITHUB_OUTPUT
 
       - name: Download digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-${{ steps.prep.outputs.image_name }}-*
           merge-multiple: true
 
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Prepare tag configuration
         id: tags
@@ -456,7 +458,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ inputs.registry }}/${{ inputs.image-name }}
           tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -16,7 +16,7 @@ jobs:
     # when a dependency bump is user-facing.
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -36,7 +36,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -40,19 +40,6 @@ flowchart TD
 Staging tracks `main` HEAD and production tracks the last released tag, so the two are deliberately
 not the same commit.
 
-## ⚡ Pipeline Timeline
-
-| Stage                 | Duration                   | Notes                       |
-| --------------------- | -------------------------- | --------------------------- |
-| Quality gates         | ~3 min                     | Parallel with tests         |
-| Tests                 | ~3 min                     | Parallel with gates         |
-| Docker builds         | ~3 min (cached)            | Registry cache, ~7 min cold |
-| Release cut           | ~1 min                     | On Version PR merge: tag + GitHub Release |
-| Staging deploy        | ~2 min                     | Automatic                   |
-| **Your verification** | You decide                 | Check staging               |
-| Production deploy     | ~2 min                     | After approval              |
-| **Total**             | **~12 min + verification** | ~8 min with full cache hits |
-
 ## 🚀 Release Flow
 
 Every merge to `main` runs CI and updates the accumulating **Version PR** (changesets). Merging that PR
@@ -129,6 +116,7 @@ Coolify handles PR previews:
 | `ci-tests.yml`         | Called by cicd.yml    | Unit, integration, visual tests                    |
 | `ci-docker-build.yml`  | Called by cicd.yml    | Docker image builds per component                  |
 | `ci-security-scan.yml` | Called by cicd.yml    | Dependency scanning (Trivy), secret detection      |
+| `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
 | `verify-changesets.yml`| PRs                   | Fails shipped-code PRs that carry no changeset     |
 | `ci-compose-validate.yml` | PRs, push to main  | Renders the reference and self-host compose stacks so an interpolation or merge break is a red check, not a stranger's bad first boot |
 | `version-pr.yml`       | Push to main          | Maintains the accumulating Version PR (changesets) |
@@ -189,20 +177,9 @@ because they decide the verdict of the App Server leg's lint and format step: th
 project the type-aware rules resolve against, the `:agents` scripts that invoke them, and the binary
 versions. A gate whose own configuration can change without re-running it is not a gate.
 
-**Benefits:**
-
-- Webapp-only changes skip Java tests (~3 min saved)
-- Docs-only changes skip all CI jobs (~7 min saved)
-- CI config changes run everything (safety net)
-
 ### Docker Layer Caching
 
 Docker builds use **registry-based caching** to store intermediate layers in `ghcr.io`:
-
-| Component            | First Build | Cached Build | Cache Size |
-| -------------------- | ----------- | ------------ | ---------- |
-| Application Server   | ~7 min      | ~30 sec      | ~500 MB    |
-| Webapp               | ~5 min      | ~30 sec      | ~200 MB    |
 
 **How it works:**
 
@@ -231,6 +208,28 @@ therefore subject to the registry's anonymous rate limit.
 
 - Outdated PR runs cancelled automatically
 - Release runs never cancelled
+
+### Monitoring CI
+
+Use GitHub's organization-level [Actions metrics](https://docs.github.com/en/actions/concepts/metrics)
+for workflow and job run time, queue time, failure rate, and runner usage. Each `CI Status Gate` job
+also includes the current run's dependency-aware timeline and job summary.
+
+The weekly `CI profile` workflow covers the server-specific data GitHub does not provide: JFR,
+resource usage, JUnit results, and Spring context-cache metrics. It signals only after three
+consecutive regressions against five earlier default-branch profiles. Branch dispatches produce
+standalone diagnostic artifacts without changing or enforcing that baseline.
+
+`SpringTestContextArchitectureTest` separately enforces the reviewed Spring context keys. Run the
+profile options locally with:
+
+```bash
+mkdir -p ci-metrics
+/usr/bin/time -v -o ci-metrics/server-integration-resource.txt \
+  pnpm run test:server:integration \
+  -DargLine=-XX:StartFlightRecording=filename=target/integration-profile.jfr,settings=profile,dumponexit=true \
+  -Dlogging.level.org.springframework.test.context.cache=DEBUG
+```
 
 ## 🛠️ Running CI Locally
 
@@ -303,7 +302,7 @@ The CI Status Gate job generates a visual **Mermaid timeline** showing:
 
 - Job execution order and duration
 - Parallel job execution
-- Runner wait times
+- Job creation-to-start delay, including dependency waiting
 - Critical path identification
 
 This helps identify bottlenecks and optimization opportunities.

--- a/scripts/check-ci-performance.test.ts
+++ b/scripts/check-ci-performance.test.ts
@@ -23,19 +23,21 @@ const summary = (startup: number, wall = 200): TestSummary => ({
 	},
 });
 
-await test("enforces absolute context budgets without history", () => {
+await test("does not signal an absolute-budget miss from one profile", () => {
 	const current = summary(121);
 	assert.ok(current.performance);
 	current.performance.contextStarts = 16;
-	assert.deepEqual(regressions(current, []), [
-		"context starts 16 > 15",
-		"context startup 121.0s > 120s",
-	]);
+	assert.deepEqual(regressions(current, []), []);
 });
 
-await test("uses median variance instead of a noisy single run", () => {
-	assert.deepEqual(
-		regressions(summary(100, 250), [summary(100, 198), summary(101, 200), summary(99, 202)]),
-		["wall time 250.0 > variance limit 240.0"],
-	);
+await test("signals only three consecutive misses against five prior profiles", () => {
+	const slow = summary(121, 250);
+	assert.ok(slow.performance);
+	slow.performance.contextStarts = 16;
+	const baseline = [100, 101, 99, 100, 100].map((startup) => summary(startup, 200));
+	assert.deepEqual(regressions(slow, [...baseline, slow, slow]), [
+		"context starts exceeded 15 in three consecutive profiles",
+		"context startup exceeded 120s in three consecutive profiles",
+		"wall time exceeded variance limit 240.0 three times",
+	]);
 });

--- a/scripts/check-ci-performance.ts
+++ b/scripts/check-ci-performance.ts
@@ -1,31 +1,39 @@
-import { readdir, readFile } from "node:fs/promises";
+import { appendFile, readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { TestSummary } from "./summarize-test-results.ts";
 
-type Metric = { name: string; value: (summary: TestSummary) => number; tolerance: number };
+type Metric = {
+	name: string;
+	unit: string;
+	value: (summary: TestSummary) => number;
+	tolerance: number;
+};
 
 const metrics: Metric[] = [
 	{
 		name: "wall time",
+		unit: "s",
 		value: (summary) => summary.performance?.wallTimeSeconds ?? 0,
 		tolerance: 0.2,
 	},
-	{ name: "summed test time", value: (summary) => summary.testTimeSeconds, tolerance: 0.15 },
+	{
+		name: "summed test time",
+		unit: "s",
+		value: (summary) => summary.testTimeSeconds,
+		tolerance: 0.15,
+	},
 	{
 		name: "CPU time",
+		unit: "s",
 		value: (summary) => summary.performance?.cpuTimeSeconds ?? 0,
 		tolerance: 0.25,
 	},
 	{
 		name: "max RSS",
+		unit: "KiB",
 		value: (summary) => summary.performance?.maxRssKilobytes ?? 0,
 		tolerance: 0.25,
-	},
-	{
-		name: "context startup time",
-		value: (summary) => summary.performance?.contextStartupSeconds ?? 0,
-		tolerance: 0.15,
 	},
 ];
 
@@ -37,25 +45,63 @@ const median = (values: number[]): number => {
 	return sorted.length % 2 === 0 ? ((sorted[middle - 1] ?? 0) + upper) / 2 : upper;
 };
 
+const percentile = (values: number[], percentage: number): number => {
+	const sorted = values.toSorted((left, right) => left - right);
+	return sorted[Math.ceil(sorted.length * percentage) - 1] ?? 0;
+};
+
+function historyMarkdown(summaries: TestSummary[]): string {
+	const usable = summaries.filter((summary) => summary.performance !== undefined).slice(-8);
+	const rows = [
+		...metrics.map((metric) => [metric.name, metric.unit, usable.map(metric.value)] as const),
+		[
+			"context starts",
+			"count",
+			usable.map((summary) => summary.performance?.contextStarts ?? 0),
+		] as const,
+		[
+			"context startup time",
+			"s",
+			usable.map((summary) => summary.performance?.contextStartupSeconds ?? 0),
+		] as const,
+		[
+			"context cache misses",
+			"count",
+			usable.map((summary) => summary.performance?.contextCacheMisses ?? 0),
+		] as const,
+	];
+	return `${[
+		"## Server integration profile baseline",
+		"",
+		`Profiles: **${usable.length}/8**`,
+		"",
+		"| Metric | Unit | p50 | p95 |",
+		"|---|---|---:|---:|",
+		...rows.map(
+			([name, unit, values]) =>
+				`| ${name} | ${unit} | ${percentile(values, 0.5).toFixed(1)} | ${percentile(values, 0.95).toFixed(1)} |`,
+		),
+	].join("\n")}\n`;
+}
+
 export function regressions(current: TestSummary, history: TestSummary[]): string[] {
 	const failures: string[] = [];
-	const performance = current.performance;
-	if (performance === undefined) return ["performance metrics are missing"];
-	if (performance.contextStarts > 15)
-		failures.push(`context starts ${performance.contextStarts} > 15`);
-	if (performance.contextStartupSeconds > 120) {
-		failures.push(`context startup ${performance.contextStartupSeconds.toFixed(1)}s > 120s`);
-	}
-	const usable = history.filter((summary) => summary.performance !== undefined).slice(-8);
-	if (usable.length < 3) return failures;
+	if (current.performance === undefined) return ["performance metrics are missing"];
+	const usable = history.filter((summary) => summary.performance !== undefined).slice(-7);
+	if (usable.length < 7) return failures;
+	const baselineRuns = usable.slice(0, 5);
+	const candidates = [...usable.slice(5), current];
+	if (candidates.every((summary) => (summary.performance?.contextStarts ?? 0) > 15))
+		failures.push("context starts exceeded 15 in three consecutive profiles");
+	if (candidates.every((summary) => (summary.performance?.contextStartupSeconds ?? 0) > 120))
+		failures.push("context startup exceeded 120s in three consecutive profiles");
 	for (const metric of metrics) {
-		const baselineValues = usable.map(metric.value);
+		const baselineValues = baselineRuns.map(metric.value);
 		const baseline = median(baselineValues);
 		const deviation = median(baselineValues.map((value) => Math.abs(value - baseline)));
 		const limit = baseline + Math.max(baseline * metric.tolerance, deviation * 3);
-		const value = metric.value(current);
-		if (value > limit)
-			failures.push(`${metric.name} ${value.toFixed(1)} > variance limit ${limit.toFixed(1)}`);
+		if (candidates.every((summary) => metric.value(summary) > limit))
+			failures.push(`${metric.name} exceeded variance limit ${limit.toFixed(1)} three times`);
 	}
 	return failures;
 }
@@ -106,7 +152,9 @@ async function main(): Promise<void> {
 	const current = parseSummary(await readFile(currentPath, "utf8"));
 	let files: string[] = [];
 	try {
-		files = (await readdir(historyDirectory)).filter((file) => file.endsWith(".json")).toSorted();
+		files = (await readdir(historyDirectory))
+			.filter((file) => file.endsWith(".json"))
+			.toSorted((left, right) => left.localeCompare(right, undefined, { numeric: true }));
 	} catch (error) {
 		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
 	}
@@ -116,6 +164,10 @@ async function main(): Promise<void> {
 		),
 	);
 	const failures = regressions(current, history);
+	const rendered = historyMarkdown([...history, current]);
+	process.stdout.write(rendered);
+	if (process.env.GITHUB_STEP_SUMMARY !== undefined)
+		await appendFile(process.env.GITHUB_STEP_SUMMARY, rendered);
 	if (failures.length > 0)
 		throw new Error(`CI performance regression:\n- ${failures.join("\n- ")}`);
 }


### PR DESCRIPTION
## Description

Make CI diagnostics more reliable without introducing a second metrics system that maintainers would have to discover and operate.

The repository already has the right general-purpose tools: GitHub's organization-level Actions metrics for workflow/job run time, queue time, failure rate, and runner usage; native per-run timelines and job summaries for individual investigations; and the existing `CI profile` workflow for Spring-specific data that GitHub cannot provide. This PR keeps that division instead of adding a custom weekly pull-request report.

It improves the targeted Spring profile by:

- showing rolling p50 and p95 values with explicit units for wall time, CPU, memory, test time, Spring starts, cumulative startup, and context-cache misses;
- requiring three consecutive regressions against five earlier profiles, so one noisy hosted runner cannot fail the profile;
- sorting profile history numerically by workflow run ID;
- enforcing and updating the rolling baseline only on the default branch, while feature-branch dispatches remain standalone diagnostics.

It also resolves actionable workflow warnings by removing the unsupported `predicate-quantifier` input, disabling Docker's optional build-record upload while retaining its native build summary plus the repository's explicit digest and SBOM artifacts, and updating affected JavaScript actions to immutable Node 24 release pins. No additional permission is granted to suppress a warning, and no required test, security, migration, image-build, signing, attestation, or preview confidence is removed.

The contributor guide now points maintainers to GitHub Actions metrics for fleet-wide CI questions and to `CI profile` for Spring investigations. Static duration estimates and the incorrect claim that job creation-to-start is pure runner wait were removed.

This intentionally narrows #1528: it delivers warning-free, actionable diagnostics using supported platform features, but does not claim that a passive custom Actions summary would enforce a service level. The remaining latency work and any explicit organization-level SLO ownership should be handled separately once [#1527](https://github.com/ls1intum/Hephaestus/issues/1527) establishes stable server margin.

Refs #1528

## How to test

- `pnpm run format`
- `pnpm run check`
- `node --import tsx --test scripts/check-ci-performance.test.ts`
- `actionlint -shellcheck=''`

After merge, dispatch **CI profile** on both the default branch and a feature branch. Both should upload diagnostic artifacts; only the default-branch run should restore and enforce rolling history. A single over-budget profile must not fail, while three consecutive controlled regressions should produce a failed scheduled profile with the rolling summary attached.

For a Docker-affecting change, confirm that the native Docker build summary, explicit digest artifacts, SBOMs, attestations, signatures, scans, and manifest creation remain available without the previous optional build-record warning.

## Checklist

- [x] No shipped application code changes, so no changeset is required.
- [x] No operator action, migration, or configuration change is required.
- [x] Required verification and image publication remain intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD documentation with monitoring guidance, performance thresholds, diagnostic artifacts, and local profiling instructions.
  * Clarified workflow timelines and Docker layer caching information.

* **Improvements**
  * Enhanced CI performance reporting with baseline tables, metric units, and clearer regression messages.
  * Improved detection of sustained performance issues across multiple runs.
  * Refined workflow behavior for performance checks and Docker build record handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->