### PR TITLE
fix(ci): make action pins resolvable by Renovate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  ".github/workflows/**/*.{yml,yaml}":
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/cd-docs-teardown.yml
+++ b/.github/workflows/cd-docs-teardown.yml
@@ -31,7 +31,7 @@ jobs:
         continue-on-error: true
 
       - name: Update PR comment
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: docs-preview
           message: |
@@ -39,7 +39,7 @@ jobs:
 
             ~~Preview has been removed~~ (PR closed)
       - name: Update Storybook PR comment
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: storybook-preview
           message: |

--- a/.github/workflows/cd-docs.yml
+++ b/.github/workflows/cd-docs.yml
@@ -94,7 +94,7 @@ jobs:
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Deploy to Surge.sh
         run: bun --bun surge ./docs-build ${{ env.PREVIEW_URL }} --token ${{ secrets.SURGE_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: docs-preview
           message: |

--- a/.github/workflows/ci-security-scan.yml
+++ b/.github/workflows/ci-security-scan.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Trivy dependency scan
         id: dependencies
         continue-on-error: true
-        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Add Storybook preview to the pull request
         if: steps.storybook_preview.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: storybook-preview
           message: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -144,6 +144,7 @@ jobs:
             ci-config:
               - '.github/workflows/**'
               - '.github/actions/**'
+              - '.github/actionlint.yaml'
             docker-config:
               - '.github/workflows/ci-docker-build.yml'
               - '.github/workflows/reusable-docker-build.yml'
@@ -163,6 +164,30 @@ jobs:
               - '!webapp/src/**/*.test.*'
               - '!webapp/src/**/*.stories.*'
               - '!webapp/src/test/**'
+
+  workflow-lint:
+    name: "Workflow syntax"
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      needs.detect-changes.outputs.should_skip != 'true' && (
+        needs.detect-changes.outputs.ci-config == 'true' ||
+        github.event_name != 'pull_request'
+      )
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: reviewdog/action-actionlint@dbe5299849118fd6f099ba563d263d770955a64a # v1.73.2
+        with:
+          actionlint_flags: -shellcheck=
+          fail_level: error
+          filter_mode: nofilter
+          reporter: github-check
 
   Quality:
     uses: ./.github/workflows/ci-quality-gates.yml
@@ -243,7 +268,7 @@ jobs:
     permissions:
       actions: read
       statuses: write
-    needs: [detect-changes, Quality, Security, Test, Changesets, Docker]
+    needs: [detect-changes, workflow-lint, Quality, Security, Test, Changesets, Docker]
     if: always()
     steps:
       - name: Generate workflow timeline
@@ -294,6 +319,7 @@ jobs:
         id: evaluate
         run: |
           echo "detect-changes: ${{ needs.detect-changes.result }}"
+          echo "workflow-lint: ${{ needs.workflow-lint.result }}"
           echo "Quality:        ${{ needs.Quality.result }}"
           echo "Security:       ${{ needs.Security.result }}"
           echo "Test:           ${{ needs.Test.result }}"
@@ -342,6 +368,7 @@ jobs:
             esac
           }
 
+          echo "| Workflow syntax | $(result_to_emoji '${{ needs.workflow-lint.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Quality | $(result_to_emoji '${{ needs.Quality.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Test | $(result_to_emoji '${{ needs.Test.result }}') |" >> $GITHUB_STEP_SUMMARY
           echo "| Changesets | $(result_to_emoji '${{ needs.Changesets.result }}') |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -74,7 +74,7 @@ jobs:
         # Always overwrites the sticky comment, closed pull requests included: a torn-down preview
         # must never leave a live-looking link behind.
         if: always() && steps.tombstone.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: app-preview
           number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Explain why the preview did not deploy
         if: steps.context.outputs.announce == 'true'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: app-preview
           number: ${{ steps.context.outputs.pr_number }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Announce the deployment
         if: steps.github_deployment.outputs.deployment_id != ''
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: app-preview
           number: ${{ steps.context.outputs.pr_number }}
@@ -168,7 +168,7 @@ jobs:
 
       - name: Publish the preview link
         if: steps.finalize.outputs.final_state == 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: app-preview
           number: ${{ steps.context.outputs.pr_number }}
@@ -186,7 +186,7 @@ jobs:
           steps.context.outputs.eligible == 'true' &&
           steps.recheck.outputs.opted_out != 'true' &&
           steps.wait.outputs.state != 'success'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: app-preview
           number: ${{ steps.context.outputs.pr_number }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,7 +45,7 @@ jobs:
         continue-on-error: true
 
       - name: "Comment on PR with validation error"
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: steps.commitlint.outcome == 'failure'
         with:
           header: pr-title-lint-error
@@ -59,7 +59,7 @@ jobs:
             > 📖 See [CONTRIBUTING.md](https://github.com/ls1intum/Hephaestus/blob/main/CONTRIBUTING.md) for commit message guidelines.
 
       - name: "Remove error comment on success"
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: steps.commitlint.outcome == 'success'
         with:
           header: pr-title-lint-error


### PR DESCRIPTION
## Description

Make GitHub Action pins resolvable by Renovate without weakening immutable SHA pinning. Sticky Pull Request Comment now carries its exact `v2.9.4` tag at every use, and Trivy Action is upgraded from an untagged commit to the full SHA for `v0.36.0`.

Add a required `actionlint` CI job whenever workflow configuration changes and on every default-branch run. It validates the complete workflow inventory and feeds the aggregate CI status gate, preventing invalid workflow syntax from merging.

Follow-up to #1570. This addresses the two lookup failures reported by [Dependency Dashboard #709](https://github.com/ls1intum/Hephaestus/issues/709).

## How to test

- `bun run format`
- `bun run check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -shellcheck=`
- Confirm the **Workflow syntax** CI job passes and is included in **CI Status Gate**.
- After merge, trigger Renovate and confirm both action lookup warnings disappear from the Dependency Dashboard.

## Checklist

- No changeset is required because this only corrects CI action metadata and validation; it does not change shipped behavior.
- All action references remain pinned to immutable 40-character commit SHAs.
- ShellCheck remains outside this job until the repository's existing findings are addressed; actionlint still checks workflow structure, expressions, events, jobs, steps, and action usage.
