### PR TITLE
feat(release): enforce supply-chain evidence

### DIFF
--- a/.changeset/secure-release-evidence.md
+++ b/.changeset/secure-release-evidence.md
@@ -1,0 +1,5 @@
+---
+"hephaestus": patch
+---
+
+Releases now publish verifiable SBOM, license, provenance, signature, and vulnerability evidence for every supported production image and platform. Production NATS, Traefik, nginx, and Alpine images are pinned to reviewed digests and covered by the same release evidence and recurring scans as Hephaestus images.

--- a/.github/actions/setup-release-security-tools/action.yml
+++ b/.github/actions/setup-release-security-tools/action.yml
@@ -1,0 +1,34 @@
+name: Setup release security tools
+description: Install checksum-verified Syft and Trivy binaries used by release evidence workflows
+inputs:
+  install-syft:
+    description: Install Syft in addition to Trivy
+    default: "true"
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        INSTALL_SYFT: ${{ inputs.install-syft }}
+        # renovate: datasource=github-releases depName=anchore/syft
+        SYFT_VERSION: 1.51.1
+        # renovate: datasource=github-releases depName=aquasecurity/trivy
+        TRIVY_VERSION: 0.74.0
+      run: |
+        set -euo pipefail
+        if [ "$INSTALL_SYFT" = true ]; then
+          syft_archive="syft_${SYFT_VERSION}_linux_amd64.tar.gz"
+          syft_base="https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}"
+          curl -fsSL --proto =https -o "/tmp/$syft_archive" "$syft_base/$syft_archive"
+          curl -fsSL --proto =https -o /tmp/syft-checksums "$syft_base/syft_${SYFT_VERSION}_checksums.txt"
+          (cd /tmp && grep " $syft_archive$" syft-checksums | sha256sum -c -)
+          tar -xzf "/tmp/$syft_archive" -C /usr/local/bin syft
+          syft version
+        fi
+        trivy_archive="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        trivy_base="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"
+        curl -fsSL --proto =https -o "/tmp/$trivy_archive" "$trivy_base/$trivy_archive"
+        curl -fsSL --proto =https -o /tmp/trivy-checksums "$trivy_base/trivy_${TRIVY_VERSION}_checksums.txt"
+        (cd /tmp && grep " $trivy_archive$" trivy-checksums | sha256sum -c -)
+        tar -xzf "/tmp/$trivy_archive" -C /usr/local/bin trivy
+        trivy --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,9 @@ on:
     types: [completed]
     branches: [main]
 
-# Key per commit so distinct releases queue independently — a global group would
-# let a newer run cancel an older release that is still pending.
+# Serialize promotion of the moving series and latest tags.
 concurrency:
-  group: release-${{ github.event.workflow_run.head_sha }}
+  group: release
   cancel-in-progress: false
 
 permissions: {}
@@ -73,14 +72,16 @@ jobs:
             echo "released=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Idempotent: if the Release already exists, this version is done. (A
-          # release whose downstream jobs half-failed is recovered by deleting the
-          # Release + its tag and re-running — not by silently re-releasing an old
-          # version, which would re-deploy it.)
-          if gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
-            echo "Release $TAG already exists — nothing to cut."
-            echo "released=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          RESUME=false
+          if existing=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft,targetCommitish 2>/dev/null); then
+            if [ "$(jq -r .isDraft <<< "$existing")" != true ]; then
+              echo "Release $TAG is already published."
+              echo "released=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            [ "$(jq -r .targetCommitish <<< "$existing")" = "$SHA" ] || {
+              echo "::error::Draft $TAG targets a different commit"; exit 1; }
+            RESUME=true
           fi
           echo "Cutting $TAG at $SHA (was $PARENT_VERSION)"
 
@@ -110,13 +111,13 @@ jobs:
               ' >> "$NOTES"
           echo "----- release notes -----"; cat "$NOTES"; echo "-------------------------"
 
-          # Creates the tag at $SHA and the Release atomically (no separate
-          # push, so there is no tag-without-Release window on a mid-step failure).
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file "$NOTES" \
-            --target "$SHA" \
-            --repo "${{ github.repository }}"
+          if [ "$RESUME" = false ]; then
+            gh release create "$TAG" --draft \
+              --title "$TAG" \
+              --notes-file "$NOTES" \
+              --target "$SHA" \
+              --repo "${{ github.repository }}"
+          fi
 
           {
             echo "released=true"
@@ -130,10 +131,8 @@ jobs:
       - name: Summary
         if: steps.cut.outputs.released == 'true'
         run: |
-          echo "## 🚀 Released ${{ steps.cut.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Staging**: Deploying automatically" >> $GITHUB_STEP_SUMMARY
-          echo "- **Production**: Waiting for approval" >> $GITHUB_STEP_SUMMARY
+          echo "## Preparing ${{ steps.cut.outputs.tag_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Evidence verification is in progress." >> "$GITHUB_STEP_SUMMARY"
 
   tag-images:
     needs: release
@@ -148,6 +147,12 @@ jobs:
       agent-pi-digest: ${{ steps.retag.outputs.agent-pi-digest }}
       application-server-digest: ${{ steps.retag.outputs.application-server-digest }}
     steps:
+      - name: Check out the released tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release.outputs.sha }}
+          fetch-depth: 1
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -155,14 +160,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retag images and capture digests
+      - name: Capture release image digests
         id: retag
         env:
-          VERSION: ${{ needs.release.outputs.version }}
-          # The `major.minor` series tag: it moves onto every patch release in the line, exactly as
-          # `latest` moves onto every release. Both are channel tags; only the spelling differs, and
-          # naming this one `CHANNEL` made them look like different things. ADR 0031.
-          SERIES: ${{ needs.release.outputs.major }}.${{ needs.release.outputs.minor }}
           SHA: ${{ needs.release.outputs.sha }}
         run: |
           set -euo pipefail
@@ -172,7 +172,9 @@ jobs:
             docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' | jq -r '.digest'
           }
 
-          IMAGES=("webapp" "application-server" "agent-pi" "release-pin-fetcher" "postgres")
+          mapfile -t IMAGES < <(jq -er '.images[]' security/release-images.json)
+          [ "${#IMAGES[@]}" -gt 0 ] || { echo "::error::Release image inventory is empty"; exit 1; }
+          : > release-images.tsv
 
           # Probe all images first; refuse to partial-publish if any is missing.
           for img in "${IMAGES[@]}"; do
@@ -195,20 +197,7 @@ jobs:
             [[ "$SRC_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || {
               echo "::error::$img source digest is malformed: ${SRC_DIGEST:-<empty>}"; exit 1; }
             echo "$img source digest: $SRC_DIGEST"
-
-            docker buildx imagetools create \
-              -t "$FULL_IMAGE:$VERSION" \
-              -t "$FULL_IMAGE:$SERIES" \
-              -t "$FULL_IMAGE:latest" \
-              "$FULL_IMAGE:$SHA"
-
-            for tag in "$VERSION" "$SERIES" "latest"; do
-              DST_DIGEST=$(manifest_digest "$FULL_IMAGE:$tag")
-              if [[ "$SRC_DIGEST" != "$DST_DIGEST" ]]; then
-                echo "::error::Retag changed the digest for $img:$tag — refusing to publish."
-                exit 1
-              fi
-            done
+            printf '%s\t%s\n' "$img" "$SRC_DIGEST" >> release-images.tsv
 
             case "$img" in
               agent-pi)            echo "agent-pi-digest=$SRC_DIGEST" >> "$GITHUB_OUTPUT" ;;
@@ -216,12 +205,6 @@ jobs:
             esac
             echo "::endgroup::"
           done
-
-      - name: Check out the released tree
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.release.outputs.sha }}
-          fetch-depth: 1
 
       # The pin asset below tells every production deploy to run THIS agent image, so this is the
       # last point at which an image the released server cannot drive is still catchable. The
@@ -244,6 +227,112 @@ jobs:
             exit 1
           fi
           echo "agent-pi implements runtime contract v${expected}"
