### PR TITLE
docs(ci): drop a wrong claim about OAuth callback URLs

### DIFF
--- a/.changeset/preview-oauth-note.md
+++ b/.changeset/preview-oauth-note.md
@@ -1,0 +1,4 @@
+---
+---
+
+Corrects a comment in the preview environment example; no deployed behaviour changes.

--- a/docker/preview/.env.example
+++ b/docker/preview/.env.example
@@ -20,9 +20,9 @@ HEPHAESTUS_AUTH_BOOTSTRAP_ADMINS=
 # Optional. Overrides the application server's direct-memory ceiling.
 #APP_MAX_DIRECT_MEMORY=128M
 
-# Optional preview-only GitHub OAuth app. GitHub rejects wildcard callback URLs, so one app cannot
-# serve every pr<id> host at once: either re-point its callback at the preview you are signing into,
-# or leave these blank and reach the preview as a bootstrap admin.
+# Optional preview-only GitHub OAuth app. Its callback has to cover this application's API hosts,
+# shaped pr<id>.api.<preview zone> — the preview builds its redirect_uri from the host it is served
+# on. Leave these blank to reach the preview as a bootstrap admin instead.
 GH_OAUTH_CLIENT_ID=
 GH_OAUTH_CLIENT_SECRET=
 


### PR DESCRIPTION
## Description

`docker/preview/.env.example` claimed GitHub rejects wildcard callback URLs, and concluded that one OAuth app cannot serve every `pr<id>` host, so an operator must re-point the callback at whichever preview is being signed into.

That is wrong for this application. The preview for #1538 was deployed and signed into — full staging data behind a real GitHub login — with nobody touching the callback.

The comment now states the requirement an operator actually has to satisfy (a callback covering `pr<id>.api.<zone>`, since the preview builds its `redirect_uri` from the host it is served on) and asserts nothing about GitHub's policy. That assertion was both wrong and unnecessary — this file describes what to configure, not what the provider permits.

I very nearly propagated the error instead of fixing it: #1575 added a paragraph to the contributor docs repeating the claim. Closed.

## How to test

CI covers this — a comment in an example file. The behaviour it describes was verified by signing in to the live preview.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note — empty changeset: a comment in an example file
- [x] If the operator must act on this change, the changeset says how — no operator action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the preview environment’s GitHub OAuth callback configuration requirements.
  * Explained how preview builds determine the OAuth redirect URL from the served host.
  * Corrected an example comment; no deployed behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->