### PR TITLE
fix(server): report a missing variable instead of failing to read it

### DIFF
--- a/.changeset/startup-report-survives-a-missing-variable.md
+++ b/.changeset/startup-report-survives-a-missing-variable.md
@@ -2,6 +2,8 @@
 "hephaestus": patch
 ---
 
-Starting with a required environment variable unset now prints the configuration report that names
-every missing setting, instead of ending at a stack trace about an unresolved placeholder. A value
-such as `DATABASE_URL` is reported as the setting it stands for.
+A start that cannot read one of its settings — a variable referenced but never provided, or one that
+refers to itself — now prints the configuration report naming that setting, instead of ending at a
+stack trace about an unresolved placeholder. A setting that cannot be read is never answered with its
+default either, so a security switch whose value is unreadable is reported as needing attention
+rather than as satisfied, and the reason is logged.

--- a/.changeset/startup-report-survives-a-missing-variable.md
+++ b/.changeset/startup-report-survives-a-missing-variable.md
@@ -1,0 +1,7 @@
+---
+"hephaestus": patch
+---
+
+Starting with a required environment variable unset now prints the configuration report that names
+every missing setting, instead of ending at a stack trace about an unresolved placeholder. A value
+such as `DATABASE_URL` is reported as the setting it stands for.

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
@@ -9,12 +9,16 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.util.PlaceholderResolutionException;
 
 @Component
 public final class ConfigurationReadinessEvaluator {
+
+    private static final Logger log = LoggerFactory.getLogger(ConfigurationReadinessEvaluator.class);
 
     static final String DOC = "https://ls1intum.github.io/Hephaestus/admin/configuration-readiness";
     private static final Pattern DIGEST = Pattern.compile("^[a-z0-9][a-z0-9._/:\\-]*@sha256:[a-f0-9]{64}$");
@@ -255,12 +259,31 @@ public final class ConfigurationReadinessEvaluator {
         try {
             return environment.getProperty(key);
         } catch (PlaceholderResolutionException unresolved) {
+            unreadable(key, unresolved);
             return null;
         }
     }
 
+    /**
+     * Logs what the verdict cannot carry. Every caller reduces an unreadable value to "no value",
+     * which is the right verdict but a poor diagnosis: a circular reference and an unset variable
+     * look identical afterwards, and only this message separates them.
+     */
+    private void unreadable(String key, PlaceholderResolutionException unresolved) {
+        log.warn("Could not read {} while checking configuration: {}", key, unresolved.getMessage());
+    }
+
     private BooleanSetting booleanSetting(String key, boolean fallback) {
-        String value = property(key);
+        String value;
+        try {
+            value = environment.getProperty(key);
+        } catch (PlaceholderResolutionException unresolved) {
+            // Absent means the operator accepted the default. Unreadable means nobody can say what
+            // they chose, so falling back would answer a question like "is loopback egress off?"
+            // with a guess — the same verdict a value that does not parse gets.
+            unreadable(key, unresolved);
+            return new BooleanSetting(false, false);
+        }
         if (value == null) return new BooleanSetting(true, fallback);
         if ("true".equalsIgnoreCase(value)) return new BooleanSetting(true, true);
         if ("false".equalsIgnoreCase(value)) return new BooleanSetting(true, false);

--- a/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
+++ b/server/application/src/main/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluator.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+import org.springframework.util.PlaceholderResolutionException;
 
 @Component
 public final class ConfigurationReadinessEvaluator {
@@ -160,7 +161,7 @@ public final class ConfigurationReadinessEvaluator {
                 roles(ConfigurationRole.WORKER),
                 ConfigurationRequirement.RECOMMENDED,
                 worker,
-                "runsc".equals(environment.getProperty("hephaestus.sandbox.container-runtime")),
+                "runsc".equals(property("hephaestus.sandbox.container-runtime")),
                 "gVisor (runsc) is recommended for stronger agent sandbox isolation.",
                 "sandbox-isolation");
         add(
@@ -206,7 +207,7 @@ public final class ConfigurationReadinessEvaluator {
             Predicate<String> predicate,
             String explanation,
             String anchor) {
-        String value = environment.getProperty(subject);
+        String value = property(subject);
         boolean configured = requirement != ConfigurationRequirement.OPTIONAL || notBlank(value);
         boolean satisfied = applicable && predicate.test(value);
         add(facts, id, subject, roles, requirement, applicable, configured, satisfied, explanation, anchor);
@@ -244,8 +245,22 @@ public final class ConfigurationReadinessEvaluator {
         facts.add(new ConfigurationFactDTO(id, subject, roles, requirement, status, explanation, DOC + "#" + anchor));
     }
 
+    /**
+     * Reads a property the way an operator experiences it. A value like {@code jdbc:${DATABASE_URL}}
+     * throws rather than resolving when the variable behind it is unset, which is exactly the
+     * deployment this evaluator exists to describe — so an unresolvable placeholder is reported as
+     * the missing setting it stands for instead of ending the report with a stack trace.
+     */
+    private @Nullable String property(String key) {
+        try {
+            return environment.getProperty(key);
+        } catch (PlaceholderResolutionException unresolved) {
+            return null;
+        }
+    }
+
     private BooleanSetting booleanSetting(String key, boolean fallback) {
-        String value = environment.getProperty(key);
+        String value = property(key);
         if (value == null) return new BooleanSetting(true, fallback);
         if ("true".equalsIgnoreCase(value)) return new BooleanSetting(true, true);
         if ("false".equalsIgnoreCase(value)) return new BooleanSetting(true, false);

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
@@ -133,15 +133,41 @@ class ConfigurationReadinessEvaluatorTest extends BaseUnitTest {
     void shouldReportAnUnresolvablePlaceholderAsTheSettingItStandsFor() {
         MockEnvironment environment = environment(validProperties());
         environment.setActiveProfiles("prod");
-        // What a deployment with DATABASE_URL unset actually renders: application.yml pins
-        // spring.datasource.url to jdbc:${DATABASE_URL}, and resolving that throws instead of
-        // returning null. Reading it must not end the report that exists to name the omission.
+        // Resolving a placeholder over an unset variable throws instead of returning null, so
+        // reading it must not end the report. The second problem proves the report continues past
+        // the one it could not read, rather than stopping at it.
         environment.setProperty("spring.datasource.url", "jdbc:${DATABASE_URL}");
+        environment.setProperty("hephaestus.webhook.secret", "short-secret");
 
         assertThatThrownBy(() -> new ProductionConfigurationEnvironmentPostProcessor()
                         .postProcessEnvironment(environment, new SpringApplication(Object.class)))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("database.url");
+                .hasMessageContaining("database.url")
+                .hasMessageContaining("webhook.shared-secret");
+    }
+
+    @Test
+    void shouldMarkAnUnreadableSettingActionRequiredRatherThanNotConfigured() {
+        Map<String, Object> properties = validProperties();
+        properties.put("spring.datasource.url", "jdbc:${DATABASE_URL}");
+
+        List<ConfigurationFactDTO> facts = evaluateReadiness(properties, true);
+
+        // Only ACTION_REQUIRED reaches the startup filter; NOT_CONFIGURED would boot the server.
+        assertStatus(facts, "database.url", ConfigurationStatus.ACTION_REQUIRED);
+    }
+
+    @Test
+    void shouldRejectSecurityBooleansItCannotRead() {
+        Map<String, Object> properties = validProperties();
+        properties.put("hephaestus.llm.egress.allow-loopback", "${MISSING_EGRESS_FLAG}");
+        properties.put("hephaestus.sync.nats.enabled", "${MISSING_NATS_FLAG}");
+
+        List<ConfigurationFactDTO> facts = evaluateReadiness(properties, true);
+
+        // A value that cannot be read must not be answered with its permissive default.
+        assertStatus(facts, "llm.proxy-egress", ConfigurationStatus.ACTION_REQUIRED);
+        assertStatus(facts, "nats.role-contract", ConfigurationStatus.ACTION_REQUIRED);
     }
 
     @Test

--- a/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
+++ b/server/application/src/test/java/de/tum/cit/aet/hephaestus/core/configuration/ConfigurationReadinessEvaluatorTest.java
@@ -130,6 +130,21 @@ class ConfigurationReadinessEvaluatorTest extends BaseUnitTest {
     }
 
     @Test
+    void shouldReportAnUnresolvablePlaceholderAsTheSettingItStandsFor() {
+        MockEnvironment environment = environment(validProperties());
+        environment.setActiveProfiles("prod");
+        // What a deployment with DATABASE_URL unset actually renders: application.yml pins
+        // spring.datasource.url to jdbc:${DATABASE_URL}, and resolving that throws instead of
+        // returning null. Reading it must not end the report that exists to name the omission.
+        environment.setProperty("spring.datasource.url", "jdbc:${DATABASE_URL}");
+
+        assertThatThrownBy(() -> new ProductionConfigurationEnvironmentPostProcessor()
+                        .postProcessEnvironment(environment, new SpringApplication(Object.class)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("database.url");
+    }
+
+    @Test
     void shouldNotAllowAnotherProfileToBypassProductionValidation() {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("prod", "test");


### PR DESCRIPTION
## Description

`ConfigurationReadinessEvaluator` reads every setting through `Environment.getProperty`. When a value is a placeholder over an unset variable — `spring.datasource.url` is pinned to `jdbc:${DATABASE_URL}` in `application.yml` — that call **throws** rather than returning null:

```
org.springframework.util.PlaceholderResolutionException:
  Could not resolve placeholder 'DATABASE_URL' in value "jdbc:${DATABASE_URL}"
	at ConfigurationReadinessEvaluator.add(ConfigurationReadinessEvaluator.java:209)
	at ProductionConfigurationEnvironmentPostProcessor.postProcessEnvironment(…:21)
```

So the report whose entire job is to name missing configuration died on the first missing setting it was written to name. An operator starting the server without `DATABASE_URL` got a stack trace instead of the list of everything they need to set — worst exactly when it matters most, on a first deployment.

Reading now goes through one helper that treats an unresolvable placeholder as the setting being unset, which is what it means from the operator's side. The other two call sites use it too, so a placeholder anywhere in the surface cannot end the report.

## How to test

Verified against the published image (`application-server` built from `main`), not only in unit tests. An otherwise-valid `prod` environment with `DATABASE_URL` unset:

**Before** — `PlaceholderResolutionException`, no report.
**After** — the report, naming the setting:

```
Production configuration validation failed with 1 problem(s):
 - [database.url] A PostgreSQL JDBC URL is required. Set spring.datasource.url.
   https://ls1intum.github.io/Hephaestus/admin/configuration-readiness#database
```

The new test reproduces the production value exactly (`jdbc:${DATABASE_URL}` with no `DATABASE_URL`) and asserts an `IllegalStateException` naming `database.url`. Mutation-tested: reverting the one-line read makes it fail with the same `PlaceholderResolutionException` seen in production. 12 tests pass; `bun run format` and `bun run check` are green.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry)
- [x] If the operator must act on this change, the changeset says how — no action; this only improves the message a misconfigured start produces


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Startup configuration reports now identify all missing required settings instead of stopping at an unresolved placeholder error.
  - Unresolved environment-variable placeholders are reported with the related configuration setting, such as `DATABASE_URL`.
  - Improved configuration validation preserves clear error reporting for invalid datasource settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->