### PR TITLE
fix(ci): enforce local policy ratchets

### DIFF
--- a/.github/workflows/ci-quality-gates.yml
+++ b/.github/workflows/ci-quality-gates.yml
@@ -113,9 +113,11 @@ jobs:
           pnpm install --frozen-lockfile
 
           ISSUES_FOUND=()
-          FMT_OK=true; PMD_OK=true; LINT_OK=true; PIN_OK=true; TESTS_OK=true; TYPES_OK=true; SCRIPT_TYPES_OK=true; CONTRACTS_OK=true; ENV_OK=true; DOCS_OK=true; DIAGRAMS_OK=true; INSTRUCTIONS_OK=true
+          FMT_OK=true; PMD_OK=true; NULLNESS_OK=true; LINT_OK=true; PIN_OK=true; TESTS_OK=true; TYPES_OK=true; SCRIPT_TYPES_OK=true; CONTRACTS_OK=true; ENV_OK=true; DOCS_OK=true; DIAGRAMS_OK=true; INSTRUCTIONS_OK=true
 
           pnpm run format:java:check || { FMT_OK=false; ISSUES_FOUND+=("Java formatting failed. Run: pnpm run format:java"); }
+          pnpm run check:java-nullness \
+            || { NULLNESS_OK=false; ISSUES_FOUND+=("Java nullness policy failed. Run: pnpm run check:java-nullness"); }
           pnpm run lint:java || { PMD_OK=false; ISSUES_FOUND+=("PMD found violations. Run: pnpm run lint:java:report"); }
           if [ "$PMD_OK" = "true" ] && [ "${{ inputs.pmd_canary }}" = "true" ]; then
             PMD_CANARY=server/application/src/main/java/de/tum/cit/aet/hephaestus/Application.java
@@ -167,6 +169,7 @@ jobs:
             echo "|-------|--------|-----|" >> $GITHUB_STEP_SUMMARY
             [[ "$FMT_OK" == "false" ]] && echo "| Java formatting | :x: Failed | \`pnpm run format:java\` |" >> $GITHUB_STEP_SUMMARY
             [[ "$PMD_OK" == "false" ]] && echo "| Java lint (PMD) | :x: Failed | \`pnpm run lint:java:report\` |" >> $GITHUB_STEP_SUMMARY
