### PR TITLE
fix(server): disclose AI authorship on all feedback

### DIFF
--- a/.changeset/clear-ai-feedback-disclosure.md
+++ b/.changeset/clear-ai-feedback-disclosure.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Practice-review comments now identify themselves as AI-generated and link to an explanation and delivery controls.

--- a/docs/admin/github-integration.mdx
+++ b/docs/admin/github-integration.mdx
@@ -19,14 +19,15 @@ This page covers the other two.
 
 ## Choosing PAT vs GitHub App
 
-**PAT mode is fully supported** and is the right starting point for a single-org install:
+**PAT mode is fully supported for synchronization** and is the simplest way to evaluate a single-org
+install. Use a GitHub App before enabling feedback delivery so comments have a distinct app identity.
 
 | | PAT | GitHub App |
 | --- | --- | --- |
 | Setup effort | Paste a token in the workspace UI | Create + install an App, manage a private key |
 | Environment variables | None | `GH_APP_ID`, `GH_APP_PRIVATE_KEY`, `GH_APP_INSTALLATION_URL` |
 | Rate limits | 5,000 req/h, shared across all of that user's tokens | 5,000+ req/h **per installation**, scaling with org size (up to 12,500) |
-| AI-review feedback posted back to GitHub (PR comments, inline notes, approvals) | Posted as the token's user | Posted as the App (recommended) |
+| AI-review feedback posted back to GitHub (PR comments, inline notes, approvals) | Posted as the token's user; do not use for active delivery | Posted as the App |
 | Webhooks | Create manually (below) | Configured once on the App |
 
 Tokens are stored encrypted (AES-256-GCM) per workspace in the database.
@@ -34,10 +35,9 @@ Tokens are stored encrypted (AES-256-GCM) per workspace in the database.
 ### PAT mode
 
 1. Create a token: **classic PAT** with `repo` + `read:org` (the `repo` scope already
-   grants PR/issue write for feedback delivery), or a **fine-grained PAT** whose *resource
+   grants PR/issue write access), or a **fine-grained PAT** whose *resource
    owner* is the organization, with repository permissions Contents, Issues, Pull requests
-   and Discussions (Read — add Write on Issues and Pull requests to deliver AI-review
-   feedback) plus organization permissions Members and Projects (Read). Omitting
+   and Discussions (Read) plus organization permissions Members and Projects (Read). Omitting
    Discussions or Projects leaves those syncs silently empty.
 2. Leave `GH_APP_ID` unset (defaults to `0` = PAT mode).
 3. Paste the token when creating/configuring the workspace in the UI.

--- a/docs/contributor/practice-feedback-language.md
+++ b/docs/contributor/practice-feedback-language.md
@@ -59,17 +59,9 @@ A column that counts per row is headed **Feedback** and the cell holds the numbe
 needs a singular subject, name what the feedback is *about* — "the feedback for this observation", not
 "the message for this observation".
 
