### PR TITLE
fix(deps): restore trustworthy dependency automation

### DIFF
--- a/.changeset/solid-ends-decide.md
+++ b/.changeset/solid-ends-decide.md
@@ -1,0 +1,4 @@
+---
+---
+
+No release note: this updates dependency automation and its generated client output without changing operator- or user-facing behavior.

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -280,7 +280,7 @@ jobs:
 
       - name: Install cosign
         if: inputs.single-arch
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign and verify image
         if: inputs.single-arch
@@ -413,7 +413,7 @@ jobs:
           push-to-registry: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # --recursive: sign each child manifest so per-platform verify works.
       - name: Sign image with cosign

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,7 @@ Out of scope:
 
 Independent of this reporting channel, the project runs:
 
-- **Dependency updates**: [Renovate](https://docs.renovatebot.com/) (Mend-hosted) with vulnerability alerts prioritized and auto-merged ([`renovate.json`](renovate.json))
+- **Dependency updates**: [Renovate](https://docs.renovatebot.com/) proposes vulnerability fixes without dashboard approval or a minimum release age ([`renovate.json`](renovate.json))
 - **Dependency & secret scanning in CI**: Trivy filesystem scan and TruffleHog ([`ci-security-scan.yml`](.github/workflows/ci-security-scan.yml))
 - **Static analysis**: GitHub CodeQL
 - **Native alerts**: GitHub secret scanning and Dependabot dependency alerts

--- a/bun.lock
+++ b/bun.lock
@@ -116,7 +116,7 @@
       "devDependencies": {
         "@chromatic-com/storybook": "5.2.1",
         "@gitlab/svgs": "^3.160.0",
-        "@hey-api/openapi-ts": "0.97.1",
+        "@hey-api/openapi-ts": "0.97.3",
         "@oxlint/plugins": "1.79.0",
         "@playwright/test": "1.60.0",
         "@primer/primitives": "11.9.0",
@@ -859,13 +859,13 @@
 
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
-    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.1", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA=="],
+    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.2", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-R2NMf3wq97rh1mjz33WJQU8svz3F0RYUjvx/QzXucjpSqQ3O5huTdDjErG4fMxSr1X+X56NuDrqtGfHmo1TRUQ=="],
 
     "@hey-api/json-schema-ref-parser": ["@hey-api/json-schema-ref-parser@1.4.2", "", { "dependencies": { "@jsdevtools/ono": "7.1.3", "@types/json-schema": "7.0.15", "js-yaml": "4.1.1" } }, "sha512-ZhCFSKI2ipZHEbgmtUHdyddvRU3wJ4elgCfYUC7T7hZa4EivSrVflTQf2w+v3TuaYxR1Y2V2kq3otqTttrrK8Q=="],
 
-    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.97.1", "", { "dependencies": { "@hey-api/codegen-core": "0.8.1", "@hey-api/json-schema-ref-parser": "1.4.2", "@hey-api/shared": "0.4.3", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "@lukeed/ms": "2.0.2", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "14.0.3", "get-tsconfig": "4.14.0" }, "peerDependencies": { "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc" }, "bin": { "openapi-ts": "bin/run.js" } }, "sha512-LksUJeXAqwf6OhcCCr3/B4YjnBs5rqSqjDUKMBvkgp4OhaCQiJrOvntctFxdnugy8jUojP4yi/eJf5xYzcYzCQ=="],
+    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.97.3", "", { "dependencies": { "@hey-api/codegen-core": "0.8.2", "@hey-api/json-schema-ref-parser": "1.4.2", "@hey-api/shared": "0.4.5", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "@lukeed/ms": "2.0.2", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "14.0.3", "get-tsconfig": "4.14.0" }, "peerDependencies": { "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc" }, "bin": { "openapi-ts": "./bin/run.js" } }, "sha512-4sR6/E/POuy7aPZW9DDjhObzZCq7eSJWiW0+epXeKNczoTWEwdOyWFy9Ca/CnXYlZ3oJsrv0ZD0OO+YuczT7CA=="],
 
-    "@hey-api/shared": ["@hey-api/shared@0.4.3", "", { "dependencies": { "@hey-api/codegen-core": "0.8.1", "@hey-api/json-schema-ref-parser": "1.4.2", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "cross-spawn": "7.0.6", "open": "11.0.0", "semver": "7.7.4" } }, "sha512-3tHfZNXgGOt+3P3Kq9cvqmZ9i7e3jtrkip1uDpZTX1+hTNboHhYdjxnT8AbrDuvslTaQHoAOlP4/iCDdzd9Jag=="],
+    "@hey-api/shared": ["@hey-api/shared@0.4.5", "", { "dependencies": { "@hey-api/codegen-core": "0.8.2", "@hey-api/json-schema-ref-parser": "1.4.2", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "cross-spawn": "7.0.6", "open": "11.0.0", "semver": "7.7.4" } }, "sha512-au4eHpBXAe1du0iMp6ESYuEaMS2jsoEyrbcT246btRhI9rMeQFEs7ZjtcMGXGsxhpaR38A8cPGNHx7QOrWAdMw=="],
 
     "@hey-api/spec-types": ["@hey-api/spec-types@0.2.0", "", { "dependencies": { "@hey-api/types": "0.1.4" } }, "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg=="],
 

--- a/docs/contributor/release-management.mdx
+++ b/docs/contributor/release-management.mdx
@@ -151,11 +151,11 @@ Check the current release: `git describe --tags --abbrev=0` or
 
 ## Dependency management
 
-Dependencies are managed through the
-[Renovate Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/). Approved
-updates are scheduled after the configured release-age checks; vulnerability alerts may run and merge
-independently. Bot PRs are exempt from the changeset check — when a dependency bump is user-facing,
-a maintainer adds the changeset.
+Routine dependency updates require approval through the
+[Renovate Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) and observe
+the configured schedule and release age. Vulnerability-fix pull requests bypass those controls but
+still require review. Bot PRs are exempt from the changeset check — when a dependency bump is
+user-facing, a maintainer adds the changeset.
 
 Exact pins remain exact during Renovate updates. Formatter upgrades must include and separately review
 any resulting mechanical formatting changes.

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"description": "Renovate config - dashboard only, manual updates",
 	"extends": [
 		"config:best-practices",
 		":semanticCommitTypeAll(chore)",
@@ -11,9 +10,16 @@
 	"timezone": "Europe/Berlin",
 	"schedule": ["before 7am on monday"],
 	"minimumReleaseAge": "3 days",
-	"platformAutomerge": true,
-	"automergeStrategy": "squash",
 	"semanticCommitScope": "deps",
+	"enabledManagers": [
+		"bun",
+		"maven",
+		"maven-wrapper",
+		"dockerfile",
+		"docker-compose",
+		"github-actions",
+		"custom.regex"
+	],
 	"dependencyDashboard": true,
 	"dependencyDashboardTitle": "Dependency Dashboard",
 	"lockFileMaintenance": {
@@ -23,32 +29,53 @@
 	"rangeStrategy": "replace",
 	"packageRules": [
 		{
-			"description": "Group Java/Spring",
 			"matchManagers": ["maven"],
-			"groupName": "Java dependencies",
+			"matchDepTypes": ["compile", "runtime", "provided", "optional", "parent", "parent-root"],
+			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+			"groupName": "Java runtime and framework dependencies",
 			"labels": ["dependencies", "java"]
 		},
 		{
-			"description": "Group webapp non-major updates",
+			"matchManagers": ["maven"],
+			"matchDepTypes": ["build", "test"],
+			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+			"groupName": "Java developer tooling",
+			"labels": ["dependencies", "java"]
+		},
+		{
 			"matchFileNames": ["webapp/package.json"],
+			"matchDepTypes": ["dependencies"],
 			"matchUpdateTypes": ["minor", "patch"],
-			"groupName": "Webapp dependencies",
+			"groupName": "Webapp runtime dependencies",
 			"labels": ["dependencies", "webapp"]
 		},
 		{
-			"description": "Group documentation deps",
+			"matchFileNames": ["webapp/package.json"],
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "Webapp developer tooling",
+			"labels": ["dependencies", "webapp"]
+		},
+		{
 			"matchFileNames": ["docs/package.json"],
-			"groupName": "Documentation dependencies",
+			"matchDepTypes": ["dependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "Documentation runtime dependencies",
 			"labels": ["dependencies", "docs"]
 		},
 		{
-			"description": "Major updates",
+			"matchFileNames": ["docs/package.json"],
+			"matchDepTypes": ["devDependencies"],
+			"matchUpdateTypes": ["minor", "patch"],
+			"groupName": "Documentation developer tooling",
+			"labels": ["dependencies", "docs"]
+		},
+		{
 			"matchUpdateTypes": ["major"],
 			"minimumReleaseAge": "7 days",
 			"labels": ["dependencies", "breaking"]
 		},
 		{
-			"description": "Core frameworks",
 			"matchPackageNames": [
 				"typescript",
 				"react",
@@ -60,38 +87,23 @@
 			"groupName": "Core frameworks"
 		},
 		{
-			"description": "GitHub Actions",
 			"matchManagers": ["github-actions"],
+			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
 			"groupName": "GitHub Actions",
 			"labels": ["dependencies", "ci"]
 		},
 		{
-			"description": "Docker images",
 			"matchManagers": ["dockerfile", "docker-compose"],
-			"groupName": "Docker images",
-			"pinDigests": true,
 			"labels": ["dependencies", "infrastructure"]
 		},
 		{
-			"description": "Release runtime images",
-			"matchPackageNames": [
-				"docker.io/library/alpine",
-				"docker.io/library/nats",
-				"docker.io/library/nginx",
-				"docker.io/library/traefik",
-				"alpine",
-				"nats",
-				"nginx",
-				"traefik"
-			],
-			"groupName": "Release runtime images",
-			"automerge": false,
-			"labels": ["dependencies", "infrastructure", "security"]
+			"matchUpdateTypes": ["major"],
+			"groupName": null
 		}
 	],
 	"customManagers": [
 		{
-			"description": "Track ARG <PKG>_VERSION pins in Dockerfiles via a `# renovate:` magic comment, so Renovate handles bumps for tools installed inside the image (e.g. agent-pi's @earendil-works/pi-coding-agent).",
+			"description": "Track Dockerfile ARG version pins",
 			"customType": "regex",
 			"managerFilePatterns": ["/(^|/)Dockerfile$/"],
 			"matchStrings": [
@@ -110,7 +122,7 @@
 			"versioningTemplate": "semver"
 		},
 		{
-			"description": "Keep the release evidence inventory aligned with reviewed upstream image pins",
+			"description": "Track release image tags and digests",
 			"customType": "regex",
 			"managerFilePatterns": ["/^security/release-images\\.json$/"],
 			"matchStrings": [
@@ -120,8 +132,8 @@
 		}
 	],
 	"vulnerabilityAlerts": {
+		"enabled": true,
 		"labels": ["security", "dependencies"],
-		"schedule": ["at any time"],
 		"minimumReleaseAge": null,
 		"dependencyDashboardApproval": false,
 		"automerge": false,

--- a/webapp/openapi-ts.config.ts
+++ b/webapp/openapi-ts.config.ts
@@ -1,10 +1,10 @@
-import { defaultPlugins, defineConfig } from "@hey-api/openapi-ts";
+import { defineConfig } from "@hey-api/openapi-ts";
 
 export default defineConfig({
 	input: "../server/openapi.yaml",
 	output: "src/api",
 	plugins: [
-		...defaultPlugins,
+		"@hey-api/typescript",
 		"@hey-api/client-fetch",
 		{
 			name: "@tanstack/react-query",
@@ -15,16 +15,13 @@ export default defineConfig({
 			bigInt: false,
 			name: "@hey-api/transformers",
 		},
-		// The transformers plugin only *emits* `transformers.gen.ts`; the SDK ignores it unless asked.
-		// Without this the generated types promise `Date` while the fetch client hands back the raw
-		// ISO string, so anything typed against the client (`.toLocaleDateString()`) throws on the
-		// first real response while every `new Date(…)` fixture stays green.
+		// Apply generated date transformers so SDK values match their Date types.
 		{
 			name: "@hey-api/sdk",
 			transformer: true,
 		},
 	],
-	// Generated query hooks do not support SSE responses; Mentor uses use-mentor-chat.ts.
+	// SSE operations use the streaming client rather than generated query hooks.
 	parser: {
 		filters: {
 			operations: {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -69,7 +69,7 @@
 	"devDependencies": {
 		"@chromatic-com/storybook": "5.2.1",
 		"@gitlab/svgs": "^3.160.0",
-		"@hey-api/openapi-ts": "0.97.1",
+		"@hey-api/openapi-ts": "0.97.3",
 		"@oxlint/plugins": "1.79.0",
 		"@playwright/test": "1.60.0",
 		"@primer/primitives": "11.9.0",
@@ -86,6 +86,7 @@
 		"@testing-library/dom": "10.4.1",
 		"@testing-library/react": "16.3.2",
 		"@testing-library/user-event": "14.6.1",
+		"@types/hast": "3.0.5",
 		"@types/node": "24.12.4",
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",
@@ -109,8 +110,7 @@
 		"typescript7": "npm:typescript@7.0.2",
 		"vite": "8.2.2",
 		"vite-plugin-terminal": "1.4.0",
-		"vitest": "4.1.11",
-		"@types/hast": "3.0.5"
+		"vitest": "4.1.11"
 	},
 	"msw": {
 		"workerDirectory": [

--- a/webapp/src/api/client/client.gen.ts
+++ b/webapp/src/api/client/client.gen.ts
@@ -48,10 +48,7 @@ export const createClient = (config: Config = {}): Client => {
     };
 
     if (opts.security) {
-      await setAuthParams({
-        ...opts,
-        security: opts.security,
-      });
+      await setAuthParams(opts);
     }
 
     if (opts.requestValidator) {

--- a/webapp/src/api/client/types.gen.ts
+++ b/webapp/src/api/client/types.gen.ts
@@ -151,12 +151,13 @@ type MethodFn = <
 
 type SseFn = <
   TData = unknown,
-  TError = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _TError = unknown,
   ThrowOnError extends boolean = false,
   TResponseStyle extends ResponseStyle = 'fields',
 >(
   options: Omit<RequestOptions<never, TResponseStyle, ThrowOnError>, 'method'>,
-) => Promise<ServerSentEventsResult<TData, TError>>;
+) => Promise<ServerSentEventsResult<TData>>;
 
 type RequestFn = <
   TData = unknown,

--- a/webapp/src/api/client/utils.gen.ts
+++ b/webapp/src/api/client/utils.gen.ts
@@ -118,14 +118,12 @@ const checkForExistence = (
   return false;
 };
 
-export const setAuthParams = async ({
-  security,
-  ...options
-}: Pick<Required<RequestOptions>, 'security'> &
-  Pick<RequestOptions, 'auth' | 'query'> & {
+export async function setAuthParams(
+  options: Pick<RequestOptions, 'auth' | 'query' | 'security'> & {
     headers: Headers;
-  }) => {
-  for (const auth of security) {
+  },
+): Promise<void> {
+  for (const auth of options.security ?? []) {
     if (checkForExistence(options, auth.name)) {
       continue;
     }
@@ -154,7 +152,7 @@ export const setAuthParams = async ({
         break;
     }
   }
-};
+}
 
 export const buildUrl: Client['buildUrl'] = (options) =>
   getUrl({

--- a/webapp/src/api/core/params.gen.ts
+++ b/webapp/src/api/core/params.gen.ts
@@ -104,10 +104,10 @@ const stripEmptySlots = (params: Params) => {
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {
-    body: {},
-    headers: {},
-    path: {},
-    query: {},
+    body: Object.create(null),
+    headers: Object.create(null),
+    path: Object.create(null),
+    query: Object.create(null),
   };
 
   const map = buildKeyMap(fields);


### PR DESCRIPTION
## Description

Restore Renovate's dependency inventory around the repository's current Bun, Maven, container, and GitHub Actions toolchain. Security fixes now bypass routine dashboard approval and release-age controls without being auto-merged, while routine updates are split into reviewable runtime, developer-tooling, Actions, and container changes.

This also resolves [Dependabot alert #501](https://github.com/ls1intum/Hephaestus/security/dependabot/501) by upgrading `@hey-api/openapi-ts` from `0.97.1` to the minimum patched `0.97.3` release and regenerating the checked-in client. The generator configuration explicitly selects its plugins, so regeneration is warning-free and continues applying date transformers to SDK responses. The separate TypeScript 7 compatibility work remains in #1466.

Release signing stays immutable: every Cosign installer reference now uses the same verified full SHA for `v4.1.2`. Routine image upgrades are no longer mislabeled as security fixes or forced into collision-prone broad groups.

Closes #1570

## How to test

```bash
npx --yes --package renovate renovate-config-validator --strict renovate.json
bun run generate:api:application-server:client
bun run verify
```

Expected results:

- Renovate configuration validates without warnings.
- Client generation reports `@hey-api/openapi-ts v0.97.3` without duplicate-plugin warnings.
- The generated client diff is deterministic.
- All Cosign installer references use `6f9f17788090df1f26f669e9d70d6ae9567deba6` (`v4.1.2`).

Local verification completed successfully: 992 webapp tests, 168 custom lint-rule tests, 1,625 Storybook browser tests, 7,098 server unit/architecture tests, coverage checks, and the webapp, Storybook, and documentation production builds.

After merge, the hosted Renovate run must refresh the Dependency Dashboard and GitHub must rescan `bun.lock` before the dashboard cleanup and alert closure are externally visible.

## Checklist

- [x] Added an empty changeset because this maintenance change has no operator- or user-facing release note.
- [x] No operator action, required environment variable, or manual migration is introduced.
