### PR TITLE
fix(ci): rebuild Storybook previews from source

### DIFF
--- a/.changeset/clear-nails-begin.md
+++ b/.changeset/clear-nails-begin.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release note: this changes CI preview generation only.

--- a/.github/actions/setup-caches/action.yml
+++ b/.github/actions/setup-caches/action.yml
@@ -1,5 +1,5 @@
 name: "Setup CI caches"
-description: "Caches Maven repo + generated sources, Playwright browsers, and Storybook builds. Node/pnpm setup happens in the calling workflow via pnpm/action-setup + actions/setup-node (cache: pnpm)."
+description: "Caches Maven dependencies and Playwright browsers. Node/pnpm setup happens in the calling workflow."
 inputs:
   cache-type:
     description: "Type of cache to setup"
@@ -43,14 +43,3 @@ runs:
         key: ${{ inputs.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
           ${{ inputs.os }}-playwright-
-
-    - name: Cache Storybook build
-      if: contains(fromJSON('["webapp-visual", "webapp-storybook"]'), inputs.cache-type)
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          webapp/storybook-static
-          webapp/.storybook/.cache
-        key: ${{ inputs.os }}-storybook-${{ hashFiles('webapp/**/*.stories.tsx', 'webapp/.storybook/**', 'pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ inputs.os }}-storybook-

--- a/webapp/chromatic.config.json
+++ b/webapp/chromatic.config.json
@@ -16,7 +16,6 @@
   "projectId": "Project:66a8981a27ced8fef3190d41",
   "skip": "dependabot/**",
   "storybookBaseDir": "webapp",
-  "storybookBuildDir": "storybook-static",
   "traceChanged": "expanded",
   "untraced": [
     "**/*.md",


### PR DESCRIPTION
## Description

Ensures every Chromatic Storybook preview is built from the checked-out source instead of uploading a previously cached `storybook-static` directory.

The previous cache key covered stories, Storybook configuration, and the lockfile, but not component source, styles, or public assets. Combined with Chromatic's `storybookBuildDir` setting, that allowed a green CI run to publish stale UI under the current commit SHA. This change removes the generated Storybook output cache and lets Chromatic build from source on every preview run.

No application behavior, API, persistence, permissions, or deployment configuration changes.

## How to test

1. Run `pnpm run format` and `pnpm run check`.
2. Let the `Test / Webapp: Stories` job publish a Chromatic preview.
3. Change a component without editing its story and rerun the workflow.
4. Confirm the new preview contains the component change and that CI no longer restores or saves `webapp/storybook-static`.

## Checklist

- [x] Added an empty changeset because this is a CI-only correction with no operator- or user-facing release note.
- [x] No operator action, environment variable, or migration is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined build and visual testing configuration by removing obsolete Storybook build caching.
  * Updated visual testing settings to no longer reference a dedicated Storybook build directory.
  * Added release metadata for the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->