### PR TITLE
docs(ci): say that preview sign-in serves one preview at a time

### DIFF
--- a/.changeset/preview-signin-caveat.md
+++ b/.changeset/preview-signin-caveat.md
@@ -1,0 +1,4 @@
+---
+---
+
+Contributor documentation only; no deployed behaviour changes.

--- a/docs/contributor/ci-cd.mdx
+++ b/docs/contributor/ci-cd.mdx
@@ -130,8 +130,13 @@ leaderboard are already there — which is what makes a preview worth looking at
 before the application server boots: review triggers, agent bindings and sweep schedules are off,
 queued jobs are cancelled, and the instance identity is dropped so the preview signs its own tokens.
 The application server also reads staging's event stream, on a durable of its own. Agent runs and
-inbound webhooks stay off. Sign-in works only if the preview-only GitHub OAuth app is configured, and
-the accounts in the preview application's `HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS` come up as admins.
+inbound webhooks stay off.
+
+Signing in needs one thing from an operator. GitHub rejects wildcard callback URLs, so the
+preview-only OAuth app's callback names a single preview host — `pr<id>.api.<zone>` — and only that
+preview can be signed into until someone re-points it. Ask in the maintainers' channel if you need
+sign-in on yours. Accounts listed in the preview application's `HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS`
+come up as admins once signed in.
 
 Each stack keeps its own PostgreSQL, preview-only credentials, and signed commit-addressed CI images.
 No container holds the Docker socket: the seed loader reads staging over the network as a role that


### PR DESCRIPTION
## Description

Sign-in on a preview is confirmed working end to end — real staging data behind a real GitHub login. But the callback URL contains the PR number (`pr1538.api.<zone>/login/oauth2/code/github`), and GitHub rejects wildcard callbacks, so **one preview at a time** can be signed into until an operator re-points it.

`docker/preview/.env.example` already says this to operators. `ci-cd.mdx` — the page a contributor reads before labelling their PR — said only that sign-in works when the OAuth app is configured, which reads as a promise. The first contributor to try it on their own preview would get GitHub's `redirect_uri` error with no explanation where they were looking.

Worth landing before previews are announced to the team.

## How to test

CI covers this — documentation only. The behaviour it describes was verified by signing in to the live preview for #1538.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note — empty changeset: documentation only
- [x] If the operator must act on this change, the changeset says how — no operator action