### PR TITLE
fix(deps): skip the local Maven reactor parent

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,11 @@
 	"packageRules": [
 		{
 			"matchManagers": ["maven"],
+			"matchPackageNames": ["de.tum.cit.aet:hephaestus-server-parent"],
+			"enabled": false
+		},
+		{
+			"matchManagers": ["maven"],
 			"matchDepTypes": ["compile", "runtime", "provided", "optional", "parent", "parent-root"],
 			"matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
 			"groupName": "Java runtime and framework dependencies",


### PR DESCRIPTION
## Description

Stop Renovate from querying Maven Central for `de.tum.cit.aet:hephaestus-server-parent`. That coordinate is the unpublished parent of this repository's own Maven reactor, so no external registry can provide an update for it.

The last hosted Renovate run successfully extracted 382 dependencies but aborted after Maven Central rate-limited this uncached lookup. This narrow rule removes the repository-controlled failure path without disabling Maven updates or suppressing warnings for real dependencies.

Follow-up to #1570 and [Dependency Dashboard #709](https://github.com/ls1intum/Hephaestus/issues/709).

## How to test

- `bun run format:config`
- `bun run check`
- `npx --yes --package renovate renovate-config-validator --strict renovate.json`
- Run Renovate 44.50.3 locally in Maven-only, full dry-run mode and confirm both extracted occurrences report `Dependency: de.tum.cit.aet:hephaestus-server-parent, is disabled`, while Maven package lookup completes.
- After merge and a cooldown for Maven Central's rate limit, trigger the hosted Renovate job and confirm it reaches update and dashboard reconciliation.

## Checklist

- No changeset is required because this only changes dependency-bot discovery and has no shipped behavior.
- Real Maven dependencies, plugins, wrappers, and external parents remain enabled.
- This does not hide external-host failures for any registry-backed dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated dependency updates for the Hephaestus server parent Maven package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->