### PR TITLE
fix(scripts): keep worktree setup working when bun.lock is stale

### DIFF
--- a/scripts/jean-setup.ts
+++ b/scripts/jean-setup.ts
@@ -71,7 +71,19 @@ async function main(): Promise<void> {
 		}
 	}
 	console.log("Installing dependencies...");
-	await run("bun", ["install", "--frozen-lockfile"], { cwd: root });
+	// Not a gate: `qualify:bun-lockfile` and every CI install enforce the lockfile. A stale one here
+	// is worth a warning, not a worktree with no node_modules in it.
+	const lockfile = Bun.file(join(root, "bun.lock"));
+	const lockfileBefore = await lockfile.text();
+	try {
+		await run("bun", ["install", "--frozen-lockfile"], { cwd: root });
+	} catch {
+		console.log("  WARN: the frozen install failed — retrying without --frozen-lockfile.");
+		await run("bun", ["install"], { cwd: root });
+		// A network failure fails the frozen install too, and leaves nothing to commit.
+		if ((await lockfile.text()) !== lockfileBefore)
+			console.log("  WARN: bun.lock changed — commit it, or qualify:bun-lockfile fails in CI.");
+	}
 	console.log("✅ Jean worktree setup complete.");
 }
 


### PR DESCRIPTION
## Description

`scripts/jean-setup.ts` ran `bun install --frozen-lockfile` and let the failure end the bootstrap, leaving the worktree with **no `node_modules`**. The lockfile is already enforced by `qualify:bun-lockfile` and by all 13 CI installs, so the flag was never the thing holding the line in a dev worktree.

The frozen install becomes a preference: on failure the setup retries without the flag. It reports a stale lockfile **only when `bun.lock` actually moved** — the frozen install fails on a registry outage too, so asserting drift unconditionally would name a cause it never observed.

Real occurrence: #1556 bumped `webapp/package.json` without `bun.lock` (Dependabot cannot write Bun lockfiles). Every agent worktree opened on that branch failed to initialise.

## How to test

```bash
# 1. Happy path — unchanged, no warnings.
bun scripts/jean-setup.ts; echo "exit=$?"                    # exit=0, "✅ ... complete."

# 2. Stale lockfile — recovers, and says so.
sed -i 's/"@hey-api\/openapi-ts": "0.97.1"/"@hey-api\/openapi-ts": "0.97.3"/' webapp/package.json
bun scripts/jean-setup.ts; echo "exit=$?"                    # exit=0, both WARNs, usable tree
git checkout -- webapp/package.json bun.lock && bun install --frozen-lockfile

# 3. Non-drift failure — must NOT claim the lockfile changed, must not report success.
sed -i 's#"@hey-api/openapi-ts": "0.97.1",#"@hey-api/openapi-ts": "0.97.1",\n\t\t"@nope/x": "9.9.9",#' webapp/package.json
BUN_CONFIG_REGISTRY=http://127.0.0.1:1 bun scripts/jean-setup.ts; echo "exit=$?"
# exit=1, bun's real error, no "bun.lock changed", no "✅"
git checkout -- webapp/package.json bun.lock
```

All three verified on the merge base. `bun run format && bun run check` passes.

## Checklist

`scripts/**` is not shipped code (`server/`, `webapp/`, `docker/`), so `verify-changesets` requires no changeset here.

- [x] Changeset summary reads as an operator/user-facing note — n/a, none required
- [x] Operator action documented — n/a, none

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>