+            [[ "$NULLNESS_OK" == "false" ]] && echo "| Java nullness policy | :x: Failed | \`pnpm run check:java-nullness\` |" >> $GITHUB_STEP_SUMMARY
             [[ "$PIN_OK" == "false" ]] && echo "| Biome version pin | :x: Failed | \`pnpm run check:biome-pin\` |" >> $GITHUB_STEP_SUMMARY
             [[ "$LINT_OK" == "false" ]] && echo "| Lint + format (outside webapp) | :x: Failed | \`pnpm run check:agents:fix\` |" >> $GITHUB_STEP_SUMMARY
             [[ "$TESTS_OK" == "false" ]] && echo "| Agent runtime tests | :x: Failed | \`pnpm run test:agents\` |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -311,6 +311,10 @@ jobs:
       application_server_changed: ${{ (needs.detect-changes.outputs.application-server == 'true' || needs.detect-changes.outputs.ci-config == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
       e2e_changed: ${{ (needs.detect-changes.outputs.e2e == 'true' || github.event_name != 'pull_request') && 'true' || 'false' }}
 
+  Changesets:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/verify-changesets.yml
+
   Docker:
     uses: ./.github/workflows/ci-docker-build.yml
     # Image builds consume the detected source tree, not Quality outputs. Running both branches at
@@ -341,7 +345,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, Quality, Security, Test, Docker]
+    needs: [detect-changes, Quality, Security, Test, Changesets, Docker]
     if: always()
     steps:
       - name: Generate workflow timeline
@@ -395,6 +399,7 @@ jobs:
           echo "Quality:        ${{ needs.Quality.result }}"
           echo "Security:       ${{ needs.Security.result }}"
           echo "Test:           ${{ needs.Test.result }}"
+          echo "Changesets:     ${{ needs.Changesets.result }}"
           echo "Docker:         ${{ needs.Docker.result }}"
 
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
@@ -441,6 +446,7 @@ jobs:
 
           echo "| Quality | $(result_to_emoji '${{ needs.Quality.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Test | $(result_to_emoji '${{ needs.Test.result }}') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Changesets | $(result_to_emoji '${{ needs.Changesets.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Security | $(result_to_emoji '${{ needs.Security.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Docker | $(result_to_emoji '${{ needs.Docker.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -490,6 +496,15 @@ jobs:
               echo "| Application server | \`cd server && ./mvnw test\` |" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "**Tip:** Check the **Test Results** tab above for specific failures." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "</details>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            if [[ "${{ needs.Changesets.result }}" == "failure" ]]; then
+              echo "<details><summary><b>❌ Changesets Failed</b></summary>" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Run \`pnpm run check:changesets\` for policy-test failures; otherwise correct the changeset reported by the job." >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "</details>" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/verify-changesets.yml
+++ b/.github/workflows/verify-changesets.yml
@@ -1,9 +1,7 @@
 name: Verify Changesets
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
+  workflow_call:
 
 permissions:
   contents: read
@@ -12,13 +10,12 @@ jobs:
   verify-changesets:
     name: "Verify changesets"
     runs-on: ubuntu-latest
-    # Bots (renovate, dependabot) can't author changesets; maintainers add one
-    # when a dependency bump is user-facing.
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot' }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm + Node.js
         uses: ./.github/actions/setup-pnpm-node
@@ -26,7 +23,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Check for a changeset
+      - name: Test changeset and version-sync policies
+        run: pnpm run check:changesets
+
+      - name: Check release-note presence
+        if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,9 @@ Naming: `format` applies, `format:check` verifies read-only for CI, `lint` lints
 comprehensive local quality gate. A `:webapp`, `:server` or `:agents` suffix scopes any of them; `:java`
 scopes `format` and `lint` only — the Java leg of `check` is `check:server`.
 
-**Every leg of `check` also runs in CI.** CI additionally runs the Vite build and generated route-tree
-comparison, webapp tests, server test tiers, image and security checks, and other workflow-specific
-gates. It cannot run anything needing a live credential. Run `check` before pushing because it is the
-fastest complete local quality gate, then run the affected test or build commands above.
+`pnpm run check` is the complete local quality gate. CI distributes its legs across required jobs,
+using path filters where appropriate, and adds builds, generated-file checks, broader tests, image
+checks, and security scans. Run `check` before pushing, then run the affected tests or builds.
 
 ### Lint and format scopes
 

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -57,6 +57,8 @@ Before any release, code must pass:
 | OpenAPI sync    | Diff check  | Client ↔ Server sync |
 | Java formatting | Spotless + Palantir Java Format | Code style |
 | Java lint       | PMD         | Static analysis      |
+| Java nullness policy | NullAway policy scanner | Rejects suppressed analysis and empty source discovery |
+| Changeset policy | Node test runner + Changesets | Tests release-note and version synchronization rules |
 | Webapp TypeScript | oxlint + Biome (`webapp/biome.jsonc`) + tsc | Lint + format + typecheck |
 | Everything else TypeScript | oxlint (`.oxlintrc.json`) + Biome (`biome.jsonc`) + tsc | oxlint reaches the Bun runtime, its specs, both precompute trees, `scripts/**`, `docs/` and the repo-root config files; Biome formats all of those except `docs/`, which has its own config (`docs/.oxlintrc.json`) and no formatter |
 | Agent runtime   | Bun         | Runner and precompute specs, on the Bun the sandbox ships — CI reads `ARG BUN_VERSION` out of `docker/agents/pi/Dockerfile` rather than hard-coding it, and fails closed if that line is missing |
@@ -118,7 +120,7 @@ Coolify handles PR previews:
 | `ci-security-scan.yml` | Called by cicd.yml    | Dependency scanning (Trivy), secret detection      |
 | `ci-profile.yml` | Weekly, manual | Profiles server integration tests and Spring contexts |
 | `ci-server-clean-reference.yml` | Weekly, manual | Records cold server phases and compares generated JARs |
-| `verify-changesets.yml`| PRs                   | Fails shipped-code PRs that carry no changeset     |
+| `verify-changesets.yml`| Called by cicd.yml    | Tests changeset/version-sync policy and enforces release-note presence |
 | `ci-compose-validate.yml` | PRs, push to main  | Renders the reference and self-host compose stacks so an interpolation or merge break is a red check, not a stranger's bad first boot |
 | `version-pr.yml`       | Push to main          | Maintains the accumulating Version PR (changesets) |
 | `release.yml`          | On CI/CD Success      | Cuts a release when the Version PR merged: tag + GitHub Release, gates production |
@@ -131,18 +133,20 @@ Coolify handles PR previews:
 ```mermaid
 flowchart LR
     accTitle: Continuous integration job dependencies
-    accDescr: Change detection selects quality and test jobs, whose results feed the final continuous integration status gate.
+    accDescr: Required quality, test, changeset, image, and security jobs feed the final continuous integration status gate.
     subgraph cicd.yml
         DC[Detect Changes] --> QG[Quality Gates]
         DC --> TS[Test Suite]
         DC --> DB[Docker Build]
         DC --> SS[Security Scan]
+        CS[Changesets]
     end
 
     QG --> Gate[CI Status Gate]
     TS --> Gate
     DB --> Gate
     SS --> Gate
+    CS --> Gate
 
     Gate -->|All Pass| Release[release.yml]
 ```
@@ -150,7 +154,7 @@ flowchart LR
 The `cicd.yml` workflow:
 
 1. **Detects changes** using `dorny/paths-filter`
-2. **Dispatches sub-workflows** with component-specific flags
+2. **Dispatches required sub-workflows**, using component-specific flags where applicable
 3. **Aggregates results** in the CI Status Gate job
 
 ## 🎯 Performance Optimizations

--- a/docs/contributor/local-development.mdx
+++ b/docs/contributor/local-development.mdx
@@ -45,11 +45,12 @@ pnpm run check:agents          # Biome format, then oxlint, then both typechecks
 pnpm run check:agents:fix      # Apply every safe fix
 pnpm run check:webapp          # The SPA: Biome format check, then oxlint
 pnpm run typecheck:webapp      # The SPA's typecheck — a separate leg, not part of check:webapp
-pnpm run check                 # Complete local quality gate; every leg also runs in CI
+pnpm run check                 # Complete local quality gate
 ```
 
-Every `pnpm run check` leg also runs in CI. Run it locally before pushing because it fails faster and
-reports the complete local gate in one command.
+Run `pnpm run check` before pushing for the complete local gate. CI distributes those checks across
+required jobs, using path filters where appropriate, and adds builds, generated-file checks, broader
+tests, image checks, and security scans.
 
 IntelliJ and WebStorm are also supported.
 

--- a/scripts/check-java-nullness.test.ts
+++ b/scripts/check-java-nullness.test.ts
@@ -1,6 +1,24 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import test from "node:test";
-import { nullnessPolicyViolations } from "./check-java-nullness.ts";
+import { promisify } from "node:util";
+import {
+	discoverJavaSourcePaths,
+	isHandwrittenJavaSource,
+	nullnessPolicyViolations,
+} from "./check-java-nullness.ts";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = resolve(import.meta.dirname, "..");
+const GIT_ENV = {
+	...process.env,
+	GIT_DIR: undefined,
+	GIT_INDEX_FILE: undefined,
+	GIT_WORK_TREE: undefined,
+};
 
 const source = (content: string) => [{ path: "Example.java", content }];
 
@@ -41,4 +59,40 @@ await test("rejects suppression names hidden behind constants", () => {
 
 await test("ignores the warning name outside SuppressWarnings", () => {
 	assert.deepEqual(nullnessPolicyViolations(source('String checker = "NullAway";')), []);
+});
+
+await test("matches only handwritten application Java sources", () => {
+	assert.equal(
+		isHandwrittenJavaSource("server/application/src/main/java/example/Application.java"),
+		true,
+	);
+	assert.equal(
+		isHandwrittenJavaSource("server/application/src/test/java/example/ApplicationTest.java"),
+		true,
+	);
+	for (const path of [
+		"server/generated-clients/src/main/java/example/Client.java",
+		"server/application/src/main/resources/example.java",
+		"server/src/main/java/example/Legacy.java",
+		"server/application/src/main/java/example/Application.kt",
+	]) {
+		assert.equal(isHandwrittenJavaSource(path), false, path);
+	}
+});
+
+await test("discovers Application.java in the real checkout", async () => {
+	const paths = await discoverJavaSourcePaths(REPO_ROOT);
+	assert.ok(
+		paths.includes("server/application/src/main/java/de/tum/cit/aet/hephaestus/Application.java"),
+	);
+});
+
+await test("fails closed when repository discovery finds no Java sources", async () => {
+	const root = await mkdtemp(join(tmpdir(), "java-nullness-"));
+	try {
+		await execFileAsync("git", ["init", "--quiet"], { cwd: root, env: GIT_ENV });
+		await assert.rejects(discoverJavaSourcePaths(root), /No handwritten Java sources found/);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
 });

--- a/scripts/check-java-nullness.ts
+++ b/scripts/check-java-nullness.ts
@@ -13,6 +13,35 @@ export interface JavaSource {
 	readonly content: string;
 }
 
+export function isHandwrittenJavaSource(path: string): boolean {
+	return JAVA_SOURCE.test(path);
+}
+
+export async function discoverJavaSourcePaths(
+	root: string = REPO_ROOT,
+): Promise<readonly string[]> {
+	const { stdout } = await execFileAsync(
+		"git",
+		["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+		{
+			cwd: root,
+			env: {
+				...process.env,
+				GIT_DIR: undefined,
+				GIT_INDEX_FILE: undefined,
+				GIT_WORK_TREE: undefined,
+			},
+		},
+	);
+	const paths = stdout.split("\0").filter(isHandwrittenJavaSource);
+	if (paths.length === 0) {
+		throw new Error(
+			"No handwritten Java sources found under server/application/src/{main,test}/java; refusing to pass without checking anything.",
+		);
+	}
+	return paths;
+}
+
 function unicodeEscapes(source: string): string {
 	return source.replace(/\\u+([0-9a-fA-F]{4})/g, (_, hex: string) =>
 		String.fromCharCode(Number.parseInt(hex, 16)),
@@ -67,20 +96,11 @@ export function nullnessPolicyViolations(sources: readonly JavaSource[]): readon
 }
 
 async function main(): Promise<void> {
-	const { stdout } = await execFileAsync(
-		"git",
-		["ls-files", "--cached", "--others", "--exclude-standard"],
-		{
-			cwd: REPO_ROOT,
-		},
-	);
-	const paths = stdout.split("\n").filter((path) => JAVA_SOURCE.test(path));
-	const sources = await Promise.all(
-		paths.map(async (path) => ({
-			path,
-			content: await readFile(resolve(REPO_ROOT, path), "utf8"),
-		})),
-	);
+	const paths = await discoverJavaSourcePaths();
+	const sources: JavaSource[] = [];
+	for (const path of paths) {
+		sources.push({ path, content: await readFile(resolve(REPO_ROOT, path), "utf8") });
+	}
 	const suppressed = nullnessPolicyViolations(sources);
 	if (suppressed.length > 0) {
 		throw new Error(

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/architecture/OutlineApiDtoIsolationTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/architecture/OutlineApiDtoIsolationTest.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.hephaestus.architecture;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +18,9 @@ import org.junit.jupiter.api.Test;
  * vendor's wire shape can never leak past the extract/load seam even though it is now spec-generated.
  */
 class OutlineApiDtoIsolationTest extends HephaestusArchitectureTest {
+
+    private static final JavaClasses OUTLINE_CLASSES =
+            new ClassFileImporter().importPackages("de.tum.cit.aet.hephaestus.integration.outline");
 
     @Test
     void outlineWireModelsStayOnTheExtractSeam() {
@@ -35,10 +40,7 @@ class OutlineApiDtoIsolationTest extends HephaestusArchitectureTest {
                         "Outline wire models are an implementation detail of the client and its sync, collection-admin, "
                                 + "lifecycle-registrar, and webhook consumers on the extract seam; they must not leak into the "
                                 + "agent read path or any other module")
-                // Never allow this guard to pass vacuously: the generated models MUST be present in the
-                // imported set (they are — the base importer no longer excludes them), so an empty subject
-                // set here means the package moved/renamed and the boundary is no longer being checked.
                 .allowEmptyShould(false);
-        rule.check(classes);
+        rule.check(OUTLINE_CLASSES);
     }
 }


### PR DESCRIPTION
## Description

Make the repository's NullAway suppression and release-policy ratchets mandatory by routing them through the required `All CI Passed` status. Java source discovery now fails closed against the Maven application layout, including when checks run from Git hooks, and the contributor documentation accurately separates local checks from required and CI-only verification.

Because #1529 moved generated clients into their own Maven module, this also points the existing Outline ArchUnit rule at the Outline classpath explicitly so the rule continues to inspect its generated wire models rather than failing on an empty subject.

Fixes #1536

## How to test

- Run `pnpm run format && pnpm run check`.
- Run `cd server && ./mvnw -pl application -am test -Parchitecture-tests -Dtest=OutlineApiDtoIsolationTest -Dsurefire.failIfNoSpecifiedTests=false --batch-mode -q`.
- Add `@SuppressWarnings("NullAway")` to an application Java source and confirm `pnpm run check:java-nullness` fails with that path.
- Confirm `pnpm run check:java-nullness` rejects an empty Git repository through its discovery test.
- Make a changeset or version-sync test fail and confirm the `Changesets` job and required `All CI Passed` status fail together.

## Checklist

- [x] No changeset is required: this changes CI, repository tooling, tests, and contributor documentation, not shipped application code.
- [x] No operator action or migration is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - CI now validates Java nullness policies and changeset/version synchronization.
  - Pull requests include changeset verification in the overall status gate, with clearer failure reporting.

- **Documentation**
  - Updated contributor guidance to clarify the complete local quality check and recommended workflow before pushing.
  - Expanded CI/CD documentation with the new quality gates and workflow structure.

- **Reliability**
  - Improved validation of handwritten Java source discovery and architecture checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->