### PR TITLE
fix(ci): let the preview webapp start its nginx workers

### DIFF
--- a/.changeset/previews-serve-their-frontend.md
+++ b/.changeset/previews-serve-their-frontend.md
@@ -1,0 +1,5 @@
+---
+---
+
+Corrects the preview stack before pull request previews reach a release; no deployed behaviour
+changes.

--- a/docker/preview/compose.app.yaml
+++ b/docker/preview/compose.app.yaml
@@ -327,7 +327,6 @@ services:
           cpus: "1.0"
           memory: 2G
           pids: 512
-
   webapp:
     image: ghcr.io/ls1intum/hephaestus/webapp:${SOURCE_COMMIT:?Coolify supplies the deployed commit}
     # `expose` is how Coolify learns which port to route ${SERVICE_FQDN_WEBAPP} to; the image's own
@@ -351,6 +350,13 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
+    # nginx's master chowns its cache directories and then runs its workers as the nginx user. With
+    # CHOWN alone the master survives and every worker exits "fatal code 2 and cannot be respawned",
+    # which leaves a container that looks up and serves nothing.
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:80/"]
       interval: 10s

--- a/scripts/check-preview-stack.ts
+++ b/scripts/check-preview-stack.ts
@@ -116,11 +116,13 @@ const RENDER_ENV: Record<string, string> = {
 /** Values the server refuses to start without: it validates them before the context is built, so an
  * empty one here is a preview that restart-loops rather than a preview that misbehaves quietly. */
 /**
- * Capabilities a service may add back after `cap_drop: ALL`. PostgreSQL's entrypoint chowns its data
- * directory and drops to its own user, which needs these five; every other service runs with none.
+ * Capabilities a service may add back after `cap_drop: ALL`. Both entries are servers whose root
+ * process prepares a directory and then runs its real work as another user; each set is the minimum
+ * found by running the image with less. The application server needs none.
  */
 const ALLOWED_CAPABILITIES: Record<string, readonly string[]> = {
 	postgres: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"],
+	webapp: ["CHOWN", "SETGID", "SETUID"],
 };
 
 const REQUIRED_NON_EMPTY = ["HEPHAESTUS_TRUSTED_PROXIES", "WEBHOOK_SECRET"];


### PR DESCRIPTION
## Description

The first preview to get this far crash-looped in its SPA container:

```
nginx: [emerg] chown("/var/cache/nginx/client_temp", 101) failed (1: Operation not permitted)
```

`cap_drop: ALL` leaves nginx's master unable to prepare its cache directories. This is a latent bug from the original hardening rather than a regression: the webapp `depends_on` the application server being healthy, and until #1566 no preview ever reached that point, so the container had never actually started.

`CHOWN` alone is not enough, and it fails in the worst way — the master survives and reports `start worker processes`, then every worker exits:

```
[alert] 1#1: worker process 46 exited with fatal code 2 and cannot be respawned
```

leaving a container Docker still calls `running` while it serves nothing. nginx runs its workers as the `nginx` user, so it needs `SETGID` and `SETUID` too. That is the same shape as the PostgreSQL entry already in the allowlist, and the allowlist comment now says what the two have in common instead of listing one of them.

## How to test

Measured against the published image on the staging host, not reasoned about — two containers side by side, 20 seconds each:

| capabilities | result |
|---|---|
| `cap_drop: ALL` | `chown(...) failed (1: Operation not permitted)` |
| `+ CHOWN` | master up, **workers dead**: `fatal code 2 and cannot be respawned` |
| `+ CHOWN, SETGID, SETUID` | `start worker process 45, 46, 47` — stays up |

`bun run format` and `bun run check` are green; `check-preview-stack.ts` still fails on any capability not in the allowlist.

This pull request cannot preview itself — the controller refuses any head that edits `docker/preview/**` — so #1538 redeploying after merge is the end-to-end test. Everything ahead of the SPA already works there: the seed loader clones and silences staging's data, and the application server is healthy against it and against staging's broker.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note — empty changeset: previews have not reached a release, so this fixes behaviour before anyone runs it
- [x] If the operator must act on this change, the changeset says how — no operator action