+
+      - uses: ./.github/actions/setup-release-security-tools
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Generate and enforce release evidence
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p evidence
+          : > release-platforms.tsv
+          started=$SECONDS
+          trivy image --download-db-only
+          db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
+          jq -e '(.UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $updated |
+            ((now - $updated) >= 0) and ((now - $updated) <= 86400)' \
+            "$db_metadata" >/dev/null
+          cp "$db_metadata" evidence/trivy-db.json
+          jq -n --arg syft "$(syft version -o json | jq -r .version)" \
+            --arg trivy "$(trivy version --format json | jq -r .Version)" \
+            --arg cosign "$(cosign version --json | jq -r .gitVersion)" \
+            '{syft: $syft, trivy: $trivy, cosign: $cosign}' > evidence/tool-versions.json
+          generate_evidence() {
+            local image=$1 repository=$2 digest=$3 provenance=$4
+            local ref="$repository@$digest"
+            for platform in linux/amd64 linux/arm64; do
+              suffix=${platform//\//-}
+              architecture=${platform#*/}
+              platform_digest=$(docker buildx imagetools inspect "$ref" --raw | jq -er \
+                --arg architecture "$architecture" \
+                '.manifests[] | select(.platform.os == "linux" and .platform.architecture == $architecture) | .digest')
+              [[ "$platform_digest" =~ ^sha256:[a-f0-9]{64}$ ]] || { echo "::error::$image $platform digest is malformed"; exit 1; }
+              platform_ref="$repository@$platform_digest"
+              printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$image" "$platform" "$digest" "$platform_digest" "$repository" "$provenance" >> release-platforms.tsv
+              syft "$platform_ref" --scope squashed \
+                -o "syft-json=evidence/$image-$suffix.syft.json" \
+                -o "spdx-json=evidence/$image-$suffix.spdx.json" \
+                -o "cyclonedx-json=evidence/$image-$suffix.cdx.json"
+              bun scripts/check-release-sbom.ts \
+                "evidence/$image-$suffix.syft.json" \
+                "evidence/$image-$suffix.spdx.json" \
+                "evidence/$image-$suffix.cdx.json" \
+                "$platform_digest" "$platform" "evidence/$image-$suffix.sbom-summary.json"
+              trivy image --scanners vuln --format json --output "evidence/$image-$suffix.trivy.json" "$platform_ref"
+              bun scripts/check-release-vulnerabilities.ts "$image" "evidence/$image-$suffix.trivy.json" security/vulnerability-policy.json "evidence/$image-$suffix.policy.json"
+              if [ "$provenance" = first-party ]; then
+                cosign attest --yes --type spdxjson --predicate "evidence/$image-$suffix.spdx.json" "$platform_ref"
+              fi
+            done
+          }
+          while IFS=$'\t' read -r image digest; do
+            generate_evidence "$image" "ghcr.io/ls1intum/hephaestus/$image" "$digest" first-party
+          done < release-images.tsv
+          jq -r '.upstream[] | [.name, .repository, .digest] | @tsv' security/release-images.json |
+          while IFS=$'\t' read -r image repository digest; do
+            generate_evidence "$image" "$repository" "$digest" upstream
+          done
+          duration=$((SECONDS - started))
+          jq -n \
+            --arg schemaVersion "1" \
+            --arg generatedAt "$(date -u +%FT%TZ)" \
+            --arg release "${{ needs.release.outputs.tag_name }}" \
+            --arg commit "${{ needs.release.outputs.sha }}" \
+            --argjson durationSeconds "$duration" \
+            --rawfile subjects release-platforms.tsv \
+            '{schemaVersion: ($schemaVersion | tonumber), release: $release, commit: $commit,
+              generatedAt: $generatedAt, durationSeconds: $durationSeconds,
+              subjects: ($subjects | split("\n") | map(select(length > 0) | split("\t") |
+                {image: .[0], platform: .[1], indexDigest: .[2], digest: .[3], repository: .[4], provenance: .[5]}))}' \
+            > evidence/manifest.json
+          cp security/vulnerability-policy.json evidence/vulnerability-policy.json
+          cp security/release-images.json evidence/release-images.json
+          (cd evidence && sha256sum -- * > SHA256SUMS)
+
+      - name: Verify evidence from registry subjects
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r image platform _ digest repository provenance; do
+            [ "$provenance" = first-party ] || continue
+            ref="$repository@$digest"
+            suffix=${platform//\//-}
+            cosign verify-attestation \
+              --type spdxjson \
+              --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+              "$ref" > verified-attestations.json
+            jq -e --slurpfile sbom "evidence/$image-$suffix.spdx.json" \
+              'any(.[]; (.payload | @base64d | fromjson | .predicate) == $sbom[0])' \
+              verified-attestations.json >/dev/null
+          done < release-platforms.tsv
+          while IFS=$'\t' read -r image digest; do
+            ref="ghcr.io/ls1intum/hephaestus/$image@$digest"
+            cosign verify "$ref" \
+              --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/reusable-docker-build.yml@refs/heads/main' \
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+              --certificate-github-workflow-repository '${{ github.repository }}' >/dev/null
+            gh attestation verify "oci://$ref" --owner "${{ github.repository_owner }}" \
+              --signer-workflow '${{ github.repository }}/.github/workflows/reusable-docker-build.yml' >/dev/null
+          done < release-images.tsv
 
       - name: Write release pin asset
         id: pin
@@ -290,9 +379,6 @@ jobs:
           predicate: |
             { "purl": "pkg:github/ls1intum/hephaestus@${{ needs.release.outputs.tag_name }}" }
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
       - name: Sign release pin asset
         env:
           ASSET: ${{ steps.pin.outputs.asset-path }}
@@ -301,11 +387,7 @@ jobs:
           cosign sign-blob --yes --bundle "${ASSET}.sigstore.json" "$ASSET"
 
       - name: Verify signature with the deploy-side identity (fail fast)
-        # Assert here, at build time, exactly what docker/compose.app.yaml's
-        # release-pin-fetcher asserts at deploy time. A mismatch (e.g. the OIDC
-        # ref drifts) fails the release loudly instead of silently hanging every
-        # production deploy on `cosign verify-blob`. Keep this identity in sync
-        # with docker/compose.app.yaml.
+        # Keep this identity aligned with docker/compose.app.yaml.
         env:
           ASSET: ${{ steps.pin.outputs.asset-path }}
         run: |
@@ -323,19 +405,132 @@ jobs:
           ASSET: ${{ steps.pin.outputs.asset-path }}
         run: |
           set -euo pipefail
-          # Release assets are immutable: no --clobber, fail loud on re-run.
           gh release upload "$TAG_NAME" \
-            "$ASSET" "${ASSET}.sigstore.json" \
+            "$ASSET" "${ASSET}.sigstore.json" evidence/* \
+            --clobber \
             --repo "${{ github.repository }}"
 
-  deploy-staging:
+  publish-release:
     needs: [release, tag-images]
     if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      attestations: read
+    steps:
+      - name: Checkout release verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release.outputs.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify durable assets from a clean environment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir evidence
+          gh release download "$TAG_NAME" --repo "${{ github.repository }}" --dir evidence
+          (cd evidence && sha256sum -c SHA256SUMS)
+          for file in manifest.json release-images.json tool-versions.json trivy-db.json vulnerability-policy.json; do
+            test -s "evidence/$file"
+          done
+          jq -e --slurpfile inventory evidence/release-images.json \
+            '.schemaVersion == 1 and
+             ([.subjects[].image] | unique == (($inventory[0].images + [$inventory[0].upstream[].name]) | sort)) and
+             (group_by(.image) | all(.[]; [.[].platform] == ["linux/amd64", "linux/arm64"])) and
+             all(.subjects[]; (.digest | test("^sha256:[a-f0-9]{64}$")) and (.indexDigest | test("^sha256:[a-f0-9]{64}$")))' \
+            evidence/manifest.json >/dev/null
+          jq -er '.subjects[] | [.image, .platform, .digest, .repository, .provenance] | @tsv' evidence/manifest.json |
+          while IFS=$'\t' read -r image platform digest repository provenance; do
+            suffix=${platform//\//-}
+            bun scripts/check-release-sbom.ts \
+              "evidence/$image-$suffix.syft.json" \
+              "evidence/$image-$suffix.spdx.json" \
+              "evidence/$image-$suffix.cdx.json" \
+              "$digest" "$platform" /tmp/sbom-summary.json
+            cmp "evidence/$image-$suffix.sbom-summary.json" /tmp/sbom-summary.json
+            for kind in trivy policy; do
+              test -s "evidence/$image-$suffix.$kind.json"
+            done
+            if [ "$provenance" = first-party ]; then
+              cosign verify-attestation --type spdxjson \
+                --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/heads/main' \
+                --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+                "$repository@$digest" > verified-attestations.json
+              jq -e --slurpfile sbom "evidence/$image-$suffix.spdx.json" \
+                'any(.[]; (.payload | @base64d | fromjson | .predicate) == $sbom[0])' \
+                verified-attestations.json >/dev/null
+            fi
+            index_digest=$(jq -er --arg image "$image" --arg platform "$platform" \
+              '.subjects[] | select(.image == $image and .platform == $platform) | .indexDigest' evidence/manifest.json)
+            architecture=${platform#*/}
+            docker buildx imagetools inspect "$repository@$index_digest" --raw |
+              jq -e --arg architecture "$architecture" --arg digest "$digest" \
+                'any(.manifests[]; .platform.os == "linux" and .platform.architecture == $architecture and .digest == $digest)' >/dev/null
+          done
+          jq -er '[.subjects[] | select(.provenance == "first-party") | [.repository, .indexDigest]] | unique[] | @tsv' evidence/manifest.json |
+          while IFS=$'\t' read -r repository digest; do
+            ref="$repository@$digest"
+            cosign verify "$ref" \
+              --certificate-identity 'https://github.com/${{ github.repository }}/.github/workflows/reusable-docker-build.yml@refs/heads/main' \
+              --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+              --certificate-github-workflow-repository '${{ github.repository }}' >/dev/null
+            gh attestation verify "oci://$ref" --owner "${{ github.repository_owner }}" \
+              --signer-workflow '${{ github.repository }}/.github/workflows/reusable-docker-build.yml' >/dev/null
+          done
+          asset="evidence/release-${TAG_NAME}.yaml"
+          cosign verify-blob --bundle "${asset}.sigstore.json" \
+            --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' "$asset" >/dev/null
+
+      - name: Promote verified image digests
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          SERIES: ${{ needs.release.outputs.major }}.${{ needs.release.outputs.minor }}
+        run: |
+          set -euo pipefail
+          jq -er '[.subjects[] | select(.provenance == "first-party") | [.repository, .indexDigest]] | unique[] | @tsv' evidence/manifest.json |
+          while IFS=$'\t' read -r ref digest; do
+            docker buildx imagetools create -t "$ref:$VERSION" "$ref@$digest"
+            promoted=$(docker buildx imagetools inspect "$ref:$VERSION" --format '{{json .Manifest}}' | jq -r .digest)
+            [ "$promoted" = "$digest" ] || { echo "::error::Promotion changed $ref:$VERSION digest"; exit 1; }
+          done
+          jq -er '[.subjects[] | select(.provenance == "first-party") | [.repository, .indexDigest]] | unique[] | @tsv' evidence/manifest.json |
+          while IFS=$'\t' read -r ref digest; do
+            docker buildx imagetools create -t "$ref:$SERIES" -t "$ref:latest" "$ref@$digest"
+            for tag in "$SERIES" latest; do
+              promoted=$(docker buildx imagetools inspect "$ref:$tag" --format '{{json .Manifest}}' | jq -r .digest)
+              [ "$promoted" = "$digest" ] || { echo "::error::Promotion changed $ref:$tag digest"; exit 1; }
+            done
+          done
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release.outputs.tag_name }}
+        run: gh release edit "$TAG_NAME" --repo "${{ github.repository }}" --draft=false
+
+  deploy-staging:
+    needs: [release, tag-images, publish-release]
+    if: needs.release.outputs.released == 'true'
     uses: ./.github/workflows/deploy-staging.yml