-**Say what happens, not who does it.** On a practice surface, and in the footer of a delivered review
-comment, the subject is the operation and its results — *a practice review*, *a review*, *feedback*, *an
-observation* — not the application performing them. "What a review does on its own", not "What Hephaestus
-does on its own"; "Practice review", not "Hephaestus Agent". Two reasons, and both outlive the current copy:
-the product name adds a second voice to a screen that is already inside the product (and, on a provider, the
-bot account the comment is posted under has already attributed it), and reaching for a name for the doer is
-exactly what pulls a writer towards *agent*, the word this vocabulary bans. **Hephaestus** stays the right
-word where the application itself is the subject — installing it, linking an account to it, a release of it,
-and in the compound terms **Hephaestus default** and **No Hephaestus default** — and it is still the actor a
-contributor doc names when explaining what the system does. This rule is about the surfaces a developer or a
-workspace administrator reads.
+**Say what happens, not who does it.** On practice-review surfaces, use *practice review*, *review*,
+*feedback*, or *observation* as the subject. Use **Hephaestus** when the application itself is the subject,
+such as installation, account linking, or releases. Do not call the application or a review an *agent*.
 
 **All three channel names say where the feedback lands, and nothing else.** `IN_CONTEXT` lands on the work
 itself — a pull request summary or inline note, an issue comment. `IN_CHAT` lands in a turn of a

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/ApprovedFeedbackDeliveryListener.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/ApprovedFeedbackDeliveryListener.java
@@ -32,6 +32,7 @@ class ApprovedFeedbackDeliveryListener {
     private final AgentJobRepository agentJobRepository;
     private final PracticeFeedbackDeliveryPolicy deliveryPolicy;
     private final PullRequestCommentPoster commentPoster;
+    private final PracticeFeedbackCommentFormatter commentFormatter;
     private final FeedbackApprovalEligibility approvalEligibility;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -114,7 +115,11 @@ class ApprovedFeedbackDeliveryListener {
         }
         if (existing.kind() == ExistingDeliveryLookup.Kind.ABSENT) {
             try {
-                commentPoster.postApprovedProposal(job, feedback.getId(), feedback.getBody());
+                commentPoster.postApprovedProposal(
+                    job,
+                    feedback.getId(),
+                    commentFormatter.appendDisclosure(safeBody, job)
+                );
             } catch (JobDeliverySuppressedException exception) {
                 feedbackRepository.markApprovedSuppressed(
                     event.workspaceId(),

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePoster.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePoster.java
@@ -18,12 +18,11 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Reconciles sanitized inline observations through the provider-specific channel. */
 class DiffNotePoster {
 
     private static final Logger log = LoggerFactory.getLogger(DiffNotePoster.class);
 
-    /** Invisible marker appended to diff note bodies to identify hephaestus-posted notes. */
+    /** Identifies inline feedback created by Hephaestus during reconciliation. */
     static final String HEPHAESTUS_MARKER = "<!-- hephaestus-diff-note -->";
 
     private final PullRequestCommentPoster commentPoster;
@@ -71,10 +70,11 @@ class DiffNotePoster {
         SummaryChannel.FeedbackTarget target = commentPoster.buildTarget(job, kind, job.getWorkspace().getId());
 
         List<InlineFeedbackChannel.InlineFeedback> observations = mapObservations(
+            job,
             diffNotes == null ? List.of() : diffNotes
         );
 
-        // An empty reconcile clears stale notes; non-empty channels reconcile by recurrence key.
+        // Clearing on an empty run removes inline feedback that no longer recurs.
         if (observations.isEmpty()) {
             try {
                 channel.clearStaleFeedback(target, HEPHAESTUS_MARKER);
@@ -114,14 +114,14 @@ class DiffNotePoster {
         }
     }
 
-    private List<InlineFeedbackChannel.InlineFeedback> mapObservations(List<DiffNote> diffNotes) {
+    private List<InlineFeedbackChannel.InlineFeedback> mapObservations(AgentJob job, List<DiffNote> diffNotes) {
         List<InlineFeedbackChannel.InlineFeedback> observations = new ArrayList<>(diffNotes.size());
         for (DiffNote note : diffNotes) {
             String sanitized = PullRequestCommentPoster.sanitize(note.body());
             if (sanitized.isBlank()) {
                 continue;
             }
-            // A multi-line DiffAnchor stores the end first and optional range start second.
+            // DiffAnchor expects the range end before its optional start.
             Integer endLine = note.endLine();
             boolean isMultiLine = endLine != null && endLine > note.startLine();
             FeedbackAnchor.DiffAnchor anchor = isMultiLine
@@ -130,7 +130,7 @@ class DiffNotePoster {
             observations.add(
                 new InlineFeedbackChannel.InlineFeedback(
                     anchor,
-                    commentFormatter.appendSettingsNotice(sanitized),
+                    commentFormatter.appendDisclosure(sanitized, job),
                     HEPHAESTUS_MARKER,
                     note.recurrenceKey()
                 )

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePoster.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePoster.java
@@ -130,7 +130,7 @@ class DiffNotePoster {
             observations.add(
                 new InlineFeedbackChannel.InlineFeedback(
                     anchor,
-                    commentFormatter.appendInlineDisclosure(sanitized),
+                    commentFormatter.appendInlineFeedbackPrompt(sanitized),
                     HEPHAESTUS_MARKER,
                     note.recurrenceKey()
                 )

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePoster.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePoster.java
@@ -130,7 +130,7 @@ class DiffNotePoster {
             observations.add(
                 new InlineFeedbackChannel.InlineFeedback(
                     anchor,
-                    commentFormatter.appendDisclosure(sanitized, job),
+                    commentFormatter.appendInlineDisclosure(sanitized),
                     HEPHAESTUS_MARKER,
                     note.recurrenceKey()
                 )

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
@@ -40,13 +40,10 @@ class PracticeFeedbackCommentFormatter {
         return sb.toString();
     }
 
-    String appendInlineDisclosure(String sanitizedBody) {
-        var sb = new StringBuilder(sanitizedBody.length() + 220);
+    String appendInlineFeedbackPrompt(String sanitizedBody) {
+        var sb = new StringBuilder(sanitizedBody.length() + 120);
         sb.append(sanitizedBody).append("\n\n");
-        sb
-            .append("<sub>AI-generated &middot; [Why you're seeing this and how to stop it](")
-            .append(preferencesUrl)
-            .append(")</sub>\n");
+        sb.append("<sub>React with 👍 or 👎, or reply, to give feedback.</sub>\n");
         return sb.toString();
     }
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
@@ -28,26 +28,22 @@ class PracticeFeedbackCommentFormatter {
         sb.append(sanitizedBody).append("\n\n");
         sb.append("---\n");
         appendMetadataFooter(sb, job);
-        appendDeliverySettingsLink(sb);
+        appendWhyAndSettingsLink(sb);
         return sb.toString();
     }
 
-    String appendSettingsNotice(String sanitizedBody) {
-        var sb = new StringBuilder(sanitizedBody.length() + 180);
+    String appendDisclosure(String sanitizedBody, AgentJob job) {
+        var sb = new StringBuilder(sanitizedBody.length() + 420);
         sb.append(sanitizedBody).append("\n\n");
-        appendDeliverySettingsLink(sb);
+        appendMetadataFooter(sb, job);
+        appendWhyAndSettingsLink(sb);
         return sb.toString();
     }
 
-    private void appendDeliverySettingsLink(StringBuilder sb) {
-        sb.append("<sub>[Manage comments and Slack reminders](").append(preferencesUrl).append(")</sub>\n");
+    private void appendWhyAndSettingsLink(StringBuilder sb) {
+        sb.append("<sub>[Why you're seeing this and how to stop it](").append(preferencesUrl).append(")</sub>\n");
     }
 
-    /**
-     * The footer names what produced the comment — a practice review — not who ran it. The bot account the
-     * comment is posted under already attributes the application on the provider, so repeating the product
-     * name here only adds a second voice; and "agent" is the word the practice vocabulary bans for it.
-     */
     private static void appendMetadataFooter(StringBuilder sb, AgentJob job) {
         sb.append("<sub>Practice review");
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
@@ -43,7 +43,7 @@ class PracticeFeedbackCommentFormatter {
     String appendInlineFeedbackPrompt(String sanitizedBody) {
         var sb = new StringBuilder(sanitizedBody.length() + 120);
         sb.append(sanitizedBody).append("\n\n");
-        sb.append("<sub>React with 👍 or 👎, or reply, to give feedback.</sub>\n");
+        sb.append("<sub>AI-generated &middot; React with 👍 or 👎, or reply, to give feedback.</sub>\n");
         return sb.toString();
     }
 

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
@@ -51,7 +51,9 @@ class PracticeFeedbackCommentFormatter {
         if (modelName != null && !modelName.isBlank()) {
             sb.append(" &middot; ").append(HtmlUtils.htmlEscape(modelName));
         }
-        sb.append(" &middot; AI-generated and can be inaccurate. React with 👍 or 👎 to give feedback.</sub>\n");
+        sb.append(
+            " &middot; AI-generated and can be inaccurate. React with 👍 or 👎, or reply, to give feedback.</sub>\n"
+        );
     }
 
     @Nullable

--- a/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
+++ b/server/src/main/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatter.java
@@ -40,6 +40,16 @@ class PracticeFeedbackCommentFormatter {
         return sb.toString();
     }
 
+    String appendInlineDisclosure(String sanitizedBody) {
+        var sb = new StringBuilder(sanitizedBody.length() + 220);
+        sb.append(sanitizedBody).append("\n\n");
+        sb
+            .append("<sub>AI-generated &middot; [Why you're seeing this and how to stop it](")
+            .append(preferencesUrl)
+            .append(")</sub>\n");
+        return sb.toString();
+    }
+
     private void appendWhyAndSettingsLink(StringBuilder sb) {
         sb.append("<sub>[Why you're seeing this and how to stop it](").append(preferencesUrl).append(")</sub>\n");
     }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/ApprovedFeedbackDeliveryListenerTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/ApprovedFeedbackDeliveryListenerTest.java
@@ -7,6 +7,7 @@ import de.tum.cit.aet.hephaestus.agent.handler.spi.ExistingDeliveryLookup;
 import de.tum.cit.aet.hephaestus.agent.handler.spi.JobDeliverySuppressedException;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJob;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJobRepository;
+import de.tum.cit.aet.hephaestus.config.ApplicationProperties;
 import de.tum.cit.aet.hephaestus.integration.scm.domain.pullrequest.PullRequest;
 import de.tum.cit.aet.hephaestus.practices.feedback.Feedback;
 import de.tum.cit.aet.hephaestus.practices.feedback.FeedbackChannel;
@@ -44,6 +45,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             mock(AgentJobRepository.class),
             mock(PracticeFeedbackDeliveryPolicy.class),
             mock(PullRequestCommentPoster.class),
+            formatter(),
             eligibility
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -73,6 +75,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -99,7 +102,7 @@ class ApprovedFeedbackDeliveryListenerTest {
         when(poster.findApprovedProposal(job, feedbackId)).thenReturn(ExistingDeliveryLookup.absent());
         doThrow(new JobDeliverySuppressedException("silent", new RuntimeException("silent")))
             .when(poster)
-            .postApprovedProposal(job, feedbackId, "Exact proposal");
+            .postApprovedProposal(eq(job), eq(feedbackId), contains("AI-generated and can be inaccurate"));
 
         new ApprovedFeedbackDeliveryListener(
             feedbackRepository,
@@ -107,6 +110,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -139,10 +143,11 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
-        verify(poster).postApprovedProposal(job, feedbackId, "Exact proposal");
+        verify(poster).postApprovedProposal(eq(job), eq(feedbackId), contains("AI-generated and can be inaccurate"));
         verify(feedbackRepository).markApprovedDelivered(7L, feedbackId);
     }
 
@@ -171,6 +176,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -204,6 +210,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -237,6 +244,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -268,6 +276,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -302,6 +311,7 @@ class ApprovedFeedbackDeliveryListenerTest {
             jobRepository,
             policy,
             poster,
+            formatter(),
             eligible()
         ).deliver(new ApprovedFeedbackReadyEvent(7L, feedbackId));
 
@@ -311,6 +321,12 @@ class ApprovedFeedbackDeliveryListenerTest {
             FeedbackSuppressionReason.APPROVAL_STALE.name()
         );
         verifyNoInteractions(jobRepository, policy, poster);
+    }
+
+    private static PracticeFeedbackCommentFormatter formatter() {
+        return new PracticeFeedbackCommentFormatter(
+            new ApplicationProperties(null, new ApplicationProperties.Webapp("https://hephaestus.example"))
+        );
     }
 
     private static void approve(FeedbackApprovalRepository repository, Feedback feedback) {

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
@@ -101,11 +101,9 @@ class DiffNotePosterTest extends BaseUnitTest {
         assertThat(anchor.filePath()).isEqualTo("src/A.java");
         assertThat(anchor.newLineNumber()).isEqualTo(14);
         assertThat(f.body())
-            .contains("<sub>AI-generated &middot; ")
-            .doesNotContain("React with")
-            .contains(
-                "[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)"
-            );
+            .contains("<sub>React with 👍 or 👎, or reply, to give feedback.</sub>")
+            .doesNotContain("AI-generated")
+            .doesNotContain("Why you're seeing this");
         assertThat(anchor.startLine()).isEqualTo(10);
         assertThat(f.recurrenceKey()).isEqualTo("ck-multi");
     }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
@@ -101,8 +101,7 @@ class DiffNotePosterTest extends BaseUnitTest {
         assertThat(anchor.filePath()).isEqualTo("src/A.java");
         assertThat(anchor.newLineNumber()).isEqualTo(14);
         assertThat(f.body())
-            .contains("<sub>React with 👍 or 👎, or reply, to give feedback.</sub>")
-            .doesNotContain("AI-generated")
+            .contains("<sub>AI-generated &middot; React with 👍 or 👎, or reply, to give feedback.</sub>")
             .doesNotContain("Why you're seeing this");
         assertThat(anchor.startLine()).isEqualTo(10);
         assertThat(f.recurrenceKey()).isEqualTo("ck-multi");

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
@@ -27,11 +27,6 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-/**
- * Unit tests for the inline diff-note poster (DiffNote → InlineFeedback mapping + channel dispatch). Couples to
- * A1: a repo-relative anchor path flows through unchanged, and the (startLine, endLine) → (newLineNumber,
- * startLine) anchor swap is verified.
- */
 class DiffNotePosterTest extends BaseUnitTest {
 
     private static List<InlineFeedback> posted(RecordingChannel channel) {
@@ -57,7 +52,6 @@ class DiffNotePosterTest extends BaseUnitTest {
         return new FeedbackTarget(new IntegrationRef(IntegrationKind.GITLAB, 1L, null), "group/project!42", null);
     }
 
-    /** A recording channel that captures the observations it was asked to post (and whether clear was invoked). */
     private static final class RecordingChannel implements InlineFeedbackChannel {
 
         @Nullable
@@ -97,7 +91,6 @@ class DiffNotePosterTest extends BaseUnitTest {
     void multiLineNote_swapsToEndLineAnchorWithRangeStart_andCarriesRecurrenceKey() {
         RecordingChannel channel = new RecordingChannel();
         DiffNotePoster poster = poster(channel);
-        // endLine > startLine ⇒ multi-line: the anchor's newLineNumber is the END line, startLine the range start.
         DiffNote multi = new DiffNote("src/A.java", 10, 14, "Fix this range", "ck-multi");
 
         poster.reconcileInlineNotes(gitlabJob(), List.of(multi));
@@ -106,11 +99,13 @@ class DiffNotePosterTest extends BaseUnitTest {
         InlineFeedback f = channel.posted.get(0);
         FeedbackAnchor.DiffAnchor anchor = (FeedbackAnchor.DiffAnchor) f.anchor();
         assertThat(anchor.filePath()).isEqualTo("src/A.java");
-        assertThat(anchor.newLineNumber()).isEqualTo(14); // end line
-        assertThat(f.body()).contains(
-            "[Manage comments and Slack reminders](https://hephaestus.example/settings#practice-feedback)"
-        );
-        assertThat(anchor.startLine()).isEqualTo(10); // range start
+        assertThat(anchor.newLineNumber()).isEqualTo(14);
+        assertThat(f.body())
+            .contains("AI-generated and can be inaccurate")
+            .contains(
+                "[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)"
+            );
+        assertThat(anchor.startLine()).isEqualTo(10);
         assertThat(f.recurrenceKey()).isEqualTo("ck-multi");
     }
 
@@ -131,14 +126,13 @@ class DiffNotePosterTest extends BaseUnitTest {
     void blankBodyNote_isSkipped_andClearsStaleWhenAllBlank() {
         RecordingChannel channel = new RecordingChannel();
         DiffNotePoster poster = poster(channel);
-        // A body that sanitizes to blank yields no observation → the all-empty path clears stale notes instead.
         DiffNote blank = new DiffNote("src/A.java", 10, null, "   ", "ck-blank");
 
         DiffNotePoster.DiffNoteResult result = poster.reconcileInlineNotes(gitlabJob(), List.of(blank));
 
         assertThat(result.posted()).isZero();
-        assertThat(channel.posted).isNull(); // postInlineFeedback never invoked
-        assertThat(channel.cleared).isTrue(); // stale-clear path taken
+        assertThat(channel.posted).isNull();
+        assertThat(channel.cleared).isTrue();
     }
 
     @Test
@@ -165,8 +159,6 @@ class DiffNotePosterTest extends BaseUnitTest {
 
     @Test
     void repoRelativeAnchorPath_flowsThroughUnchanged() {
-        // A1 coupling: the poster does not mutate the anchor path — the repo-relativisation must already have
-        // happened upstream in DeliveryComposer. A repo-relative path arrives and is posted verbatim.
         RecordingChannel channel = new RecordingChannel();
         DiffNotePoster poster = poster(channel);
         DiffNote note = new DiffNote("src/components/Button.tsx", 1, null, "Remove unused import", "ck-1");

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/DiffNotePosterTest.java
@@ -101,7 +101,8 @@ class DiffNotePosterTest extends BaseUnitTest {
         assertThat(anchor.filePath()).isEqualTo("src/A.java");
         assertThat(anchor.newLineNumber()).isEqualTo(14);
         assertThat(f.body())
-            .contains("AI-generated and can be inaccurate")
+            .contains("<sub>AI-generated &middot; ")
+            .doesNotContain("React with")
             .contains(
                 "[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)"
             );

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
@@ -61,7 +61,8 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
         String result = formatter("https://hephaestus.example").appendInlineFeedbackPrompt("Inline feedback");
 
         assertThat(result).isEqualTo(
-            "Inline feedback\n\n<sub>React with 👍 or 👎, or reply, to give feedback.</sub>\n"
+            "Inline feedback\n\n" +
+                "<sub>AI-generated &middot; React with 👍 or 👎, or reply, to give feedback.</sub>\n"
         );
     }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import de.tum.cit.aet.hephaestus.agent.job.AgentJob;
 import de.tum.cit.aet.hephaestus.config.ApplicationProperties;
 import de.tum.cit.aet.hephaestus.testconfig.BaseUnitTest;
-import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
@@ -26,14 +25,9 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
                 "<sub>Practice review &middot; model&lt;&amp;&gt; &middot; AI-generated and can be inaccurate." +
                     " React with 👍 or 👎 to give feedback.</sub>"
             )
-            // Run duration is operator telemetry; the developer reading a review has no use for it.
-            .doesNotContain("1m 30s")
             .contains(
-                "[Manage comments and Slack reminders](https://hephaestus.example.com/settings#practice-feedback)"
-            )
-            // Every developer who receives feedback reads this footer, so the product name staying out of
-            // it is pinned rather than left to review.
-            .doesNotContain("Hephaestus Agent");
+                "[Why you're seeing this and how to stop it](https://hephaestus.example.com/settings#practice-feedback)"
+            );
     }
 
     @Test
@@ -43,17 +37,23 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
         String result = formatter.format("Body", job());
 
         assertThat(result).contains(
-            "[Manage comments and Slack reminders](https://hephaestus.example/app/settings#practice-feedback)"
+            "[Why you're seeing this and how to stop it](https://hephaestus.example/app/settings#practice-feedback)"
         );
     }
 
     @Test
-    void appendsDeliverySettingsLinkToSupplementalComment() {
-        String result = formatter("https://hephaestus.example").appendSettingsNotice("Inline feedback");
+    void appendsDisclosureAndSettingsLinkToInlineComment() {
+        String result = formatter("https://hephaestus.example").appendDisclosure("Inline feedback", job());
 
-        assertThat(result).isEqualTo(
-            "Inline feedback\n\n<sub>[Manage comments and Slack reminders](https://hephaestus.example/settings#practice-feedback)</sub>\n"
-        );
+        assertThat(result)
+            .startsWith("Inline feedback\n\n")
+            .contains(
+                "<sub>Practice review &middot; model&lt;&amp;&gt; &middot; AI-generated and can be inaccurate." +
+                    " React with 👍 or 👎 to give feedback.</sub>"
+            )
+            .endsWith(
+                "<sub>[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)</sub>\n"
+            );
     }
 
     private static PracticeFeedbackCommentFormatter formatter(String webappUrl) {
@@ -65,8 +65,6 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
     private static AgentJob job() {
         AgentJob job = new AgentJob();
         job.setId(UUID.randomUUID());
-        job.setStartedAt(Instant.parse("2024-01-01T00:00:00Z"));
-        job.setCompletedAt(Instant.parse("2024-01-01T00:01:30Z"));
         job.setConfigSnapshot(new ObjectMapper().createObjectNode().put("upstreamModelId", "model<&>"));
         return job;
     }

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
@@ -42,11 +42,11 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
     }
 
     @Test
-    void appendsDisclosureAndSettingsLinkToInlineComment() {
-        String result = formatter("https://hephaestus.example").appendDisclosure("Inline feedback", job());
+    void appendsDisclosureAndSettingsLink() {
+        String result = formatter("https://hephaestus.example").appendDisclosure("Approved feedback", job());
 
         assertThat(result)
-            .startsWith("Inline feedback\n\n")
+            .startsWith("Approved feedback\n\n")
             .contains(
                 "<sub>Practice review &middot; model&lt;&amp;&gt; &middot; AI-generated and can be inaccurate." +
                     " React with 👍 or 👎, or reply, to give feedback.</sub>"
@@ -54,6 +54,18 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
             .endsWith(
                 "<sub>[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)</sub>\n"
             );
+    }
+
+    @Test
+    void appendsCompactDisclosureToInlineComment() {
+        String result = formatter("https://hephaestus.example").appendInlineDisclosure("Inline feedback");
+
+        assertThat(result).isEqualTo(
+            "Inline feedback\n\n" +
+                "<sub>AI-generated &middot; " +
+                "[Why you're seeing this and how to stop it]" +
+                "(https://hephaestus.example/settings#practice-feedback)</sub>\n"
+        );
     }
 
     private static PracticeFeedbackCommentFormatter formatter(String webappUrl) {

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
@@ -57,14 +57,11 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
     }
 
     @Test
-    void appendsCompactDisclosureToInlineComment() {
-        String result = formatter("https://hephaestus.example").appendInlineDisclosure("Inline feedback");
+    void appendsFeedbackPromptToInlineComment() {
+        String result = formatter("https://hephaestus.example").appendInlineFeedbackPrompt("Inline feedback");
 
         assertThat(result).isEqualTo(
-            "Inline feedback\n\n" +
-                "<sub>AI-generated &middot; " +
-                "[Why you're seeing this and how to stop it]" +
-                "(https://hephaestus.example/settings#practice-feedback)</sub>\n"
+            "Inline feedback\n\n<sub>React with 👍 or 👎, or reply, to give feedback.</sub>\n"
         );
     }
 

--- a/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
+++ b/server/src/test/java/de/tum/cit/aet/hephaestus/agent/handler/PracticeFeedbackCommentFormatterTest.java
@@ -23,7 +23,7 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
             .contains("Test body content")
             .contains(
                 "<sub>Practice review &middot; model&lt;&amp;&gt; &middot; AI-generated and can be inaccurate." +
-                    " React with 👍 or 👎 to give feedback.</sub>"
+                    " React with 👍 or 👎, or reply, to give feedback.</sub>"
             )
             .contains(
                 "[Why you're seeing this and how to stop it](https://hephaestus.example.com/settings#practice-feedback)"
@@ -49,7 +49,7 @@ class PracticeFeedbackCommentFormatterTest extends BaseUnitTest {
             .startsWith("Inline feedback\n\n")
             .contains(
                 "<sub>Practice review &middot; model&lt;&amp;&gt; &middot; AI-generated and can be inaccurate." +
-                    " React with 👍 or 👎 to give feedback.</sub>"
+                    " React with 👍 or 👎, or reply, to give feedback.</sub>"
             )
             .endsWith(
                 "<sub>[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)</sub>\n"

--- a/webapp/src/components/settings/PracticeFeedbackSection.tsx
+++ b/webapp/src/components/settings/PracticeFeedbackSection.tsx
@@ -23,7 +23,8 @@ export function PracticeFeedbackSection({
 					Practice feedback
 				</h2>
 				<p className="text-sm text-muted-foreground">
-					Control new comments on work you author and related Slack reminders.
+					Your workspace can deliver AI-generated practice feedback on work you author and send
+					related Slack reminders. You can turn these messages off below.
 				</p>
 			</div>
 
@@ -31,9 +32,9 @@ export function PracticeFeedbackSection({
 				<FieldContent>
 					<FieldLabel htmlFor="practice-feedback-delivery">Comments and Slack reminders</FieldLabel>
 					<FieldDescription>
-						When off, Hephaestus won't post new practice-feedback comments on issues, pull requests,
-						or merge requests you author or send related Slack reminders. Reviews still run,
-						observations remain stored, and workspace admins can still view them.
+						Turn this off to stop new comments on issues, pull requests, and merge requests you
+						author, and related Slack reminders. Reviews still run, and workspace admins can still
+						see the resulting observations.
 					</FieldDescription>
 				</FieldContent>
 				<Switch


### PR DESCRIPTION
## Description

Makes every source-control practice-feedback lane clearly identify AI-generated content. The disclosure is applied by the shared delivery formatter, including to inline review comments and proposals released after human approval—the two paths that previously bypassed it.

### What recipients will see in each lane

The examples below use `claude-sonnet-4` to show the optional model segment and an illustrative settings URL. In production, the link uses the deployment's configured webapp URL. If model metadata is unavailable, the model segment disappears cleanly.

#### Pull/merge-request summary

One footer describes the complete review, below the summary separator:

> ## Practice review
>
> **Extract authorization into the service boundary**  
> Both callers currently repeat the same check. Centralizing it would keep the policy consistent.
>
> **Keep the transaction around the state change**  
> Moving the write outside the transaction can expose a partially updated result.
>
> ---
> <sub>Practice review · claude-sonnet-4 · AI-generated and can be inaccurate. React with 👍 or 👎, or reply, to give feedback.</sub>  
> <sub>[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)</sub>

#### Issue feedback

Issue feedback uses the same summary-style ending:

> The acceptance criteria describe the happy path, but not what should happen when authorization expires during the operation. Adding that case would make the expected behavior testable.
>
> ---
> <sub>Practice review · claude-sonnet-4 · AI-generated and can be inaccurate. React with 👍 or 👎, or reply, to give feedback.</sub>  
> <sub>[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)</sub>

#### Inline review comment

The disclosure stays with each line-specific suggestion, even when the comment is viewed independently from the summary:

> **`AuthorizationService.java`, line 84**
>
> Consider moving this check into the service method so every caller follows the same authorization policy.
>
> <sub>AI-generated · React with 👍 or 👎, or reply, to give feedback.</sub>

Inline notes retain the essential AI label and the useful per-finding interaction cue. They deliberately omit the repeated model name, accuracy sentence, and settings link; the containing top-level review owns that fuller context.

#### Admin-approved proposal

Human approval controls whether the proposal may be delivered; it does not erase how the proposal was produced. The approved body receives the same disclosure at delivery time:

> The new endpoint performs the same permission check in two places. Extracting it into the application service would reduce the chance that future callers bypass it.
>
> <sub>Practice review · claude-sonnet-4 · AI-generated and can be inaccurate. React with 👍 or 👎, or reply, to give feedback.</sub>  
> <sub>[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)</sub>

#### Missing model metadata

All source-control lanes degrade to the same compact footer rather than showing an empty placeholder:

> <sub>Practice review · AI-generated and can be inaccurate. React with 👍 or 👎, or reply, to give feedback.</sub>  
> <sub>[Why you're seeing this and how to stop it](https://hephaestus.example/settings#practice-feedback)</sub>

#### Slack reminder

Slack reminders retain their existing deterministic notification copy and receive no AI label. They point recipients to feedback delivered elsewhere; they are not themselves model-generated feedback. In other words, this PR does **not** turn a reminder such as “New practice feedback is available” into an “AI-generated” message.

### Settings reached from every disclosure

The shared link lands directly on the practice-feedback section, which explains both why delivery occurs and what opting out changes:

> Turn this off to stop new comments on issues, pull requests, and merge requests you author, and related Slack reminders. Reviews still run, and workspace admins can still see the resulting observations.

### Delivery identity

The body-level disclosure is present regardless of provider identity. For GitHub, the integration guide now distinguishes synchronization from delivery: personal access tokens remain supported for synchronization, while active feedback delivery should use a GitHub App so comments also have a distinct App identity. This provides both signals where GitHub supports them without pretending that a PAT posts as a bot.

No migration or new configuration is introduced.

Fixes #1360

## How to test

- Trigger practice feedback that produces a pull/merge-request summary, inline review comment, issue comment, and an admin-approved proposal.
- Confirm each top-level summary, issue comment, and approved proposal says it is AI-generated and includes the link “Why you're seeing this and how to stop it.”
- Confirm each attached inline note shows only “AI-generated · React with 👍 or 👎, or reply, to give feedback.”
- Verify the optional model name is shown on top-level feedback when present and omitted cleanly when absent.
- Follow the link and confirm the practice-feedback settings explain delivery and provide the comments/Slack-reminders control.
- In GitHub App mode, confirm feedback is authored by the App identity.
- Confirm deterministic Slack reminders retain their existing copy and do not receive a misleading AI label.
- Automated coverage: `pnpm run check`, `pnpm run test:webapp`, and the full server unit suite with the `quick` profile disabled.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry) — see `.changeset/README.md`
- [x] If the operator must act on this change (new required env var, manual migration step), the changeset summary says how (`**Operators:** …`) and `MIGRATION.md` is updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Practice-review comments now identify AI-generated feedback.
  * Comments include links to explanations and delivery settings.
  * Feedback settings clarify that comments and Slack reminders can be disabled while reviews continue running.

* **Documentation**
  * Updated GitHub integration guidance for synchronization and feedback delivery.
  * Refined terminology guidance for practice-review content.

* **Bug Fixes**
  * Standardized disclosures across approved and inline feedback comments.
  * Improved feedback formatting and prompts, including support for replies and reactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





