### PR TITLE
fix(ci): record the branch a preview was built from, not the merge ref

### DIFF
--- a/.changeset/footer-branch-links-to-a-branch.md
+++ b/.changeset/footer-branch-links-to-a-branch.md
@@ -1,0 +1,6 @@
+---
+"hephaestus": patch
+---
+
+On preview and staging deployments the footer's branch link now opens the branch it names. Builds of
+a pull request recorded the merge ref (`1538/merge`) rather than the branch, so the link led nowhere.

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -48,9 +48,11 @@ jobs:
       registry: "ghcr.io"
       # Bake commit + branch (the Dockerfile's ARGs) so the footer build strip is
       # populated on CI-built deploys; Coolify sets these itself for previews.
+      # head_ref, not ref_name: on a pull request the latter is the merge ref `<n>/merge`, which is
+      # not a branch and does not resolve as one — the footer links it and got a 404.
       build-args: |
         SOURCE_COMMIT=${{ github.sha }}
-        COOLIFY_BRANCH=${{ github.ref_name }}
+        COOLIFY_BRANCH=${{ github.head_ref || github.ref_name }}
       # amd64-only on PRs (main/release build both arches). See reusable-docker-build.yml.
       single-arch: ${{ github.event_name == 'pull_request' }}
       tags: |


### PR DESCRIPTION
## Description

The preview footer for #1538 showed `1538/merge` as the branch, linking to `github.com/ls1intum/Hephaestus/tree/1538/merge` — which 404s. The commit (`8edecd4`) and the deploy time were correct; only the branch was wrong.

`ci-docker-build.yml` bakes `COOLIFY_BRANCH=${{ github.ref_name }}` into the webapp image. On a `pull_request` event that is the **merge ref**, `<n>/merge`, not a branch. `github.head_ref` is the pull request's branch and is empty on a push, so `github.head_ref || github.ref_name` keeps `main` and tag builds exactly as they were.

Worth noting where this did *not* need fixing: `webapp/docker/entrypoint.sh` already prefers the baked branch over the generic `main` that Coolify injects at runtime, and has a further fallback that resolves the branch from the GitHub API. That fallback never fired here because it is guarded on `GIT_BRANCH == "main"`, and the value was `1538/merge` — a wrong answer rather than a missing one. Correcting the value at the source is what makes the existing chain produce the right result, so no heuristic changes.

## How to test

The footer's branch link on any non-production deployment should open the branch. Verified the current behaviour on the live preview for #1538 (`GIT_BRANCH: "1538/merge"` in the served `env-config`, link 404s); the fix takes effect on the next webapp image build.

`bun run format` and `bun run check` are green.

## Checklist

- [x] My changeset summary reads as an operator/user-facing note (it becomes the changelog entry)
- [x] If the operator must act on this change, the changeset says how — no operator action