-    # The called org workflow (ls1intum/.github deploy-docker-compose.yml@main)
-    # requires these. With the top-level `permissions: {}`, omitting them makes
-    # workflow COMPILATION fail ("requesting 'contents: read' but only allowed
-    # 'none'") — a startup_failure that killed every release since June 2026.
+    # Required by the called deployment workflow.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/rescan-release-images.yml
+++ b/.github/workflows/rescan-release-images.yml
@@ -1,0 +1,92 @@
+name: Rescan supported release images
+on:
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: read
+  issues: write
+concurrency:
+  group: rescan-supported-release
+  cancel-in-progress: false
+jobs:
+  rescan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-bun
+      - uses: ./.github/actions/setup-release-security-tools
+        with:
+          install-syft: "false"
+      - name: Download and verify latest supported release evidence
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir release-evidence
+          gh release download --repo "${{ github.repository }}" --dir release-evidence
+          (cd release-evidence && sha256sum -c SHA256SUMS)
+          for file in manifest.json release-images.json tool-versions.json trivy-db.json vulnerability-policy.json; do
+            test -s "release-evidence/$file"
+          done
+          jq -e --slurpfile inventory release-evidence/release-images.json \
+            '.schemaVersion == 1 and
+             ([.subjects[].image] | unique == (($inventory[0].images + [$inventory[0].upstream[].name]) | sort)) and
+             (group_by(.image) | all(.[]; [.[].platform] == ["linux/amd64", "linux/arm64"])) and
+             all(.subjects[]; (.digest | test("^sha256:[a-f0-9]{64}$")) and (.indexDigest | test("^sha256:[a-f0-9]{64}$")))' \
+            release-evidence/manifest.json >/dev/null
+          jq -er '.subjects[] | [.image, .platform, .indexDigest, .digest, .repository] | @tsv' release-evidence/manifest.json |
+          while IFS=$'\t' read -r image platform index_digest digest repository; do
+            suffix=${platform//\//-}
+            bun scripts/check-release-sbom.ts \
+              "release-evidence/$image-$suffix.syft.json" \
+              "release-evidence/$image-$suffix.spdx.json" \
+              "release-evidence/$image-$suffix.cdx.json" \
+              "$digest" "$platform" /tmp/sbom-summary.json
+            cmp "release-evidence/$image-$suffix.sbom-summary.json" /tmp/sbom-summary.json
+            for kind in trivy policy; do
+              test -s "release-evidence/$image-$suffix.$kind.json"
+            done
+            architecture=${platform#*/}
+            docker buildx imagetools inspect "$repository@$index_digest" --raw |
+              jq -e --arg architecture "$architecture" --arg digest "$digest" \
+                'any(.manifests[]; .platform.os == "linux" and .platform.architecture == $architecture and .digest == $digest)' >/dev/null
+          done
+      - name: Rescan immutable subjects
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir reports
+          trivy image --download-db-only
+          db_metadata="${TRIVY_CACHE_DIR:-$HOME/.cache/trivy}/db/metadata.json"
+          jq -e '(.UpdatedAt | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) as $updated |
+            ((now - $updated) >= 0) and ((now - $updated) <= 86400)' \
+            "$db_metadata" >/dev/null
+          cp "$db_metadata" reports/trivy-db.json
+          jq -er '.subjects[] | [.image, .platform, .digest, .repository] | @tsv' release-evidence/manifest.json |
+          while IFS=$'\t' read -r image platform digest repository; do
+            suffix=${platform//\//-}
+            trivy image --scanners vuln --format json --output "reports/$image-$suffix.json" "$repository@$digest"
+            bun scripts/check-release-vulnerabilities.ts "$image" "reports/$image-$suffix.json" security/vulnerability-policy.json "reports/$image-$suffix.policy.json"
+          done
+      - name: Upload diagnostic reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: supported-release-rescan-${{ github.run_id }}
+          path: reports
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Notify vulnerability response tracking
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment 1369 --repo "${{ github.repository }}" --body \
+            "The supported-release rescan is **unknown or failing policy**. Treat this as actionable until triaged: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -71,7 +71,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
       id-token: write
       attestations: write
     steps:
@@ -227,89 +226,6 @@ jobs:
           fi
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "Per-arch digest: $DIGEST"
-
-      # SBOMs are emitted by Paketo into /layers/sbom/ during the build; pack downloads them via
-      # the OCI label io.buildpacks.lifecycle.metadata.
-      - name: Install pack CLI (Buildpacks SBOM extraction)
-        if: inputs.use-buildpacks
-        env:
-          PACK_VERSION: v0.40.6
-        run: |
-          set -euo pipefail
-          ARCH_SUFFIX=$([ "${{ runner.arch }}" = "ARM64" ] && echo "-arm64" || echo "")
-          BASE="https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}"
-          curl -fsSL --proto =https -o /tmp/pack.tgz       "${BASE}/pack-${PACK_VERSION}-linux${ARCH_SUFFIX}.tgz"
-          curl -fsSL --proto =https -o /tmp/pack.sha256    "${BASE}/pack-${PACK_VERSION}-linux${ARCH_SUFFIX}.tgz.sha256"
-          ( cd /tmp && awk '{print $1"  pack.tgz"}' pack.sha256 | sha256sum -c - )
-          tar -xzf /tmp/pack.tgz -C /usr/local/bin pack
-          pack version
-
-      - name: Extract SBOM from buildpack image
-        if: inputs.use-buildpacks
-        continue-on-error: true
-        env:
-          PER_ARCH_TAG: ${{ inputs.registry }}/${{ inputs.image-name }}:ci-${{ github.run_id }}-${{ steps.prep.outputs.platform_pair }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${{ runner.temp }}/sbom"
-          # --remote reads from the registry rather than the local daemon — the image was just
-          # pushed by spring-boot:build-image. Auth is inherited from the docker/login-action
-          # earlier in this job via ~/.docker/config.json.
-          pack sbom download "$PER_ARCH_TAG" --remote --output-dir "${{ runner.temp }}/sbom"
-          ls -la "${{ runner.temp }}/sbom/layers/sbom/"
-
-      - name: Upload SBOM
-        if: inputs.use-buildpacks
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sbom-${{ steps.prep.outputs.image_name }}-${{ steps.prep.outputs.platform_pair }}
-          path: ${{ runner.temp }}/sbom/
-          if-no-files-found: error
-          retention-days: 90
-
-      # Direct trivy binary install — aquasecurity/trivy-action's transitive setup-trivy dep
-      # breaks consumers of this reusable workflow when it can't resolve. Report-only baseline;
-      # flip --exit-code 1 once HIGH+ is at zero on main.
-      - name: Install Trivy
-        id: install-trivy
-        if: inputs.use-buildpacks
-        continue-on-error: true
-        env:
-          TRIVY_VERSION: 0.70.0
-        run: |
-          set -euo pipefail
-          ARCH=$([ "${{ runner.arch }}" = "ARM64" ] && echo "ARM64" || echo "64bit")
-          BASE="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}"
-          ARCHIVE="trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz"
-          curl -fsSL --proto =https -o "/tmp/${ARCHIVE}"          "${BASE}/${ARCHIVE}"
-          curl -fsSL --proto =https -o /tmp/trivy_checksums.txt   "${BASE}/trivy_${TRIVY_VERSION}_checksums.txt"
-          ( cd /tmp && grep " ${ARCHIVE}$" trivy_checksums.txt | sha256sum -c - )
-          tar -xzf "/tmp/${ARCHIVE}" -C /usr/local/bin trivy
-          trivy --version
-
-      - name: Run Trivy (CVE scan, report-only)
-        if: inputs.use-buildpacks && steps.install-trivy.outcome == 'success'
-        continue-on-error: true
-        env:
-          # Trivy queries the registry directly (not the local daemon) and does not read
-          # ~/.docker/config.json — explicit credentials are required for ghcr.io.
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          PER_ARCH_TAG: ${{ inputs.registry }}/${{ inputs.image-name }}:ci-${{ github.run_id }}-${{ steps.prep.outputs.platform_pair }}
-        run: |
-          set -euo pipefail
-          trivy image --severity CRITICAL,HIGH --ignore-unfixed --exit-code 0 \
-            --format sarif --output "${{ runner.temp }}/trivy.sarif" "$PER_ARCH_TAG"
-
-      # Surface findings in the GitHub Security tab + PR annotations rather than a 30-day artifact
-      # nobody opens. continue-on-error keeps the workflow green while the baseline is non-zero.
-      - name: Upload Trivy SARIF to GitHub code scanning
-        if: inputs.use-buildpacks && steps.install-trivy.outcome == 'success'
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.30.9
-        with:
-          sarif_file: ${{ runner.temp }}/trivy.sarif
-          category: trivy-image-${{ steps.prep.outputs.platform_pair }}
 
       - name: Export digest
         env:

--- a/docker/compose.core.yaml
+++ b/docker/compose.core.yaml
@@ -131,7 +131,7 @@ services:
         max-file: "3"
 
   nats-server:
-    image: nats:alpine
+    image: nats:2.14.6-alpine@sha256:ad7a43eb7e3337c3c38ce5d784d1461791f95f730f252d2b25eee699752a0ca3
     restart: unless-stopped
     ports:
       # Loopback-only by default. Set NATS_BIND_HOST=0.0.0.0 (or a specific interface) to let other

--- a/docker/compose.proxy.yaml
+++ b/docker/compose.proxy.yaml
@@ -2,7 +2,7 @@ services:
   reverse-proxy:
     # Keep at >=3.3: below it the app-server sticky.cookie.path label (workspace replica affinity)
     # fails to parse and Traefik silently drops the whole router. Pin a current 3.x.
-    image: traefik:v3.7.4
+    image: traefik:v3.7.4@sha256:fcdef599e6259359833dd2e1d49f9e964f66825d69bd3dd468f51102ce013d03
     restart: unless-stopped
     networks:
       - shared-network
@@ -60,7 +60,7 @@ services:
         max-file: "3"
 
   maintenance:
-    image: nginx:alpine
+    image: nginx:1.31.4-alpine@sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913
     restart: unless-stopped
     configs:
       - source: maintenance-page

--- a/docs/admin/buildpacks-cds-decision.md
+++ b/docs/admin/buildpacks-cds-decision.md
@@ -64,8 +64,6 @@ Revert `.github/workflows/ci-docker-build.yml` (the `use-buildpacks: true` line)
 
 - **Coolify graceful shutdown** — `application.yml` sets `SHUTDOWN_TIMEOUT:20s`. Coolify's default container stop-grace is 10s; bump it to ≥25s in the deploy substrate so SIGTERM has time to drain in-flight requests. The Paketo launcher `exec`s the JVM; signal forwarding is native, no `tini`.
 - **JVM memory** — do NOT set `MaxRAMPercentage`, `-Xmx`, or `-Xss` in Coolify env. Paketo's memory calculator handles them. Override only `BPL_JVM_HEAD_ROOM` if needed.
-- **SBOM** — Paketo emits Syft + SPDX + CycloneDX at `/layers/sbom/`. CI extracts via `pack sbom download` and uploads as a 90-day artifact.
-- **CVE scan** — Trivy runs on every PR and uploads SARIF to GitHub Security. Until the baseline is clean, results are non-blocking; flip `--exit-code 1` in the workflow once HIGH+ is at zero.
 - **CI build time** — expect +60–120s per build vs the prior Dockerfile baseline (CDS training run dominates).
 
 ## Sources

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -32,7 +32,11 @@ sequenceDiagram
     M->>VP: changesets action folds pending changesets into the accumulating Version PR
     Note over VP: CHANGELOG.md + version bump preview
     VP->>M: Maintainer merges when the release is ready
-    M->>R: Tag vX.Y.Z, GitHub Release with curated notes,<br/>docker images X.Y.Z / X.Y / latest
+    M->>R: Create draft vX.Y.Z release
+    R->>R: Generate and verify digest-bound evidence
+    R->>R: Promote X.Y.Z / X.Y / latest image tags
+    R->>R: Publish release and deploy staging
+    Note over R: Production still requires approval
 ```
 
 1. **Every user-facing PR carries a changeset.** `bun changeset` asks for the bump type and an
@@ -50,10 +54,73 @@ sequenceDiagram
    the full suite and a release is only cut if that run succeeds. Maintainers bypass the branch
    ruleset, so the absent required checks don't block the merge. Versioning also moves any
    `### Next release` section in `MIGRATION.md` under the version being cut.
-3. **Merging the Version PR cuts the release.** The release workflow tags `vX.Y.Z` at the merge
-   commit, creates the GitHub Release from the new changelog section, retags the CI-built Docker
-   images as `X.Y.Z`, `X.Y`, and `latest`, publishes the signed release-pin asset, and starts the
-   deploy chain (staging automatically, production after approval).
+3. **Merging the Version PR cuts the release.** The workflow creates a draft release at the merge
+   commit. After its evidence gate passes, it promotes the CI-built images to `X.Y.Z`, `X.Y`, and
+   `latest`, publishes the release, deploys staging, and requests production approval.
+
+## Supply-chain evidence
+
+A release remains a draft until every first-party and upstream production image in
+`security/release-images.json` has passed the evidence
+gate. The gate resolves each image index and its `linux/amd64` and `linux/arm64` manifests to immutable
+digests. It generates a lossless Syft inventory plus SPDX and CycloneDX SBOMs for each deployed platform.
+The gate proves that the Syft source metadata identifies the exact digest and architecture, checks that
+every discovered package survives both standard-format conversions, and records packages whose license
+could not be detected. It also scans each platform manifest with Trivy, signs its SPDX predicate as an OCI
+attestation, and verifies the image signature and build provenance. The SBOMs, license summaries, scan
+reports, applied policy, checksums, and `manifest.json` are GitHub Release assets, so they outlive Actions
+artifact retention. Publication requires every artifact to be present, well formed, and bound to its
+recorded digest.
+
+Upstream NATS, Traefik, nginx, and Alpine images are versioned and digest-pinned in the production
+Compose topology. They receive the same per-platform SBOM, license, vulnerability, and index-membership
+evidence as first-party images. Hephaestus requires its own signatures and build provenance only for
+images it builds; it does not misrepresent observed upstream images as Hephaestus-built artifacts.
+
+The version-controlled policy rejects new fixable HIGH or CRITICAL findings. Baselines use exact
+image/CVE/package/installed-version fingerprints. Exceptions use the same scope and require an owner,
+justification, and future expiry.
+
+The latest release is rescanned weekly. A policy violation or scan failure is reported on
+[the vulnerability response issue](https://github.com/ls1intum/Hephaestus/issues/1369); scanner failure
+is never treated as no findings.
+
+### Operator verification
+
+Install `gh`, `jq`, `cosign`, and GNU `sha256sum`, then use a clean directory and replace `vX.Y.Z`
+below. Verification uses the digests in the release manifest, never mutable tags:
+
+```bash
+gh release download vX.Y.Z --repo ls1intum/Hephaestus
+sha256sum -c SHA256SUMS
+
+jq -r '.subjects[] | [.image, .platform, .digest] | @tsv' manifest.json |
+while IFS=$'\t' read -r image platform digest; do
+  ref="ghcr.io/ls1intum/hephaestus/$image@$digest"
+  suffix=${platform//\//-}
+  cosign verify-attestation --type spdxjson \
+    --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/release.yml@refs/heads/main' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com "$ref" \
+    > verified-attestations.json
+  jq -e --slurpfile sbom "$image-$suffix.spdx.json" \
+    'any(.[]; (.payload | @base64d | fromjson | .predicate) == $sbom[0])' \
+    verified-attestations.json >/dev/null
+done
+
+jq -r '[.subjects[] | [.image, .indexDigest]] | unique[] | @tsv' manifest.json |
+while IFS=$'\t' read -r image digest; do
+  ref="ghcr.io/ls1intum/hephaestus/$image@$digest"
+  cosign verify "$ref" \
+    --certificate-identity 'https://github.com/ls1intum/Hephaestus/.github/workflows/reusable-docker-build.yml@refs/heads/main' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  gh attestation verify "oci://$ref" --owner ls1intum \
+    --signer-workflow ls1intum/Hephaestus/.github/workflows/reusable-docker-build.yml
+done
+```
+
+The downloaded `*.spdx.json` and `*.cdx.json` files are the machine-readable package and license
+inventories. `*.trivy.json` is a point-in-time scan, not a promise that vulnerability knowledge remains
+unchanged.
 
 ## Writing changesets
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"format:config:check": "oxfmt --check *.ts *.json .oxfmtrc.json .oxlintrc.json .changeset/*.cjs .changeset/*.json .vscode/*.json scripts/tsconfig.json project.code-workspace",
 		"lint:agents": "oxlint server docker scripts docs .changeset .github commitlint.config.ts",
 		"lint:agents:fix": "oxlint --fix server docker scripts docs .changeset .github commitlint.config.ts",
-		"check:agents": "bun run format:agents:check && bun run format:docs:check && bun run format:config:check && bun run lint:agents && bun run typecheck:agents && bun run typecheck:scripts && bun run test:tooling",
+		"check:agents": "bun run format:agents:check && bun run format:docs:check && bun run format:config:check && bun run lint:agents && bun run typecheck:agents && bun run typecheck:scripts && bun scripts/check-release-image-inventory.ts && bun run test:tooling",
 		"check:agents:fix": "bun run format:agents && bun run format:docs && bun run format:config && oxlint --fix server docker scripts docs .changeset .github commitlint.config.ts",
 		"ci:agents": "bun run format:agents:check && bun run format:docs:check && bun run format:config:check && oxlint -f github server docker scripts docs .changeset .github commitlint.config.ts",
 		"format:server": "bun run format:java",

--- a/renovate.json
+++ b/renovate.json
@@ -69,7 +69,24 @@
 			"description": "Docker images",
 			"matchManagers": ["dockerfile", "docker-compose"],
 			"groupName": "Docker images",
+			"pinDigests": true,
 			"labels": ["dependencies", "infrastructure"]
+		},
+		{
+			"description": "Release runtime images",
+			"matchPackageNames": [
+				"docker.io/library/alpine",
+				"docker.io/library/nats",
+				"docker.io/library/nginx",
+				"docker.io/library/traefik",
+				"alpine",
+				"nats",
+				"nginx",
+				"traefik"
+			],
+			"groupName": "Release runtime images",
+			"automerge": false,
+			"labels": ["dependencies", "infrastructure", "security"]
 		}
 	],
 	"customManagers": [
@@ -81,6 +98,25 @@
 				"# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\nARG [A-Z_]+_VERSION=(?<currentValue>\\S+)"
 			],
 			"versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+		},
+		{
+			"description": "Track release security tool versions",
+			"customType": "regex",
+			"managerFilePatterns": ["/^\\.github/actions/setup-release-security-tools/action\\.yml$/"],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+(?<envName>[A-Z_]+): (?<currentValue>\\S+)"
+			],
+			"extractVersionTemplate": "^v(?<version>.*)$",
+			"versioningTemplate": "semver"
+		},
+		{
+			"description": "Keep the release evidence inventory aligned with reviewed upstream image pins",
+			"customType": "regex",
+			"managerFilePatterns": ["/^security/release-images\\.json$/"],
+			"matchStrings": [
+				"\"repository\": \"(?<depName>[^\"]+)\",\\s+\"tag\": \"(?<currentValue>[^\"]+)\",\\s+\"digest\": \"(?<currentDigest>sha256:[a-f0-9]{64})\""
+			],
+			"datasourceTemplate": "docker"
 		}
 	],
 	"vulnerabilityAlerts": {
@@ -88,8 +124,7 @@
 		"schedule": ["at any time"],
 		"minimumReleaseAge": null,
 		"dependencyDashboardApproval": false,
-		"prPriority": 10,
-		"automerge": true,
+		"automerge": false,
 		"groupName": null
 	},
 	"ignorePaths": ["**/node_modules/**", "**/target/**", "**/dist/**", "**/build/**"]

--- a/scripts/check-release-image-inventory.test.ts
+++ b/scripts/check-release-image-inventory.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { validateInventory } from "./check-release-image-inventory.ts";
+
+await test("repository release builds are covered by the evidence inventory", () => {
+	const inventory = JSON.parse(readFileSync("security/release-images.json", "utf8")) as unknown;
+	const workflow = readFileSync(".github/workflows/ci-docker-build.yml", "utf8");
+	assert.deepEqual(validateInventory(inventory, workflow), []);
+});
+
+await test("rejects missing and duplicate inventory entries", () => {
+	assert.deepEqual(
+		validateInventory(
+			{ images: ["server"], upstream: [] },
+			'image-name: "ls1intum/hephaestus/new"',
+		),
+		["new"],
+	);
+	assert.throws(
+		() => validateInventory({ images: ["server", "server"], upstream: [] }, ""),
+		/duplicates/,
+	);
+	assert.throws(() => validateInventory({ images: [], upstream: [{}] }, ""), /malformed upstream/);
+});

--- a/scripts/check-release-image-inventory.ts
+++ b/scripts/check-release-image-inventory.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+
+type UpstreamImage = { name: string; repository: string; digest: string };
+
+function isUpstreamImage(value: unknown): value is UpstreamImage {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"name" in value &&
+		"repository" in value &&
+		"digest" in value &&
+		typeof value.name === "string" &&
+		typeof value.repository === "string" &&
+		typeof value.digest === "string" &&
+		/^sha256:[a-f0-9]{64}$/.test(value.digest)
+	);
+}
+
+export function releaseImages(workflow: string): string[] {
+	return [...workflow.matchAll(/image-name:\s*["']ls1intum\/hephaestus\/([^"']+)["']/g)].map(
+		(match) => match[1] ?? "",
+	);
+}
+
+export function validateInventory(inventory: unknown, workflow: string): string[] {
+	if (
+		typeof inventory !== "object" ||
+		inventory === null ||
+		!("images" in inventory) ||
+		!Array.isArray(inventory.images) ||
+		inventory.images.some((image) => typeof image !== "string" || !/^[a-z0-9-]+$/.test(image))
+	)
+		throw new Error("malformed release image inventory");
+	const configured = inventory.images;
+	if (new Set(configured).size !== configured.length)
+		throw new Error("release image inventory contains duplicates");
+	if (!("upstream" in inventory) || !Array.isArray(inventory.upstream))
+		throw new Error("malformed upstream image inventory");
+	if (inventory.upstream.some((upstream) => !isUpstreamImage(upstream)))
+		throw new Error("malformed upstream image inventory");
+	return releaseImages(workflow).filter((image) => !configured.includes(image));
+}
+
+if (import.meta.main) {
+	const inventory = JSON.parse(readFileSync("security/release-images.json", "utf8")) as unknown;
+	const missing = validateInventory(
+		inventory,
+		readFileSync(".github/workflows/ci-docker-build.yml", "utf8"),
+	);
+	if (missing.length > 0)
+		throw new Error(`release images missing from evidence inventory: ${missing.join(", ")}`);
+	if (
+		typeof inventory !== "object" ||
+		inventory === null ||
+		!("upstream" in inventory) ||
+		!Array.isArray(inventory.upstream)
+	)
+		throw new Error("malformed upstream image inventory");
+	const compose = [
+		"docker/compose.app.yaml",
+		"docker/compose.core.yaml",
+		"docker/compose.proxy.yaml",
+	]
+		.map((path) => readFileSync(path, "utf8"))
+		.join("\n");
+	for (const image of inventory.upstream) {
+		if (!isUpstreamImage(image)) throw new Error("malformed upstream image inventory");
+		if (!compose.includes(`@${image.digest}`))
+			throw new Error(`upstream image ${image.name} is not digest-pinned in the deployment`);
+	}
+	const upstreamDigests = new Set(
+		inventory.upstream.filter(isUpstreamImage).map((image) => image.digest),
+	);
+	for (const match of compose.matchAll(/^\s*image:\s*["']?([^\s"']+)/gm)) {
+		const reference = match[1] ?? "";
+		if (reference.startsWith("ghcr.io/ls1intum/hephaestus/")) continue;
+		const digest = reference.match(/@(sha256:[a-f0-9]{64})$/)?.[1];
+		if (!digest || !upstreamDigests.has(digest))
+			throw new Error(`deployed upstream image is unpinned or missing from evidence: ${reference}`);
+	}
+}

--- a/scripts/check-release-sbom.test.ts
+++ b/scripts/check-release-sbom.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { validateReleaseSbom } from "./check-release-sbom.ts";
+
+const digest = `sha256:${"a".repeat(64)}`;
+const artifact = {
+	name: "example",
+	version: "1.2.3",
+	type: "npm",
+	purl: "pkg:npm/example@1.2.3",
+	locations: [{ path: "/app/package.json" }],
+	licenses: [{ value: "MIT" }],
+};
+const syft = {
+	source: {
+		type: "image",
+		metadata: { manifestDigest: digest, os: "linux", architecture: "amd64" },
+	},
+	artifacts: [artifact],
+};
+const spdx = {
+	spdxVersion: "SPDX-2.3",
+	dataLicense: "CC0-1.0",
+	documentNamespace: "https://example.com/sbom",
+	packages: [
+		{
+			name: "example",
+			versionInfo: "1.2.3",
+			externalRefs: [{ referenceType: "purl", referenceLocator: artifact.purl }],
+		},
+	],
+};
+const cycloneDx = {
+	bomFormat: "CycloneDX",
+	specVersion: "1.6",
+	components: [{ name: "example", version: "1.2.3", purl: artifact.purl }],
+};
+
+await test("proves subject binding and lossless package conversion", () => {
+	assert.deepEqual(validateReleaseSbom(syft, spdx, cycloneDx, digest, "linux/amd64"), {
+		schemaVersion: 1,
+		digest,
+		platform: "linux/amd64",
+		packageCount: 1,
+		packagesWithPurl: 1,
+		packagesWithLicense: 1,
+		packagesWithoutLicense: [],
+	});
+});
+
+await test("rejects wrong subjects and packages lost during conversion", () => {
+	assert.throws(
+		() => validateReleaseSbom(syft, spdx, cycloneDx, `sha256:${"b".repeat(64)}`, "linux/amd64"),
+		/wrong manifest/,
+	);
+	assert.throws(
+		() => validateReleaseSbom(syft, { ...spdx, packages: [] }, cycloneDx, digest, "linux/amd64"),
+		/SPDX output omitted/,
+	);
+	assert.throws(
+		() => validateReleaseSbom(syft, spdx, { ...cycloneDx, components: [] }, digest, "linux/amd64"),
+		/CycloneDX output omitted/,
+	);
+});
+
+await test("records unknown licenses instead of pretending they are known", () => {
+	const result = validateReleaseSbom(
+		{ ...syft, artifacts: [{ ...artifact, licenses: [] }] },
+		spdx,
+		cycloneDx,
+		digest,
+		"linux/amd64",
+	);
+	assert.equal(result.packagesWithLicense, 0);
+	assert.deepEqual(result.packagesWithoutLicense, [{ name: "example", version: "1.2.3" }]);
+});

--- a/scripts/check-release-sbom.ts
+++ b/scripts/check-release-sbom.ts
@@ -1,0 +1,135 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+type JsonObject = Record<string, unknown>;
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function object(value: unknown, label: string): JsonObject {
+	if (!isJsonObject(value)) throw new Error(`${label} must be an object`);
+	return value;
+}
+
+function array(value: unknown, label: string): unknown[] {
+	if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+	return value;
+}
+
+function text(value: unknown, label: string): string {
+	if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+	return value;
+}
+
+function packageKey(value: unknown, label: string): string {
+	const item = object(value, label);
+	return `${text(item.name, `${label}.name`)}\u0000${text(item.version, `${label}.version`)}`;
+}
+
+function purl(value: unknown): string | undefined {
+	const item = object(value, "package");
+	return typeof item.purl === "string" && item.purl.length > 0 ? item.purl : undefined;
+}
+
+export function validateReleaseSbom(
+	syftInput: unknown,
+	spdxInput: unknown,
+	cycloneDxInput: unknown,
+	digest: string,
+	platform: string,
+): JsonObject {
+	if (!/^sha256:[a-f0-9]{64}$/.test(digest)) throw new Error("subject digest is malformed");
+	const [os, architecture] = platform.split("/");
+	if (os !== "linux" || !architecture) throw new Error("platform must be linux/<architecture>");
+
+	const syft = object(syftInput, "Syft SBOM");
+	const source = object(syft.source, "Syft source");
+	const metadata = object(source.metadata, "Syft source metadata");
+	if (source.type !== "image") throw new Error("Syft source is not an image");
+	if (metadata.manifestDigest !== digest)
+		throw new Error("Syft SBOM is bound to the wrong manifest");
+	if (metadata.os !== os || metadata.architecture !== architecture)
+		throw new Error("Syft SBOM is bound to the wrong platform");
+
+	const artifacts = array(syft.artifacts, "Syft artifacts");
+	if (artifacts.length === 0) throw new Error("Syft SBOM contains no packages");
+	const expectedPurls = new Set<string>();
+	const missingLicenses: JsonObject[] = [];
+	for (const [index, value] of artifacts.entries()) {
+		const artifact = object(value, `Syft artifact ${index}`);
+		text(artifact.type, `Syft artifact ${index}.type`);
+		packageKey(artifact, `Syft artifact ${index}`);
+		const artifactPurl = purl(artifact);
+		if (artifactPurl) expectedPurls.add(artifactPurl);
+		if (array(artifact.locations, `Syft artifact ${index}.locations`).length === 0)
+			throw new Error(`Syft artifact ${index} has no location evidence`);
+		if (array(artifact.licenses, `Syft artifact ${index}.licenses`).length === 0)
+			missingLicenses.push({
+				name: text(artifact.name, "artifact.name"),
+				version: text(artifact.version, "artifact.version"),
+			});
+	}
+
+	const spdx = object(spdxInput, "SPDX SBOM");
+	if (spdx.spdxVersion !== "SPDX-2.3" || spdx.dataLicense !== "CC0-1.0")
+		throw new Error("invalid SPDX document metadata");
+	text(spdx.documentNamespace, "SPDX document namespace");
+	const spdxPurls = new Set<string>();
+	const spdxKeys = new Set<string>();
+	for (const [index, value] of array(spdx.packages, "SPDX packages").entries()) {
+		const item = object(value, `SPDX package ${index}`);
+		if (typeof item.name === "string" && typeof item.versionInfo === "string")
+			spdxKeys.add(`${item.name}\u0000${item.versionInfo}`);
+		for (const ref of Array.isArray(item.externalRefs) ? item.externalRefs : []) {
+			const external = object(ref, "SPDX external reference");
+			if (external.referenceType === "purl" && typeof external.referenceLocator === "string")
+				spdxPurls.add(external.referenceLocator);
+		}
+	}
+
+	const cycloneDx = object(cycloneDxInput, "CycloneDX SBOM");
+	if (cycloneDx.bomFormat !== "CycloneDX") throw new Error("invalid CycloneDX format");
+	text(cycloneDx.specVersion, "CycloneDX spec version");
+	const cyclonePurls = new Set<string>();
+	const cycloneKeys = new Set<string>();
+	for (const [index, value] of array(cycloneDx.components, "CycloneDX components").entries()) {
+		const component = object(value, `CycloneDX component ${index}`);
+		if (typeof component.name === "string" && typeof component.version === "string")
+			cycloneKeys.add(`${component.name}\u0000${component.version}`);
+		if (typeof component.purl === "string") cyclonePurls.add(component.purl);
+	}
+
+	for (const value of artifacts) {
+		const artifactPurl = purl(value);
+		const key = packageKey(value, "Syft artifact");
+		if (!(artifactPurl ? spdxPurls.has(artifactPurl) : spdxKeys.has(key)))
+			throw new Error(`SPDX output omitted ${key.replace("\u0000", "@")} from the Syft inventory`);
+		if (!(artifactPurl ? cyclonePurls.has(artifactPurl) : cycloneKeys.has(key)))
+			throw new Error(
+				`CycloneDX output omitted ${key.replace("\u0000", "@")} from the Syft inventory`,
+			);
+	}
+
+	return {
+		schemaVersion: 1,
+		digest,
+		platform,
+		packageCount: artifacts.length,
+		packagesWithPurl: expectedPurls.size,
+		packagesWithLicense: artifacts.length - missingLicenses.length,
+		packagesWithoutLicense: missingLicenses,
+	};
+}
+
+if (import.meta.main) {
+	const [syftPath, spdxPath, cycloneDxPath, digest, platform, outputPath] = process.argv.slice(2);
+	if (!syftPath || !spdxPath || !cycloneDxPath || !digest || !platform || !outputPath)
+		throw new Error(
+			"usage: check-release-sbom <syft> <spdx> <cyclonedx> <digest> <platform> <output>",
+		);
+	const readJson = (path: string): unknown => JSON.parse(readFileSync(path, "utf8")) as unknown;
+	writeFileSync(
+		outputPath,
+		`${JSON.stringify(validateReleaseSbom(readJson(syftPath), readJson(spdxPath), readJson(cycloneDxPath), digest, platform), null, 2)}\n`,
+	);
+}

--- a/scripts/check-release-vulnerabilities.test.ts
+++ b/scripts/check-release-vulnerabilities.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { evaluate } from "./check-release-vulnerabilities.ts";
+
+const finding = {
+	FixedVersion: "2",
+	InstalledVersion: "1",
+	PkgName: "lib",
+	Severity: "HIGH",
+	VulnerabilityID: "CVE-1",
+};
+const report = { Results: [{ Vulnerabilities: [finding] }] };
+const policy = { baseline: [], exceptions: [], schemaVersion: 1 };
+
+await test("rejects a new actionable fixed vulnerability", () => {
+	assert.deepEqual(evaluate("server", report, policy).rejected, ["server|CVE-1|lib|1"]);
+});
+
+await test("accepts an explicitly baselined installed version", () => {
+	assert.deepEqual(
+		evaluate("server", report, { ...policy, baseline: ["server|CVE-1|lib|1"] }).rejected,
+		[],
+	);
+});
+
+await test("does not classify an unfixed vulnerability as actionable", () => {
+	assert.deepEqual(
+		evaluate(
+			"server",
+			{ Results: [{ Vulnerabilities: [{ ...finding, FixedVersion: "" }] }] },
+			policy,
+		).rejected,
+		[],
+	);
+});
+
+await test("accepts an owned, justified, unexpired exception", () => {
+	const exceptions = [
+		{
+			expires: "2099-01-01T00:00:00Z",
+			image: "server",
+			installedVersion: "1",
+			justification: "not reachable in the deployed configuration",
+			owner: "@security",
+			package: "lib",
+			vulnerability: "CVE-1",
+		},
+	];
+	assert.deepEqual(evaluate("server", report, { ...policy, exceptions }).rejected, []);
+	assert.deepEqual(
+		evaluate("server", report, {
+			...policy,
+			exceptions: [{ ...exceptions[0], installedVersion: "0" }],
+		}).rejected,
+		["server|CVE-1|lib|1"],
+	);
+});
+
+await test("rejects expired and malformed exceptions", () => {
+	const exceptions = [
+		{
+			expires: "2020-01-01T00:00:00Z",
+			image: "server",
+			installedVersion: "1",
+			justification: "reviewed",
+			owner: "@security",
+			package: "lib",
+			vulnerability: "CVE-1",
+		},
+	];
+	assert.match(
+		evaluate("server", report, { ...policy, exceptions }, new Date("2021-01-01")).errors[0] ?? "",
+		/expired/,
+	);
+	assert.throws(() => evaluate("server", {}, policy), /malformed Trivy report/);
+	assert.throws(
+		() => evaluate("server", { Results: [{ Vulnerabilities: [{ Severity: "HIGH" }] }] }, policy),
+		/missing InstalledVersion/,
+	);
+});

--- a/scripts/check-release-vulnerabilities.ts
+++ b/scripts/check-release-vulnerabilities.ts
@@ -1,0 +1,162 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+type Finding = {
+	FixedVersion?: string;
+	InstalledVersion?: string;
+	PkgName?: string;
+	Severity?: string;
+	VulnerabilityID?: string;
+};
+
+type Exception = {
+	expires: string;
+	image: string;
+	installedVersion: string;
+	justification: string;
+	owner: string;
+	package: string;
+	vulnerability: string;
+};
+type Policy = { baseline: string[]; exceptions: Exception[]; schemaVersion: number };
+
+const record = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isException = (value: unknown): value is Exception =>
+	record(value) &&
+	[
+		"expires",
+		"image",
+		"installedVersion",
+		"justification",
+		"owner",
+		"package",
+		"vulnerability",
+	].every((field) => typeof value[field] === "string");
+
+const isPolicy = (value: unknown): value is Policy =>
+	record(value) &&
+	value.schemaVersion === 1 &&
+	Array.isArray(value.baseline) &&
+	value.baseline.every((entry) => typeof entry === "string") &&
+	Array.isArray(value.exceptions) &&
+	value.exceptions.every(isException);
+
+function parseJson(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+function fingerprint(image: string, finding: Finding): string {
+	return `${image}|${finding.VulnerabilityID}|${finding.PkgName}|${finding.InstalledVersion}`;
+}
+
+export function evaluate(
+	image: string,
+	reportValue: unknown,
+	policyValue: unknown,
+	now = new Date(),
+) {
+	if (!record(reportValue) || !Array.isArray(reportValue.Results))
+		throw new Error("malformed Trivy report");
+	if (!isPolicy(policyValue)) {
+		throw new Error("malformed vulnerability policy");
+	}
+	const policy = policyValue;
+	const baseline = new Set(policy.baseline);
+	const errors: string[] = [];
+	if (baseline.size !== policy.baseline.length) errors.push("baseline contains duplicate entries");
+	for (const entry of baseline) {
+		if (!/^[^|]+\|[^|]+\|[^|]+\|[^|]+$/.test(entry))
+			errors.push(`malformed baseline entry: ${entry}`);
+	}
+	for (const exception of policy.exceptions) {
+		if (
+			!exception.owner ||
+			!exception.justification ||
+			!exception.expires ||
+			!exception.image ||
+			!exception.installedVersion ||
+			!exception.package ||
+			!exception.vulnerability
+		) {
+			errors.push(
+				"exception is missing an owner, justification, expiry, image, package, installed version, or vulnerability",
+			);
+			continue;
+		}
+		const expiry = new Date(exception.expires);
+		if (
+			!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(exception.expires) ||
+			Number.isNaN(expiry.valueOf()) ||
+			expiry <= now
+		)
+			errors.push(`exception expired: ${exception.vulnerability} (${exception.expires})`);
+	}
+	const findings: Finding[] = [];
+	for (const result of reportValue.Results) {
+		if (
+			!record(result) ||
+			(result.Vulnerabilities != null && !Array.isArray(result.Vulnerabilities))
+		)
+			throw new Error("malformed Trivy result");
+		for (const value of result.Vulnerabilities ?? []) {
+			if (!record(value)) throw new Error("malformed Trivy vulnerability");
+			for (const field of ["InstalledVersion", "PkgName", "Severity", "VulnerabilityID"])
+				if (typeof value[field] !== "string" || value[field].length === 0)
+					throw new Error(`malformed Trivy vulnerability: missing ${field}`);
+			findings.push({
+				FixedVersion: typeof value.FixedVersion === "string" ? value.FixedVersion : undefined,
+				InstalledVersion:
+					typeof value.InstalledVersion === "string" ? value.InstalledVersion : undefined,
+				PkgName: typeof value.PkgName === "string" ? value.PkgName : undefined,
+				Severity: typeof value.Severity === "string" ? value.Severity : undefined,
+				VulnerabilityID:
+					typeof value.VulnerabilityID === "string" ? value.VulnerabilityID : undefined,
+			});
+		}
+	}
+	const actionable = findings.filter(
+		(finding) =>
+			(finding.Severity === "HIGH" || finding.Severity === "CRITICAL") &&
+			typeof finding.FixedVersion === "string" &&
+			finding.FixedVersion.trim().length > 0,
+	);
+	const rejected = actionable.filter((finding) => {
+		const id = fingerprint(image, finding);
+		if (baseline.has(id)) return false;
+		return !policy.exceptions.some(
+			(exception) =>
+				exception.image === image &&
+				exception.package === finding.PkgName &&
+				exception.installedVersion === finding.InstalledVersion &&
+				exception.vulnerability === finding.VulnerabilityID &&
+				new Date(exception.expires) > now,
+		);
+	});
+	return {
+		actionable: actionable.map((finding) => fingerprint(image, finding)),
+		errors,
+		rejected: rejected.map((finding) => fingerprint(image, finding)),
+	};
+}
+
+if (import.meta.main) {
+	const [image, reportPath, policyPath, outputPath] = process.argv.slice(2);
+	if (!image || !reportPath || !policyPath || !outputPath)
+		throw new Error(
+			"usage: check-release-vulnerabilities <image> <trivy.json> <policy.json> <result.json>",
+		);
+	const result = evaluate(image, parseJson(reportPath), parseJson(policyPath));
+	writeFileSync(
+		outputPath,
+		`${JSON.stringify({ image, status: result.errors.length === 0 && result.rejected.length === 0 ? "pass" : "fail", ...result }, null, 2)}\n`,
+	);
+	if (result.errors.length > 0 || result.rejected.length > 0) {
+		for (const message of [
+			...result.errors,
+			...result.rejected.map((finding) => `new actionable finding: ${finding}`),
+		])
+			process.stderr.write(`::error::${message}\n`);
+		process.exitCode = 1;
+	}
+}

--- a/security/release-images.json
+++ b/security/release-images.json
@@ -1,0 +1,29 @@
+{
+	"images": ["webapp", "application-server", "agent-pi", "release-pin-fetcher", "postgres"],
+	"upstream": [
+		{
+			"name": "alpine",
+			"repository": "docker.io/library/alpine",
+			"tag": "3",
+			"digest": "sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
+		},
+		{
+			"name": "nats",
+			"repository": "docker.io/library/nats",
+			"tag": "2.14.6-alpine",
+			"digest": "sha256:ad7a43eb7e3337c3c38ce5d784d1461791f95f730f252d2b25eee699752a0ca3"
+		},
+		{
+			"name": "nginx",
+			"repository": "docker.io/library/nginx",
+			"tag": "1.31.4-alpine",
+			"digest": "sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913"
+		},
+		{
+			"name": "traefik",
+			"repository": "docker.io/library/traefik",
+			"tag": "v3.7.4",
+			"digest": "sha256:fcdef599e6259359833dd2e1d49f9e964f66825d69bd3dd468f51102ce013d03"
+		}
+	]
+}

--- a/security/vulnerability-policy.json
+++ b/security/vulnerability-policy.json
@@ -1,0 +1,5 @@
+{
+	"schemaVersion": 1,
+	"baseline": [],
+	"exceptions": []
+}


### PR DESCRIPTION
## Description

Makes supply-chain evidence a release requirement instead of a best-effort CI report. A release now remains a draft until every published Hephaestus image, on both supported architectures, has digest-bound SBOM, signature, provenance, vulnerability-scan, and policy evidence that verifies from a clean job.

The release gate publishes SPDX and CycloneDX SBOMs, records scanner and database metadata, rejects stale or malformed evidence, and blocks new fixable HIGH/CRITICAL findings unless an exact-version baseline or owned, justified, expiring exception applies. It also replaces the former buildpack-only, fail-open scan with a weekly rescan of the latest supported release and reports failures to #1369.

The initial vulnerability baseline is intentionally empty. The first release through this gate will fail if current images contain actionable findings; maintainers must fix them or add explicitly reviewed policy entries rather than silently inheriting existing debt.

Operator verification instructions and machine-readable license evidence are documented in the release-management guide. The expensive image work runs only during releases and the scheduled rescan, not on local or pre-push paths.

Fixes #1546

## How to test

Automated validation completed locally:

- `bun run format`
- `bun run check`
- `bun run test:webapp` — 168 tests passed
- `cd server && ./mvnw -pl application -am test -Dsurefire.includedGroups=unit -T 2C --batch-mode -q`
- `actionlint` on the changed workflows

For the end-to-end release path, cut a release candidate and verify that missing or mismatched SBOM evidence, a stale/failed Trivy database, an unrecognized image, a new actionable finding, and an expired exception each leave the GitHub Release as a draft. The workflow also verifies that every platform digest belongs to its recorded OCI index and that downloaded SPDX assets equal their signed attestation predicates.

## Checklist

- [x] Added a minor changeset because the release contract and production image pins change operator-visible behavior.
- [x] No operator migration or new configuration is required; existing deployments continue to use the documented release flow.
- [x] Follow-up #1559 owns consuming a signed release-wide digest lock in staging, production, and rollback paths; this PR owns producing and verifying the release evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Releases now undergo automated evidence checks, including SBOM generation, vulnerability scanning, signing, and attestation verification before publication.
  - Added scheduled and manually triggered vulnerability rescans with diagnostic reports and failure notifications.
  - Added release image inventories and vulnerability policies for supply-chain tracking and exception handling.
  - Release runtime images are now pinned to verified versions for reproducible deployments.

- **Documentation**
  - Updated release-management guidance for draft releases, evidence gates, verification, and deployment sequencing.

- **Chores**
  - Centralized security-tool setup with checksum verification and version validